### PR TITLE
Hide navigator.webdriver via [Pref] gate in WebIDL  

### DIFF
--- a/patches/playwright/1-leak-fixes.patch
+++ b/patches/playwright/1-leak-fixes.patch
@@ -1,9 +1,39 @@
+diff --git a/modules/libpref/init/StaticPrefList.yaml b/modules/libpref/init/StaticPrefList.yaml
+--- a/modules/libpref/init/StaticPrefList.yaml
++++ b/modules/libpref/init/StaticPrefList.yaml
+@@ -5487,6 +5487,13 @@
+ #endif
+   mirror: always
+
++# Hide navigator.webdriver attribute when false (Camoufox: anti-fingerprinting,
++# referenced via [Pref] in dom/webidl/Navigator.webidl).
++- name: dom.webdriver.enabled
++  type: bool
++  value: false
++  mirror: always
++
+ # Is support for the Web Audio API enabled?
+ - name: dom.webaudio.enabled
+   type: bool
+
+diff --git a/dom/webidl/Navigator.webidl b/dom/webidl/Navigator.webidl
+--- a/dom/webidl/Navigator.webidl
++++ b/dom/webidl/Navigator.webidl
+@@ -310,7 +310,7 @@
+
+ // https://w3c.github.io/webdriver/webdriver-spec.html#interface
+ interface mixin NavigatorAutomationInformation {
+-  [Constant, Cached]
++  [Constant, Cached, Pref="dom.webdriver.enabled"]
+   readonly attribute boolean webdriver;
+ };
+
 diff --git a/dom/base/Navigator.cpp b/dom/base/Navigator.cpp
 index 9880047350..318d2edba8 100644
 --- a/dom/base/Navigator.cpp
 +++ b/dom/base/Navigator.cpp
 @@ -2316,28 +2316,7 @@ dom::PrivateAttribution* Navigator::PrivateAttribution() {
- 
+
  /* static */
  bool Navigator::Webdriver() {
 -#ifdef ENABLE_WEBDRIVER


### PR DESCRIPTION
                                                                                                                                                                                                                                                                     
  ## Summary
                                                                                                                                                                                                                                                                              
  `patches/playwright/1-leak-fixes.patch` already drops `Navigator::Webdriver()` to `return false` at the C++ level — but the `webdriver` attribute on `Navigator` is still **exposed** by WebIDL. Anti-bot platforms like FingerprintJS, DataDome and PerimeterX check the   *presence* of `navigator.webdriver`
                                                                                                                                                                                                                                                                              
  ## Description                                                                                                                                                                                                                                                              
  
  Two new hunks added to `1-leak-fixes.patch`:                                                                                                                                                                                                                                
                                                                  
  1. **`modules/libpref/init/StaticPrefList.yaml`** — declare a new static pref `dom.webdriver.enabled` (default `false`). Required because WebIDL `[Pref="x.y.z"]` resolves at build time to `mozilla::StaticPrefs::x_y_z`;                                                                                                                                                                        
  
  2. **`dom/webidl/Navigator.webidl`** — add `Pref="dom.webdriver.enabled"` to the existing `[Constant, Cached]` extended-attribute bracket on the `webdriver` attribute. When the pref is `false`, the WebIDL binding code generator omits the attribute from the prototype entirely; `'webdriver' in navigator` returns `false`, matching vanilla Firefox.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                             ## Type of Change                                               
                                                                                                                                                                                                                                                                              
  - [x] Bug fix                                                   
  - [ ] New feature                       
  - [ ] Documentation update
  - [ ] Other                                                                                                                                                                                                                                                                 
                                              
  ## Testing                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                 
  Quick local repro:                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                              
  ```python                                                                                                                                                                                                                                                                   
  import asyncio                                                                                                                                                                                                                                                              
  from camoufox.async_api import AsyncCamoufox                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                              
  async def main():
      async with AsyncCamoufox(headless=True) as browser:                                                                                                                                                                                                                     
          page = await browser.new_page()                         
          await page.goto("about:blank")  
          present = await page.evaluate("'webdriver' in navigator")
          value   = await page.evaluate("navigator.webdriver")                                                                                                                                                                                                                
          print(f"  'webdriver' in navigator = {present}")
          print(f"  navigator.webdriver       = {value}")                                                                                                                                                                                                                     
                                                                  
  asyncio.run(main())                                                                                                                                                                                                                                                         
  ```                                                             
                                                            
  ## Fingerprint Report                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                              
  This PR specifically targets a fingerprint surface (`navigator.webdriver` exposure). Build-tester run pending — happy to attach if a maintainer requests it. Expected delta on the score: positive (one fewer detectable signal).                                           
                                                                                                                                                                                                                                                                              
  <details>                                                       
  <summary>Fingerprint report</summary>                                                                                                                                                                                                                                       
                                                                  
  (to be attached after build-tester run; happy to coordinate)                                                                                                                                                                                                                
                                                                  
  </details>
                                                                                                                                                                                                                                                                              
  ## Checklist                                
                                                                                                                                                                                                                                                                              
  - [ ] I have linked a related issue above — none open; happy to file one if preferred
  - [x] My changes are focused on a single logical change                                                                                                                                                                                                                     
  - [x] I have added testing instructions which include the desired result
  - [ ] ~~Service tests pass~~ — temporarily out of service per template                                                                                                                                                                                                      
  - [ ] Build test passes — pending; this PR adds a new static pref so the build *must* recompile WebIDLPrefs.cpp; would appreciate a maintainer's confirmation that the score improves