### PR TITLE
Get IP fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pythonlib/*.png
 scripts/*.png
 scripts/test*
 .vscode
+.idea
 /tests/*.disabled
 k8s/
 

--- a/pythonlib/camoufox/ip.py
+++ b/pythonlib/camoufox/ip.py
@@ -100,6 +100,8 @@ def public_ip(proxy: Optional[str] = None) -> str:
         "https://ifconfig.co/ip",
         "https://ipecho.net/plain",
     ]
+
+    exception = None
     for url in URLS:
         try:
             with _suppress_insecure_warning():
@@ -113,8 +115,6 @@ def public_ip(proxy: Optional[str] = None) -> str:
             ip = resp.text.strip()
             validate_ip(ip)
             return ip
-        except requests.exceptions.ProxyError as e:
-            raise InvalidProxy(f"Failed to connect to proxy: {proxy}") from e
-        except (requests.RequestException, InvalidIP):
+        except (requests.exceptions.ProxyError, requests.RequestException, InvalidIP) as exception:
             pass
-    raise InvalidIP("Failed to get IP address")
+    raise InvalidIP(f"Failed to get IP address: {exception}")


### PR DESCRIPTION
The problem occurred when:
1. Using IPv6 proxies that couldn't connect to the first URL in the list (https://api.ipify.org), because it doesn't support IPv6 and instead of trying to connect to the next URL, an exception was raised.
2. Using some IPv4 proxies that for some reason couldn't connect to the first URL in the list and raised an exception, which instead of trying the next URL, just raised an exception.

Fixed by removing the exception raising in this case, moving the exception to all other cases and adding the exception output at the end, if failed to get IP address.

Also added PyCharm's ".idea" in .gitignore file.