### PR TITLE
Fix unbound exception ip function

### DIFF
--- a/pythonlib/camoufox/ip.py
+++ b/pythonlib/camoufox/ip.py
@@ -101,7 +101,7 @@ def public_ip(proxy: Optional[str] = None) -> str:
         "https://ipecho.net/plain",
     ]
 
-    exception = None
+    end_exception = None
     for url in URLS:
         try:
             with _suppress_insecure_warning():
@@ -116,5 +116,5 @@ def public_ip(proxy: Optional[str] = None) -> str:
             validate_ip(ip)
             return ip
         except (requests.exceptions.ProxyError, requests.RequestException, InvalidIP) as exception:
-            pass
-    raise InvalidIP(f"Failed to get IP address: {exception}")
+            end_exception = exception
+    raise InvalidIP(f"Failed to get IP address: {end_exception}")


### PR DESCRIPTION
Variables assigned in `as` blocks are garbage collected at the end of the block. Hence even if we define `exception = None` the `exception` variable gets cleaned in the `as exception` block. And on the `raise InvalidIP` line we get an `UnboundLocalError` instead of an `InvalidIP` error with the exception information.

You can easily reproduce with something like:
```py
def invalid() -> None:
    exception = None
    try:
        raise ValueError("test")
    except ValueError as exception:
        pass
    raise RuntimeError(f"Failed to get IP address: {exception}")  # UnboundLocalError


invalid()  # UnboundLocalError
```
