### PR TITLE
Fix Accept-Encoding override breaking content decoding (br/zstd)

### DIFF
--- a/patches/network-patches.patch
+++ b/patches/network-patches.patch
@@ -53,12 +53,12 @@ index d0aebdf965..01472ec205 100644
 
  nsresult nsHttpHandler::SetAcceptEncodings(const char* aAcceptEncodings,
                                             bool isSecure, bool isDictionary) {
-+  if (auto value = MaskConfig::GetString("headers.Accept-Encoding")) {
-+    mHttpsAcceptEncodings.Assign(nsCString(value.value().c_str()));
-+    return NS_OK;
-+  }
    if (isDictionary) {
     mDictionaryAcceptEncodings = aAcceptEncodings;
   } else if (isSecure) {
++    if (auto value = MaskConfig::GetString("headers.Accept-Encoding")) {
++      mHttpsAcceptEncodings.Assign(nsCString(value.value().c_str()));
++      return NS_OK;
++    }
      mHttpsAcceptEncodings = aAcceptEncodings;
    } else {

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -553,6 +553,14 @@ def launch_options(
         from_browserforge(fingerprint, ff_version_str),
     )
 
+    # Ensure zstd is in Accept-Encoding (Firefox 126+ supports it natively,
+    # but older BrowserForge fingerprints may omit it)
+    ae_key = 'headers.Accept-Encoding'
+    if ae_key in config:
+        ae = config[ae_key]
+        if 'zstd' not in ae:
+            config[ae_key] = ae + ', zstd'
+
     target_os = get_target_os(config)
 
     # Set a random window.history.length


### PR DESCRIPTION
Moves the Accept-Encoding config override into the `isSecure` branch so it doesn't short-circuit the HTTP and dictionary paths. Also appends zstd to Accept-Encoding from BrowserForge fingerprints that lack it (FF126+).

Fixes #473, #479