### PR TITLE
Fix cleanup on exception in sync_api __enter__

### DIFF
--- a/pythonlib/camoufox/sync_api.py
+++ b/pythonlib/camoufox/sync_api.py
@@ -26,7 +26,11 @@ class Camoufox(PlaywrightContextManager):
 
     def __enter__(self) -> Union[Browser, BrowserContext]:
         super().__enter__()
-        self.browser = NewBrowser(self._playwright, **self.launch_options)
+        try:
+            self.browser = NewBrowser(self._playwright, **self.launch_options)
+        except camoufox.exceptions.InvalidProxy as e:
+            super().__exit__(camoufox.exceptions.InvalidProxy, e, None)
+            raise
         return self.browser
 
     def __exit__(self, *args: Any):


### PR DESCRIPTION
If an exception is raised in the synchronous api during the setup, super().__enter__ has been called but super().__exit__ will not get called, leading to asyncio runloop exceptions further down the line if one tries to create a new context. This commit catches the exception in order to clean up the super().__exit__ calls before reraising.