### PR TITLE
Open newpage in a new tab in an existing window instead of in an new window

### DIFF
--- a/additions/juggler/TargetRegistry.js
+++ b/additions/juggler/TargetRegistry.js
@@ -309,6 +309,45 @@ class TargetRegistry {
 
   async newPage({browserContextId}) {
     const browserContext = this.browserContextForId(browserContextId);
+
+    // Look for an existing window (via an existing PageTarget) with the same BrowserContext.
+    let existingWindow = null;
+    for (const target of this._browserToTarget.values()) {
+      if (target._browserContext === browserContext && !target._disposed) {
+        existingWindow = target._window;
+        break;
+      }
+    }
+
+    if (existingWindow) {
+      // Open a new tab in the existing window using the same userContextId.
+      const gBrowser = existingWindow.gBrowser;
+      // When opening a tab programmatically, pass the userContextId option so it's created in the right container.
+      const newTab = gBrowser.addTab('about:blank', {
+        triggeringPrincipal:
+          Services.scriptSecurityManager.getSystemPrincipal(),
+        userContextId: browserContext.userContextId
+      });
+      if (!newTab)
+        throw new Error('Failed to create tab in existing window');
+
+      const browser = newTab.linkedBrowser;
+      // Wait for the PageTarget to be created for this tab's linkedBrowser.
+      let target = this._browserToTarget.get(browser);
+      while (!target) {
+        await helper.awaitEvent(this, TargetRegistry.Events.TargetCreated);
+        target = this._browserToTarget.get(browser);
+      }
+      
+      browser.focus();
+      if (browserContext.crossProcessCookie.settings.timezoneId) {
+        if (await target.hasFailedToOverrideTimezone())
+          throw new Error('Failed to override timezone');
+      }
+      return target.id();
+    }
+
+    // No existing window for this browserContext — create a new window (original behavior).
     const features = "chrome,dialog=no,all";
     // See _callWithURIToLoad in browser.js for the structure of window.arguments
     // window.arguments[1]: unused (bug 871161)


### PR DESCRIPTION
Usage:

```
import {chromium, firefox} from "playwright"
import { launchOptions } from 'camoufox-js';

(async () => {
	const browser = await firefox.launch({
		...await launchOptions({
			headless: false,
		})
	})
	
	const conext = await browser.newContext()
	const page1 = await conext.newPage()
	await page1.goto('https://example.com');
	const page2 = await conext.newPage()
	await page2.goto('https://example.com');
	
	// Wait for 5 secs
	await new Promise(resolve => setTimeout(resolve, 5000))
	await page1.close()
	await page2.close()
	await context.close()
	await browser.close()
})();

```