### PR TITLE
unexpected keyword argument when using proxy-bypass with geoip=True

### DIFF
--- a/pythonlib/camoufox/ip.py
+++ b/pythonlib/camoufox/ip.py
@@ -24,6 +24,7 @@ class Proxy:
     server: str
     username: Optional[str] = None
     password: Optional[str] = None
+    bypass: Optional[str] = None
 
     @staticmethod
     def parse_server(server: str) -> Tuple[str, str, Optional[str]]:


### PR DESCRIPTION
passing a proxy to camoufox with the "bypass"-argument while using geoip=True runs into an exception. extending the class attributes fixes the problem on my local machine