### PR TITLE
Add allow_addon_new_tab launch option to Python lib

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -356,6 +356,7 @@ def launch_options(
     ff_version: Optional[int] = None,
     headless: Optional[bool] = None,
     main_world_eval: Optional[bool] = None,
+    allow_addon_new_tab: Optional[bool] = None,
     executable_path: Optional[Union[str, Path]] = None,
     firefox_user_prefs: Optional[Dict[str, Any]] = None,
     proxy: Optional[Dict[str, str]] = None,
@@ -424,6 +425,8 @@ def launch_options(
         main_world_eval (Optional[bool]):
             Whether to enable running scripts in the main world.
             To use this, prepend "mw:" to the script: page.evaluate("mw:" + script).
+        allow_addon_new_tab (Optional[bool]):
+            Whether to allow addon open new tabs. Defaults to False.
         executable_path (Optional[Union[str, Path]]):
             Custom Camoufox browser executable path.
         firefox_user_prefs (Optional[Dict[str, Any]]):
@@ -585,6 +588,10 @@ def launch_options(
     # Enable the main world context creation
     if main_world_eval:
         set_into(config, 'allowMainWorld', True)
+
+    # Allow addon open new tabs
+    if allow_addon_new_tab:
+        set_into(config, 'allowAddonNewtab', True)
 
     # Set Firefox user preferences
     if block_images:

--- a/settings/camoucfg.jvv
+++ b/settings/camoucfg.jvv
@@ -297,6 +297,7 @@
     "showcursor": "bool",
 
     "allowMainWorld": "bool",
+    "allowAddonNewtab": "bool",
     "forceScopeAccess": "bool",
     "enableRemoteSubframes": "bool",
     "disableTheming": "bool",

--- a/settings/properties.json
+++ b/settings/properties.json
@@ -96,6 +96,7 @@
   { "property": "mediaDevices:speakers", "type": "uint" },
   { "property": "mediaDevices:enabled", "type": "bool" },
   { "property": "allowMainWorld", "type": "bool" },
+  { "property": "allowAddonNewtab", "type": "bool" },
   { "property": "forceScopeAccess", "type": "bool" },
   { "property": "enableRemoteSubframes", "type": "bool" },
   { "property": "disableTheming", "type": "bool" },


### PR DESCRIPTION
Added the `allow_addon_new_tab` option to the launch options to allow addon to open new windows by setting `allowAddonNewtab` in the configuration.

I see that `allowAddonNewtab` is already used for in the `disable-extension-newtab.patch` (it was added in [this commit](https://github.com/daijro/camoufox/commit/ae7263428e252a25007f1c6e53baec204cb2a1d6)). However, there was no option to pass this parameter into the config when working through Python lib.

Reported in: #239 #188 

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/71d4323c-1781-4cfe-ac01-cbc207bbf7f1" />