### PR TITLE
Fix brotli/zstd decompression broken by Accept-Encoding override

### DIFF
--- a/patches/network-patches.patch
+++ b/patches/network-patches.patch
@@ -49,16 +49,17 @@ index d0aebdf965..01472ec205 100644
 
    mAcceptLanguagesIsDirty = false;
 
-@@ -2098,6 +2112,10 @@ nsresult nsHttpHandler::SetAcceptLanguages() {
+@@ -2098,6 +2112,11 @@ nsresult nsHttpHandler::SetAcceptLanguages() {
 
  nsresult nsHttpHandler::SetAcceptEncodings(const char* aAcceptEncodings,
                                             bool isSecure, bool isDictionary) {
++  nsCString encodingOverride;
 +  if (auto value = MaskConfig::GetString("headers.Accept-Encoding")) {
-+    mHttpsAcceptEncodings.Assign(nsCString(value.value().c_str()));
-+    return NS_OK;
++    encodingOverride.Assign(nsCString(value.value().c_str()));
++    aAcceptEncodings = encodingOverride.get();
 +  }
    if (isDictionary) {
-    mDictionaryAcceptEncodings = aAcceptEncodings;
-  } else if (isSecure) {
+     mDictionaryAcceptEncodings = aAcceptEncodings;
+   } else if (isSecure) {
      mHttpsAcceptEncodings = aAcceptEncodings;
    } else {


### PR DESCRIPTION
## Related Issue

Closes #542

## Description

When `headers.Accept-Encoding` is set via config (which browserforge does by default), brotli and zstd responses come back as garbled binary. gzip/deflate work fine.

**Root cause:** `SetAcceptEncodings` is called 3 times during init to populate 3 different member variables:

- `mHttpAcceptEncodings` — plain HTTP header
- `mHttpsAcceptEncodings` — HTTPS header
- `mDictionaryAcceptEncodings` — superset, used by `IsAcceptableEncoding()` to decide whether to install a decompressor

The current patch sets `mHttpsAcceptEncodings` and returns early on every call, so the other two are never populated. The outgoing header is fine (that uses `mHttpsAcceptEncodings`), but when the response comes back, `IsAcceptableEncoding("br", true)` checks `mDictionaryAcceptEncodings` — which is empty — and rejects it. gzip/deflate only survive because there's a hardcoded fallback for those two.

**Fix:** Instead of returning early, just swap out the input parameter and let the original branching logic do its thing. The config override still works exactly as intended — it just doesn't short-circuit the routing anymore.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

- Confirmed broken: `https://httpbin.org/brotli` renders as raw compressed bytes in Camoufox before the fix
- Confirmed fixed: same page renders correctly after the fix
- gzip (`https://httpbin.org/gzip`) and deflate (`https://httpbin.org/deflate`) continue to work

### To reproduce

```python
import asyncio
from camoufox.async_api import AsyncCamoufox

async def test():
    async with AsyncCamoufox(headless=True, i_know_what_im_doing=True) as browser:
        page = await browser.new_page()
        await page.goto("https://httpbin.org/brotli")
        content = await page.content()
        print("brotli" in content)  # False before fix, True after

asyncio.run(test())
```

## Fingerprint Report

<details>
<summary>Build tester report</summary>

```
Camoufox Build Tester
Binary:   camoufox-146.0.1-ruben.canvas-noise-plus-binary-search.1/obj-aarch64-apple-darwin/dist/Camoufox.app/Contents/MacOS/camoufox
Profiles: 8

Per-context phase: 6 profiles (all open simultaneously)
  macOS Per-Context A: [A] 136/136
  macOS Per-Context B: [A] 136/136
  macOS Per-Context C: [A] 136/136
  Linux Per-Context A: [B] 134/135
  Linux Per-Context B: [B] 134/135
  Linux Per-Context C: [B] 134/135

Global phase: separate browser per profile
  macOS Global: [A] 118/118
  Linux Global: [A] 117/117

OVERALL: 1045/1048 checks passed (8 profiles)
```

Linux per-context failures (1 per profile) are pre-existing and unrelated to this patch — the change only touches `SetAcceptEncodings` in `nsHttpHandler.cpp`.

</details>

<details>
<summary>Web tester / service tester</summary>

Web tester (camoufox-tester.vercel.app) is currently returning an error on their end — `python3: command not found` on the Vercel backend when generating presets. Nothing to do with the binary.

Service tester is designed for pythonlib changes and resolves to the pip-released binary, not a local patch build — not applicable here.

</details>

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] I have included a fingerprint report from https://camoufox-tester.vercel.app/
- [ ] Service tests pass (`bash service_tests/run_tests.sh`)