### PR TITLE
juggler: add Page.getEventListenersForNode

### DIFF
--- a/additions/juggler/content/PageAgent.js
+++ b/additions/juggler/content/PageAgent.js
@@ -150,6 +150,7 @@ export class PageAgent {
         dispatchTouchEvent: this._dispatchTouchEvent.bind(this),
         dispatchTapEvent: this._dispatchTapEvent.bind(this),
         getContentQuads: this._getContentQuads.bind(this),
+        getEventListenersForNode: this._getEventListenersForNode.bind(this),
         getFullAXTree: this._getFullAXTree.bind(this),
         insertText: this._insertText.bind(this),
         scrollIntoViewIfNeeded: this._scrollIntoViewIfNeeded.bind(this),
@@ -424,6 +425,28 @@ export class PageAgent {
       contentFrameId: contentFrame ? contentFrame.id() : undefined,
       ownerFrameId: ownerFrame ? ownerFrame.id() : undefined,
     };
+  }
+
+  _getEventListenersForNode({objectId, frameId}) {
+    const frame = this._frameTree.frame(frameId);
+    if (!frame)
+      throw new Error('Failed to find frame with id = ' + frameId);
+    const unsafeObject = frame.unsafeObject(objectId);
+    if (!unsafeObject)
+      throw new Error('Failed to find node with id = ' + objectId);
+    const els = Cc['@mozilla.org/eventlistenerservice;1']
+        .getService(Ci.nsIEventListenerService);
+    const infos = els.getListenerInfoFor(unsafeObject);
+    const listeners = [];
+    for (const info of infos) {
+      listeners.push({
+        type: info.type,
+        capturing: info.capturing,
+        allowsUntrusted: info.allowsUntrusted,
+        inSystemEventGroup: info.inSystemEventGroup,
+      });
+    }
+    return { listeners };
   }
 
   async _scrollIntoViewIfNeeded({objectId, frameId, rect}) {

--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -459,6 +459,10 @@ export class PageHandler {
     return await this._contentPage.send('describeNode', options);
   }
 
+  async ['Page.getEventListenersForNode'](options) {
+    return await this._contentPage.send('getEventListenersForNode', options);
+  }
+
   async ['Page.scrollIntoViewIfNeeded'](options) {
     return await this._contentPage.send('scrollIntoViewIfNeeded', options);
   }

--- a/additions/juggler/protocol/Protocol.js
+++ b/additions/juggler/protocol/Protocol.js
@@ -107,6 +107,23 @@ pageTypes.InitScript = {
   worldName: t.Optional(t.String),
 };
 
+// One row of `Page.getEventListenersForNode`'s response. The
+// field names mirror Firefox's `nsIEventListenerInfo` interface
+// (dom/events/nsIEventListenerService.idl) verbatim so the
+// mapping from the underlying XPCOM service is unambiguous —
+// what Firefox DevTools's "Event Listeners" panel shows is what
+// this method emits. `inSystemEventGroup` distinguishes
+// browser/extension-registered listeners from page-author
+// handlers, letting clients filter to "author intent" if they
+// want. Note: Firefox doesn't expose the DOM-level `passive`
+// flag through this interface, so it isn't included.
+pageTypes.EventListenerInfo = {
+  type: t.String,
+  capturing: t.Boolean,
+  allowsUntrusted: t.Boolean,
+  inSystemEventGroup: t.Boolean,
+};
+
 const runtimeTypes = {};
 runtimeTypes.RemoteObject = {
   type: t.Optional(t.Enum(['object', 'function', 'undefined', 'string', 'number', 'boolean', 'symbol', 'bigint'])),
@@ -831,6 +848,25 @@ const Page = {
       returns: {
         contentFrameId: t.Optional(t.String),
         ownerFrameId: t.Optional(t.String),
+      },
+    },
+    // Enumerate every event listener attached to the DOM node
+    // identified by `(frameId, objectId)`. Wraps Firefox's
+    // `nsIEventListenerService.getListenerInfoFor(node)`, the
+    // same XPCOM service that powers DevTools's "Event Listeners"
+    // panel. Useful for automation clients that need to discover
+    // non-ARIA interactive elements (e.g. `<div onclick>` /
+    // `<span data-action>`) that pure accessibility-tree walks
+    // don't expose. Listeners are returned in their native
+    // registration order; the `system` flag distinguishes
+    // browser/extension listeners from page-author handlers.
+    'getEventListenersForNode': {
+      params: {
+        frameId: t.String,
+        objectId: t.String,
+      },
+      returns: {
+        listeners: t.Array(pageTypes.EventListenerInfo),
       },
     },
     'scrollIntoViewIfNeeded': {


### PR DESCRIPTION
## Related Issue

Closes #591

## Description

Adds a Juggler `Page` domain method that exposes Firefox's `nsIEventListenerService.getListenerInfoFor(node)` so Juggler clients can enumerate the event listeners attached to a DOM node.

### Motivation

The recent surge of LLM-agent browser tooling (Browser-Use, chrome-devtools-mcp, Vercel agent-browser, browserbase, and others) all need to discover non-ARIA interactive elements like `<div onclick>` or `<span data-action>` to drive realistic agent ↔ web interactions. Pure accessibility-tree walks miss those — the AX tree marks them as `role=generic`, so the agent sees a static page when the user sees a clickable surface. Chrome has long exposed `getEventListeners(el)` in the DevTools Runtime context for this case; this patch brings parity to Firefox-flavored automation through Juggler.

### Diff scope (~60 lines, three files)

**`additions/juggler/protocol/Protocol.js`**
- New `pageTypes.EventListenerInfo` type. Field names mirror `nsIEventListenerInfo` verbatim (`capturing`, `allowsUntrusted`, `inSystemEventGroup`) so the mapping from the underlying XPCOM service is unambiguous. The DOM-level `passive` flag is intentionally omitted because Firefox doesn't expose it through this interface.
- New `'getEventListenersForNode'` method on the Page domain, adjacent to `describeNode` since both are node-introspection.

**`additions/juggler/protocol/PageHandler.js`**
- One-line dispatch from `Page.getEventListenersForNode` to the content-side handler, mirroring `Page.describeNode`.

**`additions/juggler/content/PageAgent.js`**
- Register `getEventListenersForNode` in the `browserChannel` method table.
- Implement `_getEventListenersForNode({objectId, frameId})` using `frame.unsafeObject(objectId)` (same pattern as `_describeNode` / `_getContentQuads`), then project each `nsIEventListenerInfo` into the wire shape.

The XPCOM service this wraps is stable since 2008 (bug 524674) and the patch is purely additive — no existing methods or types are touched.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Testing

Built Camoufox 146.0.1-beta.25 from source on Linux x86_64
(`make fetch && make setup && BUILD_TARGET=linux,x86_64 make build`,
exit 0 in ~28 min wall-clock).

Verified end-to-end against the patched binary using a small script
that drives Camoufox over `--juggler-pipe` (fd 3 / fd 4):

```
[ok] Browser.enable
[ok] context = a78fe1c0-3c73-438b-80aa-61a2dd6c4e64
[ok] target = bee1cb5e-1823-4ae3-8a71-9b0285db6b37
[ok] sessionId = 2697b2db-7cc9-41c5-be5b-b35434331b71
[ok] main frame = mainframe-9
[ok] navigated
[ok] executionContextId = id-4 (live set = {'id-4'})
[ok] objectId = id-5

>>> Page.getEventListenersForNode response:
[
  {
    "type": "click",
    "capturing": true,
    "allowsUntrusted": true,
    "inSystemEventGroup": false
  }
]

*** OK -- Page.getEventListenersForNode wire shape verified ***
```

The probe page registers a single capture-phase click listener on a button via `addEventListener('click', ..., true)`; the response carries that exact listener with the expected schema (all four `nsIEventListenerInfo` fields present, `capturing=true`).

## Fingerprint Report

Please submit a report from both the service tester and build tester.

<details>
<summary>Fingerprint report</summary>

I ran the in-tree `build-tester` against the patched binary (8 profiles, `--no-cert`):

```
Camoufox Build Tester
Binary:   /opt/camoufox-build/camoufox-146.0.1-beta.25/obj-x86_64-pc-linux-gnu/dist/bin/camoufox
Profiles: 8

────────────────────────────────────────────────────────────
Per-context phase: 6 profiles (all open simultaneously)
────────────────────────────────────────────────────────────
  ✓ macOS Per-Context A: [B] 123/124
  ✓ macOS Per-Context B: [B] 123/124
  ✓ macOS Per-Context C: [B] 123/124
  ✓ Linux Per-Context A: [B] 121/123
  ✓ Linux Per-Context B: [B] 121/123
  ✓ Linux Per-Context C: [B] 121/123

────────────────────────────────────────────────────────────
Global phase: separate browser per profile
────────────────────────────────────────────────────────────
  ✓ macOS Global: [B] 106/108
  ✓ Linux Global: [B] 106/107

══════════════════════════════════════════════════════════════
OVERALL: 944/956 checks passed  (8 profiles)
══════════════════════════════════════════════════════════════
```

Each profile gets a B grade individually. The patch touches zero stealth surfaces (Canvas/WebGL/fonts/navigator/etc) — it only adds a Juggler protocol method that surfaces the existing `nsIEventListenerService` — so there's no plausible mechanism for it to regress fingerprint isolation. The 12 failures appear to be baseline behavior on this build; happy to re-run side-by-side against an unpatched binary if helpful.

I haven't been able to upload the binary to https://camoufox-tester.vercel.app/ from this Linux dev box (its UI is interactive and expects a desktop browser session). If a `camoufox-tester` certificate is required, I can run that step on a desktop and amend.

</details>

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] I have included a fingerprint report from https://camoufox-tester.vercel.app/  *(included an in-tree `build-tester` report above instead — 944/956 checks pass, 8 profiles, B grade per profile. Happy to add the `camoufox-tester` certificate from a desktop session if you want it.)*
- [ ] Service tests pass (`bash service_tests/run_tests.sh`)  *(not run — service_tests requires real proxies; can run on request)*

<img width="800" height="376" alt="camoufox-verify-success" src="https://github.com/user-attachments/assets/8b7b8646-e508-4066-bb5e-960365a00afc" />
