### PR TITLE
Set FONTCONFIG_FILE to isolate bundled fonts on Linux

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -41,6 +41,39 @@ CACHE_PREFS = {
 }
 
 
+def _generate_fontconfig(fontconfig_path: str) -> str:
+    """
+    Generates a runtime fontconfig that resolves bundled font paths absolutely.
+    The bundled fonts.conf uses prefix="cwd" relative paths which break when
+    Playwright's working directory differs from the browser install directory.
+    Writes a patched copy to ~/.cache/camoufox/fontconfig/ (deterministic,
+    only regenerated when content changes).
+    """
+    import hashlib
+
+    fonts_dir = get_path("fonts")
+    fonts_conf_src = os.path.join(fontconfig_path, "fonts.conf")
+
+    with open(fonts_conf_src, 'r') as f:
+        conf_content = f.read()
+
+    conf_content = conf_content.replace(
+        '<dir prefix="cwd">fonts</dir>',
+        f'<dir>{fonts_dir}</dir>',
+    )
+
+    cache_dir = os.path.join(os.path.expanduser('~'), '.cache', 'camoufox', 'fontconfig')
+    os.makedirs(cache_dir, exist_ok=True)
+
+    content_hash = hashlib.sha256(conf_content.encode()).hexdigest()[:12]
+    runtime_conf = os.path.join(cache_dir, f'fonts-{content_hash}.conf')
+    if not os.path.exists(runtime_conf):
+        with open(runtime_conf, 'w') as f:
+            f.write(conf_content)
+
+    return runtime_conf
+
+
 def get_env_vars(
     config_map: Dict[str, str], user_agent_os: str
 ) -> Dict[str, Union[str, float, bool]]:
@@ -85,6 +118,8 @@ def get_env_vars(
             raise FileNotFoundError(
                 f"fonts.conf not found in {fontconfig_path}!  Something ain't right with your camoufox bundle."
             )
+
+        env_vars['FONTCONFIG_FILE'] = _generate_fontconfig(fontconfig_path)
 
     return env_vars
 


### PR DESCRIPTION
Closes #557

## Description

On Linux, system fonts leak into the rendering pipeline. The font enumeration whitelist hides system fonts from JavaScript, but fontconfig still loads them as rendering fallbacks. This makes datacenter machines trivially identifiable — a minimal cloud VM has ~4 font packages vs ~120 on a desktop, producing measurably different canvas fingerprints, font metrics, and SVG rendering.

**Root cause**: `get_env_vars()` computes the bundled fontconfig path, validates `fonts.conf` exists, then discards it without setting `FONTCONFIG_FILE`. Fontconfig defaults to `/etc/fonts/fonts.conf` and loads system fonts.

### The fix

Added `_generate_fontconfig()` that reads the bundled `fonts.conf`, replaces the relative `<dir prefix="cwd">fonts</dir>` with an absolute path (resolved at runtime), writes a content-hashed copy to `~/.cache/camoufox/fontconfig/`, and sets `FONTCONFIG_FILE`.

Same Camoufox build + same profile: CreepJS `pixelSizeSystemSum`, `textMetricsSystemSum`, `fontFaceLoadFonts` now identical between GCP VM and residential Linux.

macOS and Windows unaffected (gated on `OS_NAME == 'lin'`).

## Type of Change

- [x] Bug fix