### PR TITLE
Allow disabling font spacing perturbation (seed=0 no-op, matching audio)

### DIFF
--- a/patches/anti-font-fingerprinting.patch
+++ b/patches/anti-font-fingerprinting.patch
@@ -862,49 +862,44 @@ index 1a5bdaba99..46226fc88d 100644
  
  #include <algorithm>
  
-@@ -1567,6 +1571,41 @@ bool gfxHarfBuzzShaper::ShapeText(DrawTarget* aDrawTarget,
+@@ -1567,6 +1571,36 @@ bool gfxHarfBuzzShaper::ShapeText(DrawTarget* aDrawTarget,
  
    hb_shape(mHBFont, mBuffer, features.Elements(), features.Length());
  
-+  // Resolve seed from manager using user context ID, with deterministic fallback.
++  // Resolve seed from manager using user context ID.
++  // seed == 0 means no perturbation (consistent with AudioFingerprintManager).
 +  uint32_t pbid = aShapedText ? aShapedText->GetUserContextId() : 0;
 +  uint32_t seed = mozilla::dom::FontSpacingSeedManager::GetSeed(pbid);
-+  bool seedFromManager = (seed != 0);
-+  if (!seedFromManager) {
-+    seed = 0x6D2B79F5u; // fixed constant to avoid time-based variance
-+  }
-+  printf("HarfBuzzShaper: pbid=%u seed=%u (from_manager=%d)\n",
-+         pbid,
-+         seed,
-+         seedFromManager ? 1 : 0);
 +
-+  // Generate a random float [0, 0.1] to offset the letter spacing
-+  seed = (seed * 1103515245 + 12345) & 0x7fffffff;
-+  float randomFloat = (static_cast<float>(seed) / 2147483647.0f) * 0.1f;
-+  hb_position_t spacing = FloatToFixed(randomFloat);
++  if (seed != 0) {
++    // Generate a random float [0, 0.1] to offset the letter spacing
++    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
++    float randomFloat = (static_cast<float>(seed) / 2147483647.0f) * 0.1f;
++    hb_position_t spacing = FloatToFixed(randomFloat);
 +
-+  uint32_t glyphCount;
-+  hb_glyph_position_t* glyphPositions =
-+      hb_buffer_get_glyph_positions(mBuffer, &glyphCount);
++    uint32_t glyphCount;
++    hb_glyph_position_t* glyphPositions =
++        hb_buffer_get_glyph_positions(mBuffer, &glyphCount);
 +
-+  hb_position_t cumulativeOffset = 0;
++    hb_position_t cumulativeOffset = 0;
 +
-+  // Apply custom letter spacing
-+  for (uint32_t i = 0; i < glyphCount; ++i) {
-+    if (aVertical) {
-+      glyphPositions[i].y_advance -= spacing;
-+      glyphPositions[i].y_offset -= cumulativeOffset;
-+    } else {
-+      glyphPositions[i].x_advance += spacing;
-+      glyphPositions[i].x_offset += cumulativeOffset;
++    // Apply custom letter spacing
++    for (uint32_t i = 0; i < glyphCount; ++i) {
++      if (aVertical) {
++        glyphPositions[i].y_advance -= spacing;
++        glyphPositions[i].y_offset -= cumulativeOffset;
++      } else {
++        glyphPositions[i].x_advance += spacing;
++        glyphPositions[i].x_offset += cumulativeOffset;
++      }
++      cumulativeOffset += spacing;
 +    }
-+    cumulativeOffset += spacing;
 +  }
 +
    if (isRightToLeft) {
      hb_buffer_reverse(mBuffer);
    }
-@@ -1872,3 +1911,4 @@ nsresult gfxHarfBuzzShaper::SetGlyphsFromRun(gfxShapedText* aShapedText,
+@@ -1872,3 +1905,4 @@ nsresult gfxHarfBuzzShaper::SetGlyphsFromRun(gfxShapedText* aShapedText,
  
    return NS_OK;
  }

--- a/scripts/install-local-build.sh
+++ b/scripts/install-local-build.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Install a custom Camoufox build into the local channel.
+#
+# Usage:
+#   ./install-local-build.sh [artifact.zip] [version-build]
+#
+# If no artifact is given, uses the latest zip in dist/.
+# If no version-build is given, extracts it from the zip filename.
+#
+# Installs to ~/.cache/camoufox/browsers/local/<version-build>/
+# and sets active_version in config.json.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+CACHE_DIR="${HOME}/Library/Caches/camoufox"
+# Fall back to XDG if not on macOS
+if [[ ! -d "${HOME}/Library/Caches" ]]; then
+    CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/camoufox"
+fi
+
+BROWSERS_DIR="${CACHE_DIR}/browsers"
+CONFIG_FILE="${CACHE_DIR}/config.json"
+
+# --- Resolve artifact zip ---
+
+ARTIFACT="${1:-}"
+if [[ -z "$ARTIFACT" ]]; then
+    ARTIFACT="$(ls -t "$REPO_ROOT"/dist/camoufox-*-mac.arm64.zip 2>/dev/null | head -1)"
+    if [[ -z "$ARTIFACT" ]]; then
+        echo "No artifact found in dist/. Pass the zip path as an argument."
+        exit 1
+    fi
+    echo "Using latest artifact: $ARTIFACT"
+fi
+
+if [[ ! -f "$ARTIFACT" ]]; then
+    echo "Artifact not found: $ARTIFACT"
+    exit 1
+fi
+
+# --- Resolve version-build string ---
+
+VERSION_BUILD="${2:-}"
+if [[ -z "$VERSION_BUILD" ]]; then
+    # Extract from filename: camoufox-<version>-<build>-mac.arm64.zip
+    BASENAME="$(basename "$ARTIFACT")"
+    # Strip prefix "camoufox-" and suffix "-mac.arm64.zip" (or similar)
+    VERSION_BUILD="${BASENAME#camoufox-}"
+    VERSION_BUILD="${VERSION_BUILD%-mac.*}"
+    VERSION_BUILD="${VERSION_BUILD%-linux.*}"
+    VERSION_BUILD="${VERSION_BUILD%-win.*}"
+fi
+
+echo "Version: $VERSION_BUILD"
+
+# --- Extract version and build parts ---
+
+# version-build format: "146.0.1-ruben.brotli-fix.1"
+# version = everything up to the first hyphen-followed-by-non-digit
+# For simplicity, split on first hyphen after the semver
+VERSION="$(echo "$VERSION_BUILD" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')"
+BUILD="${VERSION_BUILD#${VERSION}-}"
+
+INSTALL_DIR="${BROWSERS_DIR}/local/${VERSION_BUILD}"
+
+echo "Installing to: $INSTALL_DIR"
+
+# --- Install ---
+
+if [[ -d "$INSTALL_DIR" ]]; then
+    echo "Removing existing installation..."
+    rm -rf "$INSTALL_DIR"
+fi
+
+mkdir -p "$INSTALL_DIR"
+
+# Unzip to temp dir first to handle nested structure
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+unzip -q "$ARTIFACT" -d "$TMP_DIR"
+
+# Handle macOS structure: the zip may contain Camoufox.app directly or nested
+if [[ -d "$TMP_DIR/Camoufox.app" ]]; then
+    mv "$TMP_DIR/Camoufox.app" "$INSTALL_DIR/Camoufox.app"
+elif [[ -d "$TMP_DIR/Camoufox/Camoufox.app" ]]; then
+    mv "$TMP_DIR/Camoufox/Camoufox.app" "$INSTALL_DIR/Camoufox.app"
+else
+    # Linux/Windows: move everything
+    mv "$TMP_DIR"/* "$INSTALL_DIR/"
+fi
+
+# Fix permissions (cp/unzip can strip executable bits)
+chmod -R 755 "$INSTALL_DIR"
+
+# Write version.json
+cat > "$INSTALL_DIR/version.json" <<VEOF
+{
+  "version": "$VERSION",
+  "build": "$BUILD",
+  "prerelease": false,
+  "local_build": true
+}
+VEOF
+
+# --- Set active version ---
+
+RELATIVE_PATH="browsers/local/${VERSION_BUILD}"
+
+# Write config.json (preserve channel if set)
+if [[ -f "$CONFIG_FILE" ]]; then
+    # Use python for safe JSON manipulation
+    python3 -c "
+import json, sys
+with open('$CONFIG_FILE') as f:
+    cfg = json.load(f)
+cfg['active_version'] = '$RELATIVE_PATH'
+with open('$CONFIG_FILE', 'w') as f:
+    json.dump(cfg, f, indent=2)
+"
+else
+    mkdir -p "$(dirname "$CONFIG_FILE")"
+    echo "{\"active_version\": \"$RELATIVE_PATH\"}" > "$CONFIG_FILE"
+fi
+
+echo ""
+echo "Installed: $INSTALL_DIR"
+echo "Active:    $RELATIVE_PATH"
+
+# Verify
+PLIST="$INSTALL_DIR/Camoufox.app/Contents/Info.plist"
+if [[ -f "$PLIST" ]]; then
+    BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST" 2>/dev/null || echo "unknown")"
+    echo "Bundle:    $BUNDLE_VERSION"
+fi
+
+echo ""
+echo "Done. Run 'camoufox list' to see installed versions."


### PR DESCRIPTION
Closes #547

## Summary

- Remove hardcoded `0x6D2B79F5u` fallback from font spacing perturbation
- Add `seed == 0` guard to skip perturbation (consistent with `AudioFingerprintManager`)
- Remove debug `printf` from the shaping path

## Description

### The inconsistency

Audio fingerprint perturbation has a clean off switch — `ApplyTransformation()` returns early when `seed == 0`. Font spacing doesn't: when no seed is set via `FontSpacingSeedManager`, the code falls back to a hardcoded constant (`0x6D2B79F5u`) and always applies perturbation.

This is a problem because the perturbation produces font/canvas hashes outside the real-device population. Fingerprint checkers with population databases (e.g. PixelScan) flag these as synthetic — "Masking detected". Being able to disable perturbation lets users choose plausibility over diversity when that tradeoff matters.

### The fix

Remove the hardcoded fallback and wrap the LCG + glyph offset loop in a `seed != 0` guard:

```cpp
uint32_t seed = FontSpacingSeedManager::GetSeed(pbid);

if (seed != 0) {
    // existing LCG + spacing application
}
```

When `GetSeed()` returns 0 (no seed set), the guard skips perturbation entirely. Same semantics as `AudioFingerprintManager::ApplyTransformation()`.

To disable from the Python API, set `fonts:spacing_seed` to 0 in the config/preset — same convention as `audio:seed` and `canvas:seed`.

Default behaviour is unchanged — `generate_context_fingerprint()` generates random non-zero seeds in `[1, 2^32-1]` as before, same as `audio:seed` and `canvas:seed`. This just makes it possible to opt out by passing 0, which font spacing was the only perturbation that didn't support.

### Side fix

Also removes the `printf("HarfBuzzShaper: ...")` debug statement that fires on every `ShapeText()` call (~4000 times per page load). This was instrumentation from development that shouldn't ship.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Regression risk

Low. The only behaviour change is:
1. **No seed explicitly set + no init script**: previously got perturbation via `0x6D2B79F5u` fallback, now gets vanilla metrics. This is the "bare Camoufox with no Python wrapper" case — unlikely to be anyone's production setup, and the new behaviour (no perturbation) is arguably more correct.
2. **Normal usage via Python API**: unchanged. Seeds are generated in range `[1, 2^32-1]` as before — perturbation on by default.
3. **Explicit seed=0**: new opt-out path that didn't exist before.