### PR TITLE
Fix launch server breaking when no proxy option is passed.

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -651,12 +651,17 @@ def launch_options(
     else:
         executable_path = launch_path()
 
-    return {
-        "executable_path": executable_path,
-        "args": args,
-        "env": env_vars,
-        "firefox_user_prefs": firefox_user_prefs,
-        "proxy": proxy,
-        "headless": headless,
-        **(launch_options if launch_options is not None else {}),
+    result = {
+      "executable_path": executable_path,
+      "args": args,
+      "env": env_vars,
+      "firefox_user_prefs": firefox_user_prefs,
+      "headless": headless,
+      **(launch_options if launch_options is not None else {}),
     }
+
+  # Only include proxy if it's not None
+    if proxy is not None:
+      result["proxy"] = proxy
+
+    return result


### PR DESCRIPTION
## Problem
  When launching Camoufox server without a proxy, the following error occurs:
  Error launching server: proxy: expected object, got null

  ## Root Cause
  The `launch_options()` function always includes `"proxy": proxy` in the returned dictionary, even when `proxy=None`. When serialized to JSON and      
  passed to Playwright's `launchServer()`, this becomes `"proxy": null`, which Playwright rejects.

  ## Solution
  Only include the proxy key in the returned options when `proxy` is not None. This matches Playwright's expectation that the proxy parameter
  should either be a valid object or completely absent.

  ## Changes
  - Modified the return statement in `launch_options()` to conditionally include proxy
  - Added conditional logic to exclude None proxy values
  - No breaking changes - existing code continues to work
