### PR TITLE
Fix out-of-viewport mousemove crash (sendMouseEvent → jugglerSendMouseEvent)

### DIFF
--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -545,7 +545,7 @@ export class PageHandler {
         // viewport coordinates, then move the mouse off from the Web Content.
         // This way we can eliminate all the hover effects.
         // NOTE: since this won't go inside the renderer, there's no need to wait for ACK.
-        win.windowUtils.sendMouseEvent(
+        win.windowUtils.jugglerSendMouseEvent(
           'mousemove',
           0 /* x */,
           0 /* y */,


### PR DESCRIPTION
Closes #564

## Summary

One-line fix: `PageHandler.js` calls `sendMouseEvent()` for out-of-viewport mousemoves, but this method doesn't exist on `nsIDOMWindowUtils`. Should be `jugglerSendMouseEvent()` — matching the in-viewport code path on line 511 and `PageAgent.js` line 542.

## Description

When `Page.dispatchMouseEvent` receives a mousemove with coordinates outside the viewport, it takes a special path (line 540) to move the mouse off the web content and clear hover effects. This path calls `win.windowUtils.sendMouseEvent()`, which throws because the method doesn't exist in Firefox's DOM API.

The in-viewport path correctly uses `jugglerSendMouseEvent()` — the Playwright-specific extension added to `nsIDOMWindowUtils`. The out-of-viewport fallback just has the wrong method name.

Triggers during normal automation when interacting with elements near the viewport edge — date pickers, dropdowns, drag operations.