### PR TITLE
Fix Glyph rendering issues

### DIFF
--- a/patches/network-patches.patch
+++ b/patches/network-patches.patch
@@ -1,8 +1,8 @@
 diff --git a/netwerk/protocol/http/moz.build b/netwerk/protocol/http/moz.build
-index b090a56d88..9fe4a5e1e8 100644
+index d2330003ca..a5ea856173 100644
 --- a/netwerk/protocol/http/moz.build
 +++ b/netwerk/protocol/http/moz.build
-@@ -218,3 +218,6 @@ XPCOM_MANIFESTS += [
+@@ -246,3 +246,6 @@ XPCOM_MANIFESTS += [
  ]
  
  include("/tools/fuzzing/libfuzzer-config.mozbuild")
@@ -11,7 +11,7 @@ index b090a56d88..9fe4a5e1e8 100644
 +LOCAL_INCLUDES += ["/camoucfg"]
 \ No newline at end of file
 diff --git a/netwerk/protocol/http/nsHttpHandler.cpp b/netwerk/protocol/http/nsHttpHandler.cpp
-index d0aebdf965..01472ec205 100644
+index 83a9dcff01..2a1d18deea 100644
 --- a/netwerk/protocol/http/nsHttpHandler.cpp
 +++ b/netwerk/protocol/http/nsHttpHandler.cpp
 @@ -14,6 +14,7 @@
@@ -22,7 +22,7 @@ index d0aebdf965..01472ec205 100644
  #include "nsHttpChannel.h"
  #include "nsHTTPCompressConv.h"
  #include "nsHttpAuthCache.h"
-@@ -747,6 +748,15 @@ uint8_t nsHttpHandler::UrgencyFromCoSFlags(uint32_t cos) {
+@@ -966,6 +967,15 @@ uint8_t nsHttpHandler::UrgencyFromCoSFlags(uint32_t cos,
  //-----------------------------------------------------------------------------
  
  const nsCString& nsHttpHandler::UserAgent(bool aShouldResistFingerprinting) {
@@ -38,27 +38,25 @@ index d0aebdf965..01472ec205 100644
    if (aShouldResistFingerprinting && !mSpoofedUserAgent.IsEmpty()) {
      LOG(("using spoofed userAgent : %s\n", mSpoofedUserAgent.get()));
      return mSpoofedUserAgent;
-@@ -2077,6 +2087,10 @@ nsresult nsHttpHandler::SetAcceptLanguages() {
+@@ -2082,6 +2092,10 @@ nsresult nsHttpHandler::SetAcceptLanguages() {
    }
-
+ 
    MOZ_ASSERT(NS_IsMainThread());
 +  if (auto value = MaskConfig::GetString("headers.Accept-Language")) {
 +    mAcceptLanguages.Assign(nsCString(value.value().c_str()));
 +    return NS_OK;
 +  }
-
+ 
    mAcceptLanguagesIsDirty = false;
-
-@@ -2098,6 +2112,10 @@ nsresult nsHttpHandler::SetAcceptLanguages() {
-
- nsresult nsHttpHandler::SetAcceptEncodings(const char* aAcceptEncodings,
-                                            bool isSecure, bool isDictionary) {
-+  if (auto value = MaskConfig::GetString("headers.Accept-Encoding")) {
-+    mHttpsAcceptEncodings.Assign(nsCString(value.value().c_str()));
-+    return NS_OK;
-+  }
+ 
+@@ -2101,6 +2115,10 @@ nsresult nsHttpHandler::SetAcceptEncodings(const char* aAcceptEncodings,
    if (isDictionary) {
-    mDictionaryAcceptEncodings = aAcceptEncodings;
-  } else if (isSecure) {
+     mDictionaryAcceptEncodings = aAcceptEncodings;
+   } else if (isSecure) {
++    if (auto value = MaskConfig::GetString("headers.Accept-Encoding")) {
++      mHttpsAcceptEncodings.Assign(nsCString(value.value().c_str()));
++      return NS_OK;
++    }
      mHttpsAcceptEncodings = aAcceptEncodings;
    } else {
+     // use legacy list if a secure override is not specified


### PR DESCRIPTION
The current patch was breaking the Dictionnary flow.

HTTP must stay different also using different accept encoding, so I'm applying the patch only when it's secure.

It's fix this rendering issue
<img width="2544" height="1102" alt="image" src="https://github.com/user-attachments/assets/233b8099-223f-436d-a19a-34f55ca587ef" />


Fix #473
Fix #464 