### PR TITLE
Ensure WebGL support by adjusting Xvfb configuration

### DIFF
--- a/pythonlib/camoufox/virtdisplay.py
+++ b/pythonlib/camoufox/virtdisplay.py
@@ -30,11 +30,11 @@ class VirtualDisplay:
 
     xvfb_args = (
         # fmt: off
-        "-screen", "0", "1x1x8",
+        "-screen", "0", "1x1x24",
         "-ac",
         "-nolisten", "tcp",
         "-extension", "RENDER",
-        "-extension", "GLX",
+        "+extension", "GLX",
         "-extension", "COMPOSITE",
         "-extension", "XVideo",
         "-extension", "XVideo-MotionCompensation",


### PR DESCRIPTION
Firefox requires a display to enable WebGL support, see https://github.com/daijro/camoufox/issues/114#issuecomment-2524720064.

Camoufox already provides a virtual display by spawning Xvfb with a screen resolution of 1x1 and an 8-bit color depth.

However, 8-bit color depth is insufficient to activate WebGL in Firefox. After testing various Xvfb configurations, it was determined that the minimum required settings are:

- 24-bit color depth
- GLX extension enabled

Update ensures that WebGL is available when running Firefox in the `headless="virtual"` mode.

**Changes Made:**

Updated Xvfb configuration to use 24-bit color depth.
Explicitly enabled the GLX extension to support OpenGL rendering.

**Manual testing script:**

```python
from camoufox.sync_api import Camoufox

with Camoufox(headless="virtual") as camoufox:
    page = camoufox.new_page()
    webgl_info = page.evaluate(
        """
        (()=>{
            try {
                const canvas = document.createElement('canvas');
                const webgl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
                const info = webgl.getExtension('WEBGL_debug_renderer_info');
                const [vendor, renderer] = [webgl.getParameter(info.UNMASKED_VENDOR_WEBGL), webgl.getParameter(info.UNMASKED_RENDERER_WEBGL)]
                return `Vendor: ${vendor}\\nRenderer: ${renderer}`
            } catch (e) {
                return `No WebGL: ${e.message}`
            }
        })()
        """
    )
    print(webgl_info)
```

**Example of positive output:**

```console
Starting virtual display: /usr/bin/Xvfb :99 -screen 0 1x1x24 -ac -nolisten tcp -extension RENDER +extension GLX -extension COMPOSITE -extension XVideo -extension XVideo-MotionCompensation -extension XINERAMA -shmem -fp built-ins -nocursor -br
Vendor: Google Inc. (NVIDIA)
Renderer: ANGLE (NVIDIA, NVIDIA GeForce GTX 980 Direct3D11 vs_5_0 ps_5_0), or similar
```