### PR TITLE
Fix worker timezone leak when using geoip/proxy

### DIFF
--- a/patches/timezone-spoofing.patch
+++ b/patches/timezone-spoofing.patch
@@ -3,9 +3,10 @@ new file mode 100644
 index 0000000000..7ec236d160
 --- /dev/null
 +++ b/dom/base/TimezoneManager.cpp
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,72 @@
 +#include "TimezoneManager.h"
 +#include "RoverfoxStorageManager.h"
++#include "MaskConfig.hpp"
 +#include "nsGlobalWindowInner.h"
 +#include "xpcpublic.h"
 +#include "mozilla/dom/BrowsingContext.h"
@@ -14,6 +15,33 @@ index 0000000000..7ec236d160
 +
 +namespace mozilla {
 +namespace dom {
++
++/* static */ void
++TimezoneManager::SetTimezone(uint32_t userContextId, const nsAString& timezone) {
++  nsAutoString key;
++  key.AppendPrintf("timezone_%u", userContextId);
++  RoverfoxStorageManager::PutString(key, timezone);
++  DisableFunction(userContextId);
++}
++
++/* static */ bool
++TimezoneManager::GetTimezone(uint32_t userContextId, nsAString& outTimezone) {
++  nsAutoString key;
++  key.AppendPrintf("timezone_%u", userContextId);
++  if (RoverfoxStorageManager::GetString(key, outTimezone)) {
++    return true;
++  }
++  // Fallback to CAMOU_CONFIG for workers/contexts where setTimezone()
++  // was never called (e.g. when timezone is set via Playwright's
++  // timezone_id context option rather than the init script path).
++  if (auto val = MaskConfig::GetString("timezone")) {
++    NS_ConvertASCIItoUTF16 tz(val->c_str());
++    RoverfoxStorageManager::PutString(key, tz);
++    outTimezone = tz;
++    return true;
++  }
++  return false;
++}
 +
 +/* static */ nsString
 +TimezoneManager::DisabledKeyForUserContext(uint32_t userContextId) {
@@ -52,12 +80,11 @@ new file mode 100644
 index 0000000000..a7f5735e53
 --- /dev/null
 +++ b/dom/base/TimezoneManager.h
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,28 @@
 +#ifndef mozilla_dom_TimezoneManager_h
 +#define mozilla_dom_TimezoneManager_h
 +
 +#include "nsString.h"
-+#include "RoverfoxStorageManager.h"
 +
 +struct JSContext;
 +class JSObject;
@@ -67,18 +94,8 @@ index 0000000000..a7f5735e53
 +
 +class TimezoneManager {
 + public:
-+  static void SetTimezone(uint32_t userContextId, const nsAString& timezone) {
-+    nsAutoString key;
-+    key.AppendPrintf("timezone_%u", userContextId);
-+    RoverfoxStorageManager::PutString(key, timezone);
-+    DisableFunction(userContextId);
-+  }
-+
-+  static bool GetTimezone(uint32_t userContextId, nsAString& outTimezone) {
-+    nsAutoString key;
-+    key.AppendPrintf("timezone_%u", userContextId);
-+    return RoverfoxStorageManager::GetString(key, outTimezone);
-+  }
++  static void SetTimezone(uint32_t userContextId, const nsAString& timezone);
++  static bool GetTimezone(uint32_t userContextId, nsAString& outTimezone);
 +
 +  static void DisableFunction(uint32_t userContextId);
 +  static bool IsFunctionEnabledForWebIDL(JSContext* aCx, JSObject* aObj);

--- a/scripts/install-local-build.sh
+++ b/scripts/install-local-build.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Install a custom Camoufox build into the local channel.
+#
+# Usage:
+#   ./install-local-build.sh [artifact.zip] [version-build]
+#
+# If no artifact is given, uses the latest zip in dist/.
+# If no version-build is given, extracts it from the zip filename.
+#
+# Installs to ~/.cache/camoufox/browsers/local/<version-build>/
+# and sets active_version in config.json.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+CACHE_DIR="${HOME}/Library/Caches/camoufox"
+# Fall back to XDG if not on macOS
+if [[ ! -d "${HOME}/Library/Caches" ]]; then
+    CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/camoufox"
+fi
+
+BROWSERS_DIR="${CACHE_DIR}/browsers"
+CONFIG_FILE="${CACHE_DIR}/config.json"
+
+# --- Resolve artifact zip ---
+
+ARTIFACT="${1:-}"
+if [[ -z "$ARTIFACT" ]]; then
+    ARTIFACT="$(ls -t "$REPO_ROOT"/dist/camoufox-*-mac.arm64.zip 2>/dev/null | head -1)"
+    if [[ -z "$ARTIFACT" ]]; then
+        echo "No artifact found in dist/. Pass the zip path as an argument."
+        exit 1
+    fi
+    echo "Using latest artifact: $ARTIFACT"
+fi
+
+if [[ ! -f "$ARTIFACT" ]]; then
+    echo "Artifact not found: $ARTIFACT"
+    exit 1
+fi
+
+# --- Resolve version-build string ---
+
+VERSION_BUILD="${2:-}"
+if [[ -z "$VERSION_BUILD" ]]; then
+    # Extract from filename: camoufox-<version>-<build>-mac.arm64.zip
+    BASENAME="$(basename "$ARTIFACT")"
+    # Strip prefix "camoufox-" and suffix "-mac.arm64.zip" (or similar)
+    VERSION_BUILD="${BASENAME#camoufox-}"
+    VERSION_BUILD="${VERSION_BUILD%-mac.*}"
+    VERSION_BUILD="${VERSION_BUILD%-linux.*}"
+    VERSION_BUILD="${VERSION_BUILD%-win.*}"
+fi
+
+echo "Version: $VERSION_BUILD"
+
+# --- Extract version and build parts ---
+
+# version-build format: "146.0.1-ruben.brotli-fix.1"
+# version = everything up to the first hyphen-followed-by-non-digit
+# For simplicity, split on first hyphen after the semver
+VERSION="$(echo "$VERSION_BUILD" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')"
+BUILD="${VERSION_BUILD#${VERSION}-}"
+
+INSTALL_DIR="${BROWSERS_DIR}/local/${VERSION_BUILD}"
+
+echo "Installing to: $INSTALL_DIR"
+
+# --- Install ---
+
+if [[ -d "$INSTALL_DIR" ]]; then
+    echo "Removing existing installation..."
+    rm -rf "$INSTALL_DIR"
+fi
+
+mkdir -p "$INSTALL_DIR"
+
+# Unzip to temp dir first to handle nested structure
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+unzip -q "$ARTIFACT" -d "$TMP_DIR"
+
+# Handle macOS structure: the zip may contain Camoufox.app directly or nested
+if [[ -d "$TMP_DIR/Camoufox.app" ]]; then
+    mv "$TMP_DIR/Camoufox.app" "$INSTALL_DIR/Camoufox.app"
+elif [[ -d "$TMP_DIR/Camoufox/Camoufox.app" ]]; then
+    mv "$TMP_DIR/Camoufox/Camoufox.app" "$INSTALL_DIR/Camoufox.app"
+else
+    # Linux/Windows: move everything
+    mv "$TMP_DIR"/* "$INSTALL_DIR/"
+fi
+
+# Fix permissions (cp/unzip can strip executable bits)
+chmod -R 755 "$INSTALL_DIR"
+
+# Write version.json
+cat > "$INSTALL_DIR/version.json" <<VEOF
+{
+  "version": "$VERSION",
+  "build": "$BUILD",
+  "prerelease": false,
+  "local_build": true
+}
+VEOF
+
+# --- Set active version ---
+
+RELATIVE_PATH="browsers/local/${VERSION_BUILD}"
+
+# Write config.json (preserve channel if set)
+if [[ -f "$CONFIG_FILE" ]]; then
+    # Use python for safe JSON manipulation
+    python3 -c "
+import json, sys
+with open('$CONFIG_FILE') as f:
+    cfg = json.load(f)
+cfg['active_version'] = '$RELATIVE_PATH'
+with open('$CONFIG_FILE', 'w') as f:
+    json.dump(cfg, f, indent=2)
+"
+else
+    mkdir -p "$(dirname "$CONFIG_FILE")"
+    echo "{\"active_version\": \"$RELATIVE_PATH\"}" > "$CONFIG_FILE"
+fi
+
+echo ""
+echo "Installed: $INSTALL_DIR"
+echo "Active:    $RELATIVE_PATH"
+
+# Verify
+PLIST="$INSTALL_DIR/Camoufox.app/Contents/Info.plist"
+if [[ -f "$PLIST" ]]; then
+    BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST" 2>/dev/null || echo "unknown")"
+    echo "Bundle:    $BUNDLE_VERSION"
+fi
+
+echo ""
+echo "Done. Run 'camoufox list' to see installed versions."


### PR DESCRIPTION
Closes #545

## Summary

Add `MaskConfig::GetString("timezone")` fallback to `TimezoneManager::GetTimezone()` so worker threads pick up the correct proxy timezone.

## Description

When `geoip=True`, the timezone is resolved from the proxy IP and stored in `CAMOU_CONFIG`. Playwright's `timezone_id` picks it up for the main thread. But `WorkerPrivate::GetOrCreateGlobalScope()` reads via `TimezoneManager::GetTimezone()` → `RoverfoxStorageManager`, which is empty — nothing has written to it via this path. Workers fall back to the host system timezone.

The fix adds a `MaskConfig` fallback to `TimezoneManager::GetTimezone()`: if storage is empty, read from `CAMOU_CONFIG` and store the result. Same pattern `AudioFingerprintManager::GetSeed()` already uses for `audio:seed`.

Also moved `SetTimezone`/`GetTimezone` from the header into `TimezoneManager.cpp` — `MaskConfig.hpp` can't be included from exported headers (they get copied to `obj-*/dist/include/` where the camoucfg include path isn't available).

## Type of change

- [x] Bug fix

## Testing

Verified with a US proxy on a UK host machine — worker timezone now matches main thread. Build-tester and web-tester results pending.