### PR TITLE
fix: return correct country from geoip database

### DIFF
--- a/pythonlib/camoufox/locale.py
+++ b/pythonlib/camoufox/locale.py
@@ -259,7 +259,7 @@ def get_geolocation(ip: str) -> Geolocation:
 
     with geoip2.database.Reader(str(MMDB_FILE)) as reader:
         resp = reader.city(ip)
-        iso_code = cast(str, resp.registered_country.iso_code).upper()
+        iso_code = cast(str, resp.country.iso_code).upper()
         location = resp.location
 
         # Check if any required attributes are missing


### PR DESCRIPTION
Currently, `geoip2.model.City.registered_country` is used for determining locale. However, for the proxy I use, this leads to locale value being `crs-SC` (Seselwa Creole French), which is completely wrong. Every other value from geoip is fine, including `country`.
From [geoip2 docs](https://geoip2.readthedocs.io/en/latest/#geoip2.models.City.registered_country): 
> `registered_country`: The registered country object for the requested IP address. This record represents the country where the ISP has registered a given IP block in and may differ from the user’s country.

> `country`: Country object for the requested IP address. This record represents the country where MaxMind believes the IP is located.

I think `country` should be used in this case.