### PR TITLE
fix: Enable Windows cross-compilation for FF146

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,12 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# Git config for commits during setup
+RUN git config --global user.email "build@camoufox" && \
+    git config --global user.name "Camoufox Build"
+
 # Fetch Firefox & apply initial patches
-RUN make setup-minimal && \
+RUN make setup && \
     make mozbootstrap && \
     mkdir -p /app/dist
 

--- a/additions/juggler/screencast/HeadlessWindowCapturer.h
+++ b/additions/juggler/screencast/HeadlessWindowCapturer.h
@@ -4,6 +4,14 @@
 
 #pragma once
 
+// pid_t is not defined in MSVC/MinGW cross-compilation targets
+#if defined(XP_WIN) || defined(_WIN32) || defined(__MINGW32__)
+#ifndef _PID_T_DEFINED
+#define _PID_T_DEFINED
+typedef int pid_t;
+#endif
+#endif
+
 #include <memory>
 #include <set>
 #include "api/video/video_frame.h"

--- a/additions/juggler/screencast/nsScreencastService.cpp
+++ b/additions/juggler/screencast/nsScreencastService.cpp
@@ -4,6 +4,14 @@
 
 #include "nsScreencastService.h"
 
+// pid_t is not defined in MSVC/MinGW cross-compilation targets
+#if defined(XP_WIN) || defined(_WIN32) || defined(__MINGW32__)
+#ifndef _PID_T_DEFINED
+#define _PID_T_DEFINED
+typedef int pid_t;
+#endif
+#endif
+
 #include "gfxPlatform.h"
 #include "ScreencastEncoder.h"
 #include "HeadlessWidget.h"

--- a/patches/anti-font-fingerprinting.patch
+++ b/patches/anti-font-fingerprinting.patch
@@ -921,11 +921,12 @@ index de9a9661a1..f878bdb36c 100644
  #include "mozilla/Sprintf.h"
  #include "mozilla/StaticPresData.h"
  #include "mozilla/UniquePtr.h"
-@@ -34,6 +35,8 @@
+@@ -34,6 +35,9 @@
  #include "nsUnicodeProperties.h"
  #include "SharedFontList-impl.h"
  #include "TextDrawTarget.h"
 +#include "mozilla/dom/BrowsingContext.h"
++#include "mozilla/dom/Document.h"
 +#include "nsPIDOMWindow.h"
 
  #ifdef XP_WIN

--- a/patches/windows-theming-bug-modified.patch
+++ b/patches/windows-theming-bug-modified.patch
@@ -20,10 +20,13 @@ index d11c35ff9d..0aa4b9058b 100644
  	$(MKDIR) -p '$(dist_dest)/Contents/Library/LaunchServices'
  ifdef MOZ_UPDATER
  	cp -f '$(dist_dest)/Contents/MacOS/updater.app/Contents/MacOS/org.mozilla.updater' '$(dist_dest)/Contents/Library/LaunchServices'
-diff --git a/browser/app/firefox.exe.manifest b/browser/app/firefox.exe.manifest
+diff --git a/browser/app/firefox.exe.manifest b/browser/app/camoufox.exe.manifest
+similarity index 80%
+rename from browser/app/firefox.exe.manifest
+rename to browser/app/camoufox.exe.manifest
 index 995b2fc869..4a03da3064 100644
 --- a/browser/app/firefox.exe.manifest
-+++ b/browser/app/firefox.exe.manifest
++++ b/browser/app/camoufox.exe.manifest
 @@ -3,10 +3,10 @@
  <assemblyIdentity
          version="1.0.0.0"


### PR DESCRIPTION
## Summary

Fixes 4 issues that prevented cross-compiling Camoufox v146 for Windows (`--target=x86_64-pc-mingw32` from Linux):

- **`pid_t` undefined**: Added conditional `typedef int pid_t` for Windows targets in `HeadlessWindowCapturer.h` and `nsScreencastService.cpp` (ref #445)
- **`camoufox.exe.manifest` missing**: Added git rename directives to `windows-theming-bug-modified.patch` so the manifest file is properly renamed from `firefox.exe.manifest`
- **`Document.h` include missing**: Added `#include "mozilla/dom/Document.h"` in `anti-font-fingerprinting.patch` for `gfxTextRun.cpp` (was using `doc->GetInnerWindow()` with only a forward declaration)
- **Dockerfile git setup**: Changed `setup-minimal` to `setup` and added git config (required for the patch reset/apply cycle)

## Testing

- Cross-compiled from Ubuntu (Docker) to Windows x86_64
- Ran on Windows 11 natively
- Verified with CreepJS: headless 0%, stealth 0%, lies 1 (canvas noise only), GPU confidence HIGH grade A
- UserAgent correctly reports Firefox/146.0

## Build instructions

```bash
docker build -t camoufox-builder .
docker run -dt --name cfox --memory=22g --entrypoint bash camoufox-builder
docker exec cfox bash -c "cd /app && export BUILD_TARGET=windows,x86_64 && make set-target && make build && make package-windows arch=x86_64"
```

> Note: Requires ~22GB RAM for Rust compilation. Set WSL2 memory via `~/.wslconfig` on Windows.

## Test plan

- [x] Cross-compilation completes without errors
- [x] Binary launches on Windows 11
- [x] CreepJS audit passes (headless: 0, stealth: 0)
- [x] Canvas, Audio, WebGL spoofing functional
- [ ] Full Playwright test suite (not yet run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)