### PR TITLE
Fix fontconfigs → fontconfig path in pythonlib/utils.py

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -70,14 +70,14 @@ def get_env_vars(
     if OS_NAME == 'lin':
         # https://github.com/coryking/camoufox/commit/f21eeb2850a74cc104fb57e17e0a2fa27b7a2a28
         # Thanks @coryking
-        # the user_agent_os is either 'lin', 'mac', or 'win' but our fontconfigs directory is 'linux', 'macos', or 'windows'
+        # the user_agent_os is either 'lin', 'mac', or 'win' but our fontconfig directory is 'linux', 'macos', or 'windows'
         directory_map = {
             'lin': 'linux',
             'mac': 'macos',
             'win': 'windows',
         }
         os_dir = directory_map.get(user_agent_os, user_agent_os)
-        fontconfig_path = get_path(os.path.join("fontconfigs", os_dir))
+        fontconfig_path = get_path(os.path.join("fontconfig", os_dir))
 
         # assert that fonts.conf exists in the directory
         if not os.path.exists(os.path.join(fontconfig_path, "fonts.conf")):


### PR DESCRIPTION
Thank you for the great project!

---

The browser bundle renamed the `fontconfigs` directory to `fontconfig` in https://github.com/daijro/camoufox/pull/519, but `pythonlib/camoufox/utils.py` still references the old `fontconfigs` path. 

This causes a `FileNotFoundError` at runtime when launching with OS fingerprint spoofing:
```
FileNotFoundError: fonts.conf not found in 
/root/.cache/camoufox/browsers/official/146.0.1-alpha.25/fontconfigs/windows!
```

## Description

This PR updates the path reference in `utils.py` to match the new directory name.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

Tested locally

## Fingerprint Report

It's pythonlib-only change, browser hasn't changed.

## Checklist

- [x] My changes are focused on a single logical change
