### PR TITLE
Fix: Execute mach clobber before git clean to prevent 'mach not found…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,14 @@ checkpoint:
 	cd $(cf_source_dir) && git commit -m "Checkpoint" -uno
 
 clean:
-	cd $(cf_source_dir) && git clean -fdx && ./mach clobber
-	make revert
+	@if [ -e "$(cf_source_dir)/.git" ]; then \
+		cd "$(cf_source_dir)" && ./mach clobber && git clean -fdx; \
+		$(MAKE) revert; \
+	else \
+		echo "No git repo found in $(cf_source_dir); re-extracting Firefox source..."; \
+		rm -rf "$(cf_source_dir)"; \
+		$(MAKE) setup-minimal; \
+	fi
 
 distclean:
 	rm -rf $(cf_source_dir) $(ff_source_tarball)

--- a/scripts/patch.py
+++ b/scripts/patch.py
@@ -49,7 +49,11 @@ class Patcher:
         with temp_cd(find_src_dir('.', version, release)):
             # Reset to unpatched state first (like "Find broken patches")
             print("Resetting to unpatched state...")
-            run('git clean -fdx && ./mach clobber && git reset --hard unpatched', exit_on_fail=False)
+            if os.path.exists('.git'):
+                run('./mach clobber && git clean -fdx && git reset --hard unpatched', exit_on_fail=False)
+            else:
+                print("No .git found in source dir; skipping git clean/reset.")
+                run('./mach clobber', exit_on_fail=False)
 
             # Re-copy additions and settings after reset
             print("Re-copying additions and settings...")


### PR DESCRIPTION
When running `make clean` or the patch script in Docker builds, the following error occurs:

   ```
   cd camoufox-146.0.1-beta.25 && git clean -fdx && ./mach clobber
   Removing ./config
   Removing ./third_party
   ...
   /bin/sh: 1: ./mach: not found
   make: *** [Makefile:114: clean] Error 127
   ```

   **Root cause**: `git clean -fdx` deletes all untracked files including the `mach` file itself, so the subsequent `./mach clobber` command fails.

   ## Solution

   Reorder the commands to execute `./mach clobber` **before** `git clean -fdx`, ensuring mach is available when clobber runs.