### PR TITLE
Remove print on start of virtual display

### DIFF
--- a/pythonlib/camoufox/virtdisplay.py
+++ b/pythonlib/camoufox/virtdisplay.py
@@ -69,7 +69,7 @@ class VirtualDisplay:
         """
         Spawn a detatched process
         """
-        if self.debug or True:
+        if self.debug:
             print('Starting virtual display:', ' '.join(self.xvfb_cmd))
         self.proc = subprocess.Popen(  # nosec
             self.xvfb_cmd,


### PR DESCRIPTION
Fixes printing of debug info on virtual display start. 
```py
if self.debug or True:
```
is always resolved to True and prints debug info
