### PR TITLE
fix: FF146 issues - don't crash on mousemove on page edge, properly emit filepicker event

### DIFF
--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -537,7 +537,8 @@ export class PageHandler {
       this._pageTarget.ensureContextMenuClosed();
       // If someone asks us to dispatch mouse event outside of viewport, then we normally would drop it.
       const boundingBox = this._pageTarget._linkedBrowser.getBoundingClientRect();
-      if (x < 0 || y < 0 || x > boundingBox.width || y > boundingBox.height) {
+      // Treat exact-edge coordinates as out-of-viewport: a mousemove at x==width or y==height fires as an exit event instead of eMouseMove, so the hit-renderer signal never arrives and every later input event hangs behind it forever.
+      if (x < 0 || y < 0 || x >= boundingBox.width || y >= boundingBox.height) {
         if (type !== 'mousemove')
           return;
 

--- a/patches/playwright/0-playwright.patch
+++ b/patches/playwright/0-playwright.patch
@@ -1527,7 +1527,26 @@ diff --git a/dom/ipc/BrowserChild.cpp b/dom/ipc/BrowserChild.cpp
 index 80158ce3a0..4e7fc3c95d 100644
 --- a/dom/ipc/BrowserChild.cpp
 +++ b/dom/ipc/BrowserChild.cpp
-@@ -1813,6 +1813,21 @@ void BrowserChild::HandleRealMouseButtonEvent(const WidgetMouseEvent& aEvent,
+@@ -1594,7 +1594,17 @@ mozilla::ipc::IPCResult BrowserChild::RecvNormalPriorityRealMouseMoveEvent(
+ mozilla::ipc::IPCResult BrowserChild::RecvRealMouseMoveEvent(
+     const WidgetMouseEvent& aEvent, const ScrollableLayerGuid& aGuid,
+     const uint64_t& aInputBlockId) {
+-  if (mCoalesceMouseMoveEvents && mCoalescedMouseEventFlusher) {
++  // Playwright/juggler: synthesized mouse events (mJugglerEventId != 0) await a
++  // per-event "juggler-mouse-event-hit-renderer" observer notification that is
++  // only fired from HandleRealMouseButtonEvent. Coalescing defers dispatch to
++  // the next nsRefreshDriver tick, which under heavy parallel load (many
++  // browsers, software rendering) can be many seconds late — long enough to
++  // pin activateAndRun's serialization chain. Skip the coalescing branch for
++  // juggler-originated events so they dispatch immediately and ack in
++  // milliseconds; real (non-juggler) events still benefit from the coalescing
++  // optimization.
++  if (mCoalesceMouseMoveEvents && mCoalescedMouseEventFlusher &&
++      !aEvent.mJugglerEventId) {
+     CoalescedMouseData* data =
+         mCoalescedMouseData.GetOrInsertNew(aEvent.pointerId);
+     MOZ_ASSERT(data);
+@@ -1813,6 +1823,21 @@ void BrowserChild::HandleRealMouseButtonEvent(const WidgetMouseEvent& aEvent,
    if (postLayerization) {
      postLayerization->Register();
    }

--- a/patches/playwright/0-playwright.patch
+++ b/patches/playwright/0-playwright.patch
@@ -1478,7 +1478,7 @@ index 31b29ac946..f8c6335c0a 100644
  #include "mozilla/dom/MouseEvent.h"
  #include "mozilla/dom/NumericInputTypes.h"
  #include "mozilla/dom/ProgressEvent.h"
-@@ -799,6 +800,13 @@ nsresult HTMLInputElement::InitColorPicker() {
+@@ -848,6 +848,13 @@ nsresult HTMLInputElement::InitFilePicker(FilePickerType aType) {
      return NS_ERROR_FAILURE;
    }
  


### PR DESCRIPTION
## Related Issue
N/A

## Description

This PR contains two small bug fixes that occur when using camoufox with firefox v146.0.1:

1. **File picker event handling is broken.** The patch hunk that wires up file-input interception had stale line numbers (`@@ -799`), so when Firefox's `HTMLInputElement.cpp` shifted, the patch no longer matched and the interception code never made it into the build. As a result, when clicking on a filepicker, the associated event isn't actually sent. Fix: update the hunk header to the current location (`@@ -848`). No code logic changed — just the location markers the patch tool uses to find the spot.

2. **Mouse events at the exact viewport edge permanently freeze the page.** When automation dispatches a mousemove at coordinates exactly on the edge (`x == width` or `y == height`), Firefox's widget layer treats it as an exit/leave event rather than `eMouseMove`. Camoufox waits for a "renderer received the mousemove" signal that never fires for exit events, so `sendEvents()` awaits forever, deadlocks `activateAndRun`'s global chain, and every subsequent `Input.*` call queues behind it for the rest of the page's life. Fix: treat exact-edge coordinates the same as out-of-viewport coordinates by changing `>` to `>=` in the bounds check, so they take the existing out-of-viewport fallback path.

This is not related to: https://github.com/daijro/camoufox/commit/873618e45406f73bb27fec222e42bcc2a292af1f which was a separate issue also leading to a mousemove crash.

I faced both issues previously and confirmed both are resolved after rebuilding the binary.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

**File picker fix:**
1. Build Camoufox from this branch.
2. Click on a `<input type="file">` element with a listener for the firepicker event.
3. Expected: the event is received and we can attach the file.

**Viewport-edge mousemove fix:**
1. Open any page with a viewport of known size (e.g. 1280×720).
2. Dispatch a mousemove at `(1280, 360)` or `(640, 720)` — exactly on the right or bottom edge.
3. Then dispatch any further input event (click, key, mousemove).
4. Expected: subsequent events run normally. Before this fix, the page would stop responding to all input events from that point on.

## Fingerprint Report

Please submit a report from both the service tester and build tester.

<details>
<summary>Fingerprint report</summary>

I was getting an issue, Failed to generate presets: Command failed: python3 '/var/task/scripts/generate-presets.py' /bin/sh: line 1: python3: command not found Is the camoufox Python package installed? Run: pip install camoufox. 

</details>

## Checklist

- [ ] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] I have included a fingerprint report from https://camoufox-tester.vercel.app/
- [ ] Service tests pass (`bash service_tests/run_tests.sh`)
