### PR TITLE
Fix init_script timezone poisoning (companion to #546)

### DIFF
--- a/pythonlib/camoufox/fingerprints.py
+++ b/pythonlib/camoufox/fingerprints.py
@@ -373,15 +373,16 @@ def _build_init_script(values: Dict[str, Any]) -> str:
                 f'  if (typeof w.setScreenColorDepth === "function") w.setScreenColorDepth({scd});'
             )
 
-    # Timezone (always call to trigger self-destruct)
+    # Timezone — only call setTimezone() when we have an explicit value.
+    # Without this, the C++ MaskConfig fallback (from CAMOU_CONFIG set by geoip
+    # in launch_options) handles timezone for both main thread and workers via
+    # SetNewDocument() and TimezoneManager::GetTimezone().
+    # The old fallback read system TZ and poisoned RoverfoxStorageManager,
+    # preventing MaskConfig from ever being consulted.
     tz = values.get('timezone')
     if tz:
         lines.append(
             f'  if (typeof w.setTimezone === "function") w.setTimezone({_json.dumps(tz)});'
-        )
-    else:
-        lines.append(
-            '  if (typeof w.setTimezone === "function") w.setTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone);'
         )
 
     # WebRTC IP


### PR DESCRIPTION
Closes #556. Companion to #546.

## Description

When no explicit timezone is provided at fingerprint generation time (the standard `geoip=True` flow), the init script falls back to `setTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone)` — reading the host's system timezone and storing it in `RoverfoxStorageManager`. This poisons the storage before the MaskConfig fallback from #546 can fire.

On a GCP VM (UTC) with a UK proxy: workers report UTC instead of Europe/London.

### The fix

Remove the `else` branch in `_build_init_script()`. When no explicit timezone is provided, don't call `setTimezone()` at all. The C++ `SetNewDocument()` hook and `TimezoneManager::GetTimezone()` MaskConfig fallback from #546 handle timezone propagation correctly when the init script doesn't interfere.

### How it interacts with #546

| PR | Side | What it fixes |
|---|---|---|
| #546 | C++ | `GetTimezone()` falls back to MaskConfig when storage is empty |
| This | Python | Init script no longer poisons storage, so the fallback actually fires |

Neither fix is sufficient alone.

## Type of change

- [x] Bug fix