### PR TITLE
fix: Return None for screen size if headless

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -157,7 +157,7 @@ def get_screen_cons(headless: Optional[bool] = None) -> Optional[Screen]:
     """
     Determines a sane viewport size for Camoufox if being ran in headful mode.
     """
-    if headless is False:
+    if headless is True:
         return None  # Skip if headless
     try:
         monitors = get_monitors()


### PR DESCRIPTION
Hi!

Thanks for the work on Camoufox. Many things that were literally impossible previously are now possible thanks to Camoufox.

One issue that I have been hitting my head against is launching Camoufox headless on an EC2 instance. This issue has previously been raised elsewhere:

- https://github.com/daijro/camoufox/issues/141 and
- https://github.com/daijro/camoufox/issues/242.

The second link proposes a simple solution, which I have tested and found to fix the issue.

This MR applies the proposed change to the `get_screen_cons()` function.

Best regards, Andrew.