### PR TITLE
Encode Camoufox server config before passing into NodeJS Playwright

### DIFF
--- a/pythonlib/camoufox/launchServer.js
+++ b/pythonlib/camoufox/launchServer.js
@@ -13,7 +13,7 @@ function collectData() {
         });
 
         process.stdin.on('end', () => {
-            resolve(JSON.parse(data));
+            resolve(JSON.parse(Buffer.from(data, "base64").toString()));
         });
     });
 }

--- a/pythonlib/camoufox/server.py
+++ b/pythonlib/camoufox/server.py
@@ -2,6 +2,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, NoReturn, Tuple, Union
 
+import base64
 import orjson
 from playwright._impl._driver import compute_driver_executable
 
@@ -47,7 +48,7 @@ def launch_server(**kwargs) -> NoReturn:
     config = launch_options(**kwargs)
     nodejs = get_nodejs()
 
-    data = orjson.dumps(to_camel_case_dict(config)).decode()
+    data = orjson.dumps(to_camel_case_dict(config))
 
     process = subprocess.Popen(  # nosec
         [
@@ -60,7 +61,7 @@ def launch_server(**kwargs) -> NoReturn:
     )
     # Write data to stdin and close the stream
     if process.stdin:
-        process.stdin.write(data)
+        process.stdin.write(base64.b64encode(data).decode())
         process.stdin.close()
 
     # Wait forever


### PR DESCRIPTION
Using `launch_server` caused the following error:

```bash
UnicodeEncodeError: 'charmap' codec can't encode characters in position 2695-2696: character maps to <undefined>
```

Fixed by encoding as base64 before writing stdin and decoding from node.