### PR TITLE
Fix virtual display under Wayland by forcing X11

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -547,6 +547,11 @@ def launch_options(
     # Handle virtual display
     if virtual_display:
         env['DISPLAY'] = virtual_display
+        # Virtual display uses Xvfb (X11). If the host session forces Wayland via env vars,
+        # GTK/Firefox may try Wayland and ignore DISPLAY, breaking Xvfb usage.
+        env['GDK_BACKEND'] = 'x11'
+        env.pop('WAYLAND_DISPLAY', None)
+        env["MOZ_ENABLE_WAYLAND"] = "0"
 
     # Warn the user for manual config settings
     if not i_know_what_im_doing:


### PR DESCRIPTION
## Related Issue

Closes #575

## Description

When using Xvfb-backed virtual display, override Wayland env vars (GDK_BACKEND, WAYLAND_DISPLAY, MOZ_ENABLE_WAYLAND) so Firefox/GTK honors DISPLAY and reliably uses the X11 virtual screen.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

I applied the patch locally and verified it works.
I am not sure if a test is needed. Please guide me if I should add it.

## Fingerprint Report

N/A

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result   (Explained in issue)
- [ ] I have included a fingerprint report from https://camoufox-tester.vercel.app/
- [x] Service tests pass (`bash service_tests/run_tests.sh`)
