### PR TITLE
Fix launch_server, to be able to use persistent_context and user_data_dir

### DIFF
--- a/pythonlib/camoufox/server.py
+++ b/pythonlib/camoufox/server.py
@@ -19,7 +19,7 @@ def camel_case(snake_str: str) -> str:
     if len(snake_str) < 2:
         return snake_str
     camel_case_str = ''.join(x.capitalize() for x in snake_str.lower().split('_'))
-    return camel_case_str[0].lower() + camel_case_str[1:]
+    return ("_" if snake_str[0] == "_" else "") + camel_case_str[0].lower() + camel_case_str[1:]
 
 
 def to_camel_case_dict(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -365,6 +365,8 @@ def launch_options(
     i_know_what_im_doing: Optional[bool] = None,
     debug: Optional[bool] = None,
     virtual_display: Optional[str] = None,
+    persistent_context: Optional[bool] = None,
+    user_data_dir: Optional[Union[str, Path]] = None,
     **launch_options: Dict[str, Any],
 ) -> Dict[str, Any]:
     """
@@ -658,5 +660,6 @@ def launch_options(
         "firefox_user_prefs": firefox_user_prefs,
         "proxy": proxy,
         "headless": headless,
+        "_user_data_dir": str(user_data_dir) if user_data_dir else None,
         **(launch_options if launch_options is not None else {}),
     }


### PR DESCRIPTION

## Issue #253 

When attempting to use `persistent_context` and `user_data_dir` parameters in `launch_server()`:

```python
launch_server(
    # ...
    persistent_context=True,
    user_data_dir='my-user-data-dir'
    # ...
)
```

These parameters are completely ignored - they are not read, parsed, or taken into account by the implementation.

## Solution

According to [playwright-core/src/browserServerImpl.ts](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/browserServerImpl.ts), the underlying implementation supports passing `_userDataDir` for persistent contexts.

This PR adds support for these parameters in `launch_server()` to enable persistent context functionality when launching browser servers.


