### PR TITLE
Add timezone and locale parameters to generate_context_fingerprint()

### DIFF
--- a/pythonlib/camoufox/fingerprints.py
+++ b/pythonlib/camoufox/fingerprints.py
@@ -420,6 +420,8 @@ def generate_context_fingerprint(
     os: Optional[str] = None,
     ff_version: Optional[str] = None,
     webrtc_ip: Optional[str] = None,
+    timezone: Optional[str] = None,
+    locale: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Generate fingerprint values for a single per-context identity.
@@ -427,6 +429,14 @@ def generate_context_fingerprint(
 
     By default, uses BrowserForge for infinite unique synthetic fingerprints.
     Pass a preset dict to use a real fingerprint preset instead.
+
+    Parameters:
+        timezone: IANA timezone string (e.g. 'Europe/London'). When provided,
+            injected into config before init_script generation. Takes priority
+            over any timezone from the preset.
+        locale: BCP-47 locale string (e.g. 'en-GB'). When provided, parsed via
+            normalize_locale() and injected into config. Also sets
+            context_options['locale'] for Playwright.
     """
     if preset is not None:
         # Use real fingerprint preset
@@ -512,6 +522,18 @@ def generate_context_fingerprint(
         }
         preset = {'navigator': nav, 'screen': screen, 'webgl': webgl}
 
+    # Inject explicit timezone/locale into config (takes priority over preset)
+    if timezone:
+        config['timezone'] = timezone
+    if locale:
+        from .locales import normalize_locale
+        parsed = normalize_locale(locale)
+        config['locale:language'] = parsed.language
+        config['locale:region'] = parsed.region
+        config['navigator.language'] = parsed.as_string
+        if parsed.script:
+            config['locale:script'] = parsed.script
+
     # Build the values dict for the init script (works for both paths)
     init_values: Dict[str, Any] = {
         'fontSpacingSeed': config.get('fonts:spacing_seed'),
@@ -554,6 +576,9 @@ def generate_context_fingerprint(
         tz = preset.get('timezone')
     if tz:
         context_options['timezone_id'] = tz
+    nav_lang = config.get('navigator.language')
+    if nav_lang:
+        context_options['locale'] = nav_lang
 
     return {
         'init_script': init_script,

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -627,7 +627,12 @@ def launch_options(
                 set_into(config, 'webrtc:ipv6', geoip)
 
         geolocation = get_geolocation(geoip, geoip_db=geoip_db)
-        config.update(geolocation.as_config())
+        geo_config = geolocation.as_config()
+        for key, value in geo_config.items():
+            if key in ('timezone', 'locale:language', 'locale:region', 'locale:script'):
+                config.setdefault(key, value)
+            else:
+                config[key] = value
 
     # Raise a warning when a proxy is being used without spoofing geolocation.
     # This is a very bad idea; the warning cannot be ignored with i_know_what_im_doing.


### PR DESCRIPTION
Closes #559

## Description

`generate_context_fingerprint()` and `launch_options()` don't coordinate on timezone and locale. Geoip resolves these in `launch_options()`, but the init script is already baked by `generate_context_fingerprint()`. There's no way to pass pre-resolved timezone/locale into the fingerprint.

### The fix

**`fingerprints.py`**: New `timezone` and `locale` params on `generate_context_fingerprint()`. When provided, injected into config before init_script generation. Locale parsed via `normalize_locale()` into `locale:language`, `locale:region`, `navigator.language`. Also sets `context_options['locale']` and `context_options['timezone_id']`.

**`utils.py`**: In `launch_options()`, geoip timezone/locale keys now use `setdefault` instead of blind overwrite. Pre-set values aren't clobbered; geolocation coordinates still overwrite (they're per-session).

### Design note

This is somewhat opinionated — it fits workflows where one IP maps to one-or-more profiles, and a profile is never used with a different IP (identity consistency across sessions). Entirely opt-in: callers who don't pass these params get current behaviour.

## Type of change

- [x] New feature

## Backward compatibility

Fully backward compatible. Both params default to `None`. The `setdefault` change only matters when config keys are already present.