### PR TITLE
Fix concurrent newPage() hangs

### DIFF
--- a/additions/juggler/TargetRegistry.js
+++ b/additions/juggler/TargetRegistry.js
@@ -21,8 +21,6 @@ const ALL_PERMISSIONS = [
 ];
 
 let globalTabAndWindowActivationChain = Promise.resolve();
-// This is a workaround for https://github.com/microsoft/playwright/issues/34586
-let didCreateFirstPage = false;
 let globalNewPageChain = Promise.resolve();
 
 class DownloadInterceptor {
@@ -310,10 +308,6 @@ export class TargetRegistry {
   }
 
   async newPage({browserContextId}) {
-    // When creating the very first page, we cannot create multiple in parallel.
-    // See https://github.com/microsoft/playwright/issues/34586.
-    if (didCreateFirstPage)
-      return this._newPageInternal({browserContextId});
     const result = globalNewPageChain.then(() => this._newPageInternal({browserContextId}));
     globalNewPageChain = result.catch(error => { /* swallow errors to keep chain running */ });
     return result;
@@ -368,7 +362,6 @@ export class TargetRegistry {
       if (await target.hasFailedToOverrideTimezone())
         throw new Error('Failed to override timezone');
     }
-    didCreateFirstPage = true;
     return target.id();
   }
 


### PR DESCRIPTION
## Related Issue                                                                                                                                                                                                                                                            
                                                                  
  Closes #279                             

  ## Summary                                                                                                                                                                                                                                                                  
  
  [microsoft/playwright#34586](https://github.com/microsoft/playwright/issues/34586) was fixed upstream. The local `didCreateFirstPage` workaround in `TargetRegistry.newPage()` is no longer  needed — and is itself the cause of #279.
Promise-chain serialization was protecting against a Firefox race but the didCreateFirstPage bypass dropped that protection for non-first pages.

  ## Type of Change                                               
                                                                                                                                                                                                                                                                              
  - [x] Bug fix
  - [ ] New feature                                                                                                                                                                                                                                                           
  - [ ] Documentation update                                      
  - [ ] Other                             

  ## Testing                                                                                                                                                                                                                                                                  
  
  Reproduced on Camoufox 146.0.1 with this minimal repro — opens 5 pages in parallel on the same context. On `main` this intermittently hangs (one or more `new_page()` calls never resolve); with the patch it completes cleanly:                                            
                                                                  
  ```python
  import asyncio                                                                                                                                                                                                                                                              
  from camoufox.async_api import AsyncCamoufox
                                                                                                                                                                                                                                                                              
  async def main():                                               
      async with AsyncCamoufox(headless=True) as browser:
          ctx = await browser.new_context()                                                                                                                                                                                                                                   
          await asyncio.wait_for(             
              asyncio.gather(*(ctx.new_page() for _ in range(5))),                                                                                                                                                                                                            
              timeout=30,                                         
          )                                                                                                                                                                                                                                                                   
  
  asyncio.run(main())                                                                                                                                                                                                                                                         
  ```   

  ## Fingerprint Report                       
                                                                                                                                                                                                                                                                              
  N/A — change is in juggler protocol handling (`TargetRegistry.newPage`); no fingerprint surface affected.
                                                                                                                                                                                                                                                                              
  <details>                                                       
  <summary>Fingerprint report</summary>                                                                                                                                                                                                                                       
                                                                  
  (no fingerprint surface touched)                                                                                                                                                                                                                                            
                                                                  
  </details>
                                                                                                                                                                                                                                                                              
  ## Checklist
                                                                                                                                                                                                                                                                              
  - [x] I have linked a related issue above                       
  - [x] My changes are focused on a single logical change
  - [x] I have added testing instructions which include the desired result
  - [ ] ~~Service tests pass~~ — temporarily out of service per template
  - [ ] Build test passes — happy to run `./build-tester/run_tests.sh` if a maintainer wants confirmation; the change doesn't touch any fingerprint surface so I expect no movement in the score
                                                                                                                                                                                                    
