### PR TITLE
fix: only include proxy key in launch options when proxy is not None

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -651,12 +651,20 @@ def launch_options(
     else:
         executable_path = launch_path()
 
-    return {
+    # Prepare base return dictionary (without proxy)
+    result = {
         "executable_path": executable_path,
         "args": args,
         "env": env_vars,
         "firefox_user_prefs": firefox_user_prefs,
-        "proxy": proxy,
         "headless": headless,
-        **(launch_options if launch_options is not None else {}),
     }
+
+    # Only add proxy key if proxy is not None
+    if proxy is not None:
+        result["proxy"] = proxy
+
+    # Merge additional launch_options (if any)
+    result.update(launch_options if launch_options is not None else {})
+
+    return result


### PR DESCRIPTION
When proxy is None, the original code still includes "proxy": None in the returned launch options dictionary. This causes an error downstream when the server expects a proxy object but receives null, e.g.:
"Error launching server: proxy: expected object, got null Failed to launch browser."

The fix conditionally adds the proxy key only when proxy is not None, preventing the null value from being passed to the browser launcher.