### PR TITLE
fix(juggler): bug - exact-edge mousemoves hang, filepicker events not properly emitted

### DIFF
--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -537,7 +537,8 @@ export class PageHandler {
       this._pageTarget.ensureContextMenuClosed();
       // If someone asks us to dispatch mouse event outside of viewport, then we normally would drop it.
       const boundingBox = this._pageTarget._linkedBrowser.getBoundingClientRect();
-      if (x < 0 || y < 0 || x > boundingBox.width || y > boundingBox.height) {
+      // Treat exact-edge coordinates as out-of-viewport: a mousemove at x==width or y==height fires as an exit event instead of eMouseMove, so the hit-renderer signal never arrives and every later input event hangs behind it forever.
+      if (x < 0 || y < 0 || x >= boundingBox.width || y >= boundingBox.height) {
         if (type !== 'mousemove')
           return;
 

--- a/patches/playwright/0-playwright.patch
+++ b/patches/playwright/0-playwright.patch
@@ -1478,7 +1478,7 @@ index 31b29ac946..f8c6335c0a 100644
  #include "mozilla/dom/MouseEvent.h"
  #include "mozilla/dom/NumericInputTypes.h"
  #include "mozilla/dom/ProgressEvent.h"
-@@ -799,6 +800,13 @@ nsresult HTMLInputElement::InitColorPicker() {
+@@ -848,6 +848,13 @@ nsresult HTMLInputElement::InitFilePicker(FilePickerType aType) {
      return NS_ERROR_FAILURE;
    }
  


### PR DESCRIPTION
## Summary

Re-submission of #580, narrowed to a single commit so it can land on its own. Two small juggler fixes:

- **Filepicker event**: re-anchor the patch hunk so the filepicker emit lands in the right location relative to upstream `HTMLInputElement::InitFilePicker`. The previous offset put the hunk in the wrong function and the event wasn't being dispatched.
- **Edge mousemove hang**: in `PageHandler.dispatchMouseEvent`, treat coordinates exactly at the right/bottom edge (`x == width` or `y == height`) as out-of-viewport. At those exact coordinates Firefox fires `eMouseExitFromWidget` instead of `eMouseMove`, so the per-event `juggler-mouse-event-hit-renderer` observer notification never arrives and every later input event hangs behind it indefinitely.

Boundary check changes from `>` to `>=` for width/height, matching the half-open viewport convention.

#580 is being closed in favor of this one + a separate virtdisplay PR.

## Test plan

- [x] Trigger a file input in a Playwright/juggler script — `filechooser` event fires reliably
- [x] Drive a mousemove to coordinates exactly at the viewport edge — subsequent input events still complete instead of hanging

Verified fix In my own build - https://github.com/JWriter20/camoufox/releases/tag/v146.0.1-beta.25.2