### PR TITLE
fix(virtdisplay): atomic display claim + isolate per-launch DISPLAY env

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -539,7 +539,11 @@ def launch_options(
     if i_know_what_im_doing is None:
         i_know_what_im_doing = False
     if env is None:
-        env = cast(Dict[str, Union[str, float, bool]], environ)
+        # Copy os.environ rather than aliasing it. Concurrent calls (each
+        # with its own virtual_display) would otherwise race on the shared
+        # os.environ['DISPLAY'] mutation below and leak each other's DISPLAY
+        # into the wrong Firefox child.
+        env = cast(Dict[str, Union[str, float, bool]], dict(environ))
     if isinstance(executable_path, str):
         # Convert executable path to a Path object
         executable_path = Path(abspath(executable_path))

--- a/pythonlib/camoufox/virtdisplay.py
+++ b/pythonlib/camoufox/virtdisplay.py
@@ -1,8 +1,10 @@
+import glob
 import os
+import os.path
+import random
 import subprocess  # nosec
-from glob import glob
-from multiprocessing import Lock
-from random import randrange
+import tempfile
+import time
 from shutil import which
 from typing import List, Optional
 
@@ -13,20 +15,19 @@ from camoufox.exceptions import (
 )
 from camoufox.pkgman import OS_NAME
 
+# How long to wait for Xvfb to bind its X11 socket before giving up.
+SOCKET_READY_TIMEOUT_S = 10.0
+SOCKET_POLL_INTERVAL_S = 0.05
+
 
 class VirtualDisplay:
-    """
-    A minimal virtual display implementation for Linux.
-    """
+    """A minimal virtual display implementation for Linux."""
 
     def __init__(self, debug: Optional[bool] = False) -> None:
-        """
-        Constructor for the VirtualDisplay class (singleton object).
-        """
         self.debug = debug
         self.proc: Optional[subprocess.Popen] = None
         self._display: Optional[int] = None
-        self._lock = Lock()
+        self._claim_path_used: Optional[str] = None
 
     xvfb_args = (
         # fmt: off
@@ -48,9 +49,6 @@ class VirtualDisplay:
 
     @property
     def xvfb_path(self) -> str:
-        """
-        Get the path to the xvfb executable
-        """
         path = which("Xvfb")
         if not path:
             raise CannotFindXvfb("Please install Xvfb to use headless mode.")
@@ -58,89 +56,173 @@ class VirtualDisplay:
             raise CannotExecuteXvfb(f"I do not have permission to execute Xvfb: {path}")
         return path
 
-    @property
-    def xvfb_cmd(self) -> List[str]:
-        """
-        Get the xvfb command
-        """
-        return [self.xvfb_path, f':{self.display}', *self.xvfb_args]
+    def _xvfb_cmd(self, display: int) -> List[str]:
+        return [self.xvfb_path, f':{display}', *self.xvfb_args]
 
-    def execute_xvfb(self):
-        """
-        Spawn a detatched process
-        """
+    def _execute_xvfb(self, display: int) -> None:
+        cmd = self._xvfb_cmd(display)
         if self.debug:
-            print('Starting virtual display:', ' '.join(self.xvfb_cmd))
+            print('Starting virtual display:', ' '.join(cmd))
+        # Force Mesa software GLX to avoid the NVIDIA libGLvnd rwlock stall.
+        env = {
+            **os.environ,
+            "__GLX_VENDOR_LIBRARY_NAME": "mesa",
+            "LIBGL_ALWAYS_SOFTWARE": "1",
+        }
         self.proc = subprocess.Popen(  # nosec
-            self.xvfb_cmd,
+            cmd,
             stdout=None if self.debug else subprocess.DEVNULL,
             stderr=None if self.debug else subprocess.DEVNULL,
+            start_new_session=True,
+            env=env,
         )
 
     def get(self) -> str:
-        """
-        Get the display number
-        """
         self.assert_linux()
 
-        with self._lock:
-            if self.proc is None:
-                self.execute_xvfb()
-            elif self.debug:
-                print(f'Using virtual display: {self.display}')
-            return f':{self.display}'
+        if self.proc is None:
+            display = VirtualDisplay._claim_display()
+            self._display = display
+            self._claim_path_used = VirtualDisplay._claim_path(display)
+            self._execute_xvfb(display)
+            self._wait_for_socket(display)
+        elif self.debug:
+            print(f'Using virtual display: {self._display}')
 
-    def kill(self):
-        """
-        Terminate the xvfb process
-        """
-        with self._lock:
-            if self.proc and self.proc.poll() is None:
-                if self.debug:
-                    print('Terminating virtual display:', self.display)
-                self.proc.terminate()
+        return f':{self._display}'
+
+    def kill(self) -> None:
+        if self.proc and self.proc.poll() is None:
+            if self.debug:
+                print('Terminating virtual display:', self._display)
+            self.proc.terminate()
+        if self._claim_path_used:
+            try:
+                os.unlink(self._claim_path_used)
+            except FileNotFoundError:
+                pass
+            self._claim_path_used = None
 
     def __del__(self):
-        """
-        Kill and delete the VirtualDisplay object
-        """
         self.kill()
+
+    def _wait_for_socket(self, display: int) -> None:
+        """Poll for /tmp/.X11-unix/X<display>; Xvfb only creates it on a successful bind."""
+        tmpd = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        socket_path = os.path.join(tmpd, ".X11-unix", f"X{display}")
+        deadline = time.monotonic() + SOCKET_READY_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if self.proc is not None:
+                rc = self.proc.poll()
+                if rc is not None:
+                    raise CannotExecuteXvfb(
+                        f"Xvfb exited with code {rc} before binding display :{display}"
+                    )
+            if os.path.exists(socket_path):
+                return
+            time.sleep(SOCKET_POLL_INTERVAL_S)
+        raise CannotExecuteXvfb(
+            f"Xvfb did not bind display :{display} within {int(SOCKET_READY_TIMEOUT_S * 1000)}ms"
+        )
 
     @staticmethod
     def _get_lock_files() -> List[str]:
-        """
-        Get list of lock files in /tmp
-        """
-        tmpd = os.environ.get('TMPDIR', '/tmp')  # nosec
+        """Lock files Xvfb creates: /tmp/.X<N>-lock."""
+        tmpd = os.environ.get("TMPDIR") or tempfile.gettempdir()
         try:
-            lock_files = glob(os.path.join(tmpd, ".X*-lock"))
-        except FileNotFoundError:
+            return [
+                p for p in glob.glob(os.path.join(tmpd, ".X*-lock"))
+                if os.path.isfile(p)
+            ]
+        except OSError:
             return []
-        return [p for p in lock_files if os.path.isfile(p)]
 
     @staticmethod
-    def _free_display() -> int:
-        """
-        Search for free display
-        """
-        ls = list(
-            map(lambda x: int(x.split("X")[1].split("-")[0]), VirtualDisplay._get_lock_files())
-        )
-        return max(99, max(ls) + randrange(3, 20)) if ls else 99  # nosec
+    def _claim_path(display: int) -> str:
+        """Camoufox-private claim file path; distinct from Xvfb's .X<N>-lock."""
+        tmpd = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        return os.path.join(tmpd, f".camoufox-X{display}.claim")
 
-    @property
-    def display(self) -> int:
-        """
-        Get the display number
-        """
-        if self._display is None:
-            self._display = self._free_display()
-        return self._display
+    # Grace period before treating an unreadable/empty claim as stale. There
+    # is a brief window after O_EXCL|O_CREAT but before the owner writes its
+    # PID; without this, a concurrent sweep would unlink a live claim.
+    _CLAIM_GRACE_SECONDS = 5.0
+
+    @staticmethod
+    def _sweep_stale_claims() -> None:
+        """Remove claim files whose owning PID is no longer alive."""
+        tmpd = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        now = time.time()
+        for path in glob.glob(os.path.join(tmpd, ".camoufox-X*.claim")):
+            try:
+                with open(path, "r") as f:
+                    raw = f.read().strip()
+                pid = int(raw)
+            except FileNotFoundError:
+                continue
+            except (OSError, ValueError):
+                # Unreadable or malformed. Could be a claim mid-creation by
+                # another process; only sweep if it has been like this for
+                # longer than the grace period.
+                try:
+                    age = now - os.path.getmtime(path)
+                except OSError:
+                    continue
+                if age > VirtualDisplay._CLAIM_GRACE_SECONDS:
+                    try:
+                        os.unlink(path)
+                    except OSError:
+                        pass
+                continue
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+            except PermissionError:
+                # PID exists but is owned by another user; leave it alone.
+                pass
+
+    @staticmethod
+    def _claim_display() -> int:
+        """Atomically reserve a display number across concurrent camoufox processes."""
+        VirtualDisplay._sweep_stale_claims()
+
+        ls: List[int] = []
+        for x in VirtualDisplay._get_lock_files():
+            try:
+                ls.append(int(os.path.basename(x).split("X")[1].split("-")[0]))
+            except (IndexError, ValueError):
+                continue
+        baseline = max([99, *ls]) if ls else 99
+        tmpd = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        pid_bytes = f"{os.getpid()}\n".encode("ascii")
+
+        for attempt in range(50):
+            candidate = baseline + random.randint(3, 19) + attempt  # nosec
+            # Skip if Xvfb already holds this display.
+            if os.path.exists(os.path.join(tmpd, f".X{candidate}-lock")):
+                continue
+            claim_path = VirtualDisplay._claim_path(candidate)
+            try:
+                fd = os.open(
+                    claim_path,
+                    os.O_EXCL | os.O_CREAT | os.O_WRONLY,
+                    0o644,
+                )
+            except FileExistsError:
+                continue
+            try:
+                os.write(fd, pid_bytes)
+            finally:
+                os.close(fd)
+            return candidate
+
+        raise CannotExecuteXvfb("Could not reserve a free X11 display after 50 attempts")
 
     @staticmethod
     def assert_linux():
-        """
-        Assert that the current OS is Linux
-        """
         if OS_NAME != 'lin':
             raise VirtualDisplayNotSupported("Virtual display is only supported on Linux.")


### PR DESCRIPTION
## Summary

Two related bugs broke `Camoufox(headless="virtual")` under parallel use in a single Python process:

1. **TOCTOU race in display claim.** `VirtualDisplay` previously scanned `/tmp/.X*-lock` to pick a "free" display number, then invoked Xvfb on `max(existing) + randint(3, 19)`. Two workers could read the same lock-file set, pick the same hint, and both invoke Xvfb on the same display. The losing Xvfb's `bind()` failed with "Server is already active", that worker silently ended up sharing the winner's Xvfb (or had no display at all).

2. **Shared `os.environ` mutation in the launch path.** `utils.py`'s launch helper aliased `env = os.environ` when no env was passed, then did `env['DISPLAY'] = virtual_display`. With multiple `Camoufox(headless="virtual")` calls running concurrently in one process, the last writer won — Firefox children inherited whatever `DISPLAY` happened to be live at the moment Playwright spawned them, causing some workers' browsers to die at startup pointing at another worker's Xvfb (or no Xvfb).

Both bugs are needed to make parallel launches reliable; either alone leaves a hole.

## Changes

### virtdisplay.py — atomic claim

Reserve the display number **before** spawning Xvfb, using a camoufox-private claim file that Xvfb itself never sees:

1. Compute a baseline above any existing `.X<N>-lock`.
2. For each candidate, skip if `.X<N>-lock` already exists.
3. `O_CREAT | O_EXCL` on `/tmp/.camoufox-X<N>.claim`. First-to-create wins; concurrent callers get `FileExistsError` and try the next number. Up to 50 attempts before raising `CannotExecuteXvfb`.
4. Write the owning PID into the claim file.
5. Spawn Xvfb on the reserved display.
6. Poll `/tmp/.X11-unix/X<N>` (the socket Xvfb only creates on a successful `bind()`) for up to 10s; raise `CannotExecuteXvfb` on timeout or early Xvfb exit.
7. On `kill()`, terminate Xvfb and unlink the claim file.

The claim file is intentionally separate from Xvfb's `.X<N>-lock` so Xvfb's own lock semantics (stale-PID detection, ownership, X.Org format) are untouched.

### virtdisplay.py — stale-claim recovery

If a camoufox process crashes before `kill()` runs, its claim file would leak and that display number would be permanently blocked. Every `_claim_display()` call sweeps `/tmp/.camoufox-X*.claim` first:

- Read the PID from each claim file. `kill(pid, 0)` raising `ProcessLookupError` → owner is dead → unlink.
- Unreadable / malformed claim files (which can briefly appear during the window between `O_CREAT` and the PID being written) are tolerated for a 5-second grace period before being treated as stale, so a concurrent sweep cannot unlink a live in-progress claim.
- Claim files whose PID is owned by another user (`PermissionError`) are left alone.

### utils.py — copy `os.environ` instead of aliasing

`launch_options(...)` now does `env = dict(environ)` instead of `env = environ`, so per-call `env['DISPLAY'] = virtual_display` writes don't leak across concurrent launches in the same process.

### virtdisplay.py — force Mesa software GLX on Xvfb

While here: set `__GLX_VENDOR_LIBRARY_NAME=mesa` and `LIBGL_ALWAYS_SOFTWARE=1` in Xvfb's spawn env. On hosts with NVIDIA drivers installed, libGLvnd loads NVIDIA's GLX provider, which acquires a global rwlock during GL init that can stall Xvfb startup for several seconds under concurrent GPU contention. Xvfb on `1x1x24` never renders anything GPU-accelerated, so software GLX is strictly an improvement.

## Why not `-displayfd`

An earlier revision used Xvfb's own `-displayfd` (let Xvfb's kernel-side `bind()` race auto-increment past collisions, read the chosen number on a pipe). It worked but had two drawbacks:

1. Every spawn paid Xvfb startup cost even on collision (Xvfb forks, retries internally, then reports).
2. The pipe-read with timeout adds startup-path failure modes (EOF, timeout, unparseable output) that need handling and made hangs harder to diagnose.

The claim-file approach resolves contention before `fork()`, so a colliding worker just retries an `os.open()` instead of waiting on a Xvfb spawn.

## Testing

Verified locally on Linux with Xvfb 21.1.11 on a host with NVIDIA drivers (where the latent libGLvnd issue exists). Test suite covers:

**virtdisplay claim correctness**

- 16 threads claiming displays simultaneously → 16 unique displays, 0 errors
- 16 processes claiming displays simultaneously → 16 unique displays, 0 errors
- 8 real Xvfb instances spawned in parallel (0.89s) → 8 distinct live displays, all responsive to `xdpyinfo`
- Single-display lifecycle → spawn, `xdpyinfo` confirms X.Org responding, `kill()` removes both the X11 socket and the claim file

**Stale-claim recovery (5 sub-cases)**

- Claim file with a dead PID is unlinked by the sweep
- Claim file with a live PID is preserved
- Subprocess claims a display, "crashes" without cleanup; next sweep reclaims the slot
- Malformed claim file is preserved within the 5s grace window, removed after
- Normal claim contains the owning PID and is removed by `kill()`

**End-to-end parallel `Camoufox(headless="virtual")`**

Before the env fix: ~25-30% of workers in N=4 batches failed with `Target page closed` / `BrowserType.launch failed` because their Firefox children inherited another worker's `DISPLAY`.

After the fix:

- 8 rounds × N=4 → 32/32 success
- N=8 → 8/8 success in 7.4s
- N=12 → 12/12 success in 8.5s