### PR TITLE
feat: add persistent fingerprint seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,26 @@ async with AsyncCamoufox() as browser:
 
 [[Installation & usage](https://camoufox.com/python/)]
 
+### Persistent Fingerprint Seeds
+
+Pass `fingerprint_seed` when you want the same generated identity to be reused
+across launches or contexts. The seed controls Camoufox-generated fingerprint
+values such as BrowserForge sampling, font and voice subsets, WebGL sampling,
+and audio/canvas/font noise seeds. It does not persist cookies, storage, or
+browser profile state.
+
+```python
+from camoufox.sync_api import Camoufox, NewContext
+
+with Camoufox(fingerprint_seed="account-123") as browser:
+    page = browser.new_page()
+    page.goto("https://example.com")
+
+    context = NewContext(browser, fingerprint_seed="account-123:context-2")
+    page = context.new_page()
+    page.goto("https://example.com")
+```
+
 ### Making Full use of Hardware Spoofing
 
 For stable releases, you should always use the main [`camoufox`](https://pypi.org/project/camoufox/) pip package. However, if you want to make use of per-context fingerprints and hardware spoofing, use the [`cloverlabs-camoufox`](https://pypi.org/project/cloverlabs-camoufox/) package. This package is updated with each releases, whereas the official package is released on delay.
@@ -322,6 +342,7 @@ Below is a list of patches and features implemented in Camoufox.
 
 - Automatically generates & injects unique device characteristics into Camoufox based on their real-world distribution
 - WebGL fingerprint injection & rotation
+- Optional persistent fingerprint seeds for stable generated identities
 - Uses the correct system fonts and subpixel antialiasing & hinting based on your target OS
 - Avoid proxy detection by calculating your target geolocation, timezone, & locale from your proxy's target region
 - Calculate and spoof the browser's language based on the distribution of language speakers in the proxy's target region

--- a/README.md
+++ b/README.md
@@ -229,8 +229,10 @@ async with AsyncCamoufox() as browser:
 Pass `fingerprint_seed` when you want the same generated identity to be reused
 across launches or contexts. The seed controls Camoufox-generated fingerprint
 values such as BrowserForge sampling, font and voice subsets, WebGL sampling,
-and audio/canvas/font noise seeds. It does not persist cookies, storage, or
-browser profile state.
+and audio/canvas/font config seeds. Launch-level seeds cover the full generated
+`CAMOU_CONFIG`; context-level seeds apply the supported per-context surfaces for
+new browser contexts. It does not persist cookies, storage, or browser profile
+state.
 
 ```python
 from camoufox.sync_api import Camoufox, NewContext

--- a/README.md
+++ b/README.md
@@ -244,6 +244,25 @@ with Camoufox(fingerprint_seed="account-123") as browser:
     page.goto("https://example.com")
 ```
 
+To persist cookies, local storage, and browser profile state, use a persistent
+context with a stable `user_data_dir` alongside the same `fingerprint_seed`:
+
+```python
+from pathlib import Path
+
+from camoufox.sync_api import Camoufox
+
+profile_dir = Path("profiles/account-123")
+
+with Camoufox(
+    persistent_context=True,
+    user_data_dir=profile_dir,
+    fingerprint_seed="account-123",
+) as context:
+    page = context.new_page()
+    page.goto("https://example.com")
+```
+
 ### Making Full use of Hardware Spoofing
 
 For stable releases, you should always use the main [`camoufox`](https://pypi.org/project/camoufox/) pip package. However, if you want to make use of per-context fingerprints and hardware spoofing, use the [`cloverlabs-camoufox`](https://pypi.org/project/cloverlabs-camoufox/) package. This package is updated with each releases, whereas the official package is released on delay.

--- a/docs/per-context-patches.md
+++ b/docs/per-context-patches.md
@@ -640,6 +640,24 @@ with Camoufox(fingerprint_seed="account-123") as browser:
 The seed only controls generated fingerprint values. It does not persist
 cookies, local storage, cache, or Playwright browser profile state.
 
+Persistent browser state should be handled separately with Playwright's
+persistent context support. Reuse the same `fingerprint_seed` and the same
+`user_data_dir` when cookies/storage should remain tied to the same generated
+identity:
+
+```python
+from pathlib import Path
+
+from camoufox.sync_api import Camoufox
+
+with Camoufox(
+    persistent_context=True,
+    user_data_dir=Path("profiles/account-123"),
+    fingerprint_seed="account-123",
+) as context:
+    ...
+```
+
 ### What Each Path Sets
 
 | Property | Source | Notes |

--- a/docs/per-context-patches.md
+++ b/docs/per-context-patches.md
@@ -614,7 +614,7 @@ bundle/
 
 ## Python Library Changes
 
-The Camoufox Python package (`pythonlib/`) generates fingerprints for both `NewBrowser` (global CAMOU_CONFIG) and `NewContext` (per-context init script). **BrowserForge is the default for both paths.** Real fingerprint presets are available as an opt-in alternative.
+The Camoufox Python package (`pythonlib/`) generates fingerprints for both `NewBrowser` (global CAMOU_CONFIG) and `NewContext` (per-context init script). **BrowserForge is the default for both paths.** Real fingerprint presets are available as an opt-in alternative. Both paths can also take `fingerprint_seed` to reuse the same Camoufox-generated identity values across runs.
 
 ### Fingerprint Source Priority
 
@@ -623,19 +623,36 @@ The Camoufox Python package (`pythonlib/`) generates fingerprints for both `NewB
 | **NewBrowser** (`launch_options()` in `utils.py`) | BrowserForge synthetic | Pass `fingerprint_preset=True` or a preset dict |
 | **NewContext** (`generate_context_fingerprint()` in `fingerprints.py`) | BrowserForge synthetic | Pass `preset=dict` explicitly |
 
+### Persistent Fingerprint Seeds
+
+`fingerprint_seed` accepts `str`, `int`, or `bytes`. It derives independent
+sub-seeds for each random fingerprint domain so one stable seed can reproduce
+the same identity while keeping BrowserForge, WebGL, font, voice, audio, canvas,
+and screen-offset sampling separate.
+
+```python
+from camoufox.sync_api import Camoufox, NewContext
+
+with Camoufox(fingerprint_seed="account-123") as browser:
+    context = NewContext(browser, fingerprint_seed="account-123:context-2")
+```
+
+The seed only controls generated fingerprint values. It does not persist
+cookies, local storage, cache, or Playwright browser profile state.
+
 ### What Each Path Sets
 
 | Property | Source | Notes |
 |----------|--------|-------|
 | UA, platform, HWC, oscpu | BrowserForge or preset | UA version patched to match Camoufox Firefox version |
 | Screen dims, colorDepth | BrowserForge or preset | Viewport adjusted by -28px for browser chrome |
-| WebGL vendor/renderer | `sample_webgl()` from `webgl_data.db` | OS-weighted probability sampling. BrowserForge does NOT generate WebGL (commented out in `browserforge.yml`). Both paths call `sample_webgl()` when WebGL values are missing. |
-| Font list | `_generate_random_font_subset()` | Random 30-78% of OS fonts. Essential + marker fonts always included. NOT from presets — generated fresh per call. |
-| Font spacing seed | `randint(1, 2^32-1)` | Excludes 0 (0 = no-op in C++) |
-| Audio seed | `randint(1, 2^32-1)` | Excludes 0 |
-| Canvas seed | `randint(1, 2^32-1)` | Excludes 0 |
+| WebGL vendor/renderer | Preset values or `sample_webgl()` from `webgl_data.db` | BrowserForge does NOT generate WebGL (commented out in `browserforge.yml`). Synthetic paths use OS-weighted probability sampling, deterministic when `fingerprint_seed` is supplied. Preset paths use preset WebGL values when present. |
+| Font list | `_generate_random_font_subset()` | Random 30-78% of OS fonts, or deterministic when `fingerprint_seed` is supplied. Essential + marker fonts always included. Normally generated fresh per call unless seeded; preset fonts are only used as a fallback if OS font generation fails. |
+| Font spacing seed | Random uint32, or derived from `fingerprint_seed` | Excludes 0 (0 = no-op in C++) |
+| Audio seed | Random uint32, or derived from `fingerprint_seed` | Excludes 0 |
+| Canvas seed | Random uint32, or derived from `fingerprint_seed` | Excludes 0 |
 | Timezone | From preset, or Intl.DateTimeFormat fallback in init script | NewBrowser: from preset or geolocation detection. NewContext: preset or browser default. |
-| Speech voices | `_generate_random_voice_subset()` | Random 40-80% of OS voices. Essential voices always included. macOS: 6 essentials + random subset of ~184. Windows: all voices (too few to subset). Linux: empty (no native voices). NOT from presets — generated fresh per call. |
+| Speech voices | `_generate_random_voice_subset()` | Random 40-80% of OS voices, or deterministic when `fingerprint_seed` is supplied. Essential voices always included. macOS: 6 essentials + random subset of ~184. Windows: all voices (too few to subset). Linux: empty (no native voices). Normally generated fresh per call unless seeded; preset voices are only used as a fallback if OS voice generation fails. |
 | WebRTC IP | Not set by default | User sets via `window.setWebRTCIPv4()`. NewContext init script defaults to empty string `""` |
 | Geolocation | User parameter or geoip detection | Via Playwright `context.setGeolocation()` |
 
@@ -643,20 +660,22 @@ The Camoufox Python package (`pythonlib/`) generates fingerprints for both `NewB
 
 **`fingerprints.py`** — Per-context fingerprint generation:
 - `generate_context_fingerprint()` — main API. Returns `{init_script, context_options, config, preset}`
+- `fingerprint_seed.py` — derives independent deterministic sub-seeds for BrowserForge, WebGL, fonts, voices, and noise seeds
 - `from_preset()` — converts real preset to CAMOU_CONFIG format
 - `from_browserforge()` — converts BrowserForge Fingerprint to CAMOU_CONFIG using `browserforge.yml` mappings
 - `_build_init_script()` — generates JavaScript IIFE calling 15 `window.setXxx()` functions with `typeof` guards (`setWebRTCIPv6` is not included — IPv6 is optional and rarely set)
-- `_generate_random_font_subset()` — unique random font subset per call (Fisher-Yates, essential + marker fonts always included)
-- `_generate_random_voice_subset()` — unique random voice subset per call (essential voices always included, OS-aware)
+- `_generate_random_font_subset()` — random by default, deterministic when passed a seeded RNG (essential + marker fonts always included)
+- `_generate_random_voice_subset()` — random by default, deterministic when passed a seeded RNG (essential voices always included, OS-aware)
 
 **`utils.py`** — Global browser launch configuration:
 - `launch_options()` — builds CAMOU_CONFIG env var, Playwright args, and Firefox prefs
+- `fingerprint_seed` — optional stable seed for launch-level BrowserForge, preset, font, voice, WebGL, history, and noise generation
 - Font subset generated via same `_generate_random_font_subset()` function
 - Voice subset generated via same `_generate_random_voice_subset()` function
 - WebGL sampled via same `sample_webgl()` function
 - Config validated against `properties.json` before serialization
 
-**`fingerprint-presets.json`** — Bundled real fingerprints organized by OS (macOS, Windows, Linux). Each preset includes navigator properties, screen dimensions, WebGL params, speech voices, and timezone. Font and voice data not used from presets — generated fresh per launch.
+**`fingerprint-presets.json`** — Bundled real fingerprints organized by OS (macOS, Windows, Linux). Each preset includes navigator properties, screen dimensions, WebGL params, speech voices, and timezone. Fonts and voices are normally generated from OS lists, deterministic when seeded, and preset values are fallback-only if OS generation fails.
 
 **`fonts.json`** — Complete OS-specific font lists for random font subset generation.
 

--- a/docs/per-context-patches.md
+++ b/docs/per-context-patches.md
@@ -627,8 +627,9 @@ The Camoufox Python package (`pythonlib/`) generates fingerprints for both `NewB
 
 `fingerprint_seed` accepts `str`, `int`, or `bytes`. It derives independent
 sub-seeds for each random fingerprint domain so one stable seed can reproduce
-the same identity while keeping BrowserForge, WebGL, font, voice, audio, canvas,
-and screen-offset sampling separate.
+the same generated launch identity while keeping BrowserForge, WebGL, font,
+voice, audio, canvas, and screen-offset sampling separate. Context-level seeds
+apply the supported per-context surfaces for new browser contexts.
 
 ```python
 from camoufox.sync_api import Camoufox, NewContext
@@ -681,7 +682,7 @@ with Camoufox(
 - `fingerprint_seed.py` — derives independent deterministic sub-seeds for BrowserForge, WebGL, fonts, voices, and noise seeds
 - `from_preset()` — converts real preset to CAMOU_CONFIG format
 - `from_browserforge()` — converts BrowserForge Fingerprint to CAMOU_CONFIG using `browserforge.yml` mappings
-- `_build_init_script()` — generates JavaScript IIFE calling 15 `window.setXxx()` functions with `typeof` guards (`setWebRTCIPv6` is not included — IPv6 is optional and rarely set)
+- `_build_init_script()` — generates JavaScript IIFE calling supported `window.setXxx()` functions with `typeof` guards (`setWebRTCIPv6` is not included — IPv6 is optional and rarely set)
 - `_generate_random_font_subset()` — random by default, deterministic when passed a seeded RNG (essential + marker fonts always included)
 - `_generate_random_voice_subset()` — random by default, deterministic when passed a seeded RNG (essential voices always included, OS-aware)
 
@@ -699,7 +700,7 @@ with Camoufox(
 
 **`voices.json`** — Complete OS-specific speech voice lists for random voice subset generation. macOS: 190 voices, Windows: 53 voices, Linux: empty. Format: `"Name:locale:type"` — names extracted at load time.
 
-**`properties.json`** — Includes `audio:seed` and `canvas:seed` as `CAMOU_CONFIG` properties (uint type). These enable the MaskConfig fallback in the audio and canvas patches when using global config without per-context JavaScript.
+**`properties.json`** — Includes `audio:seed` and `canvas:seed` as `CAMOU_CONFIG` properties (uint type). These values are generated deterministically when `fingerprint_seed` is supplied; context-level JavaScript only calls setters that the current browser exposes.
 
 **`camoufox.cfg`** — Sets `fission.autostart=true` and `dom.ipc.processPrelaunch.enabled=false`. No `dom.ipc.processCount` override needed with cross-process storage.
 

--- a/pythonlib/README.md
+++ b/pythonlib/README.md
@@ -39,8 +39,10 @@ with Camoufox(fingerprint_seed="account-123") as browser:
 ```
 
 The seed controls generated identity values such as BrowserForge sampling,
-font and voice subsets, WebGL sampling, and audio/canvas/font noise seeds. It
-does not persist cookies, storage, cache, or profile state.
+font and voice subsets, WebGL sampling, and audio/canvas/font config seeds.
+Launch-level seeds cover the full generated `CAMOU_CONFIG`; context-level seeds
+apply the supported per-context surfaces for new browser contexts. It does not
+persist cookies, storage, cache, or profile state.
 
 To keep browser state tied to the same generated identity, reuse the same
 `fingerprint_seed` and the same `user_data_dir` with a persistent context:

--- a/pythonlib/README.md
+++ b/pythonlib/README.md
@@ -21,6 +21,46 @@ In addition, it will also calculate your target geolocation, timezone, and local
 
 ---
 
+## Persistent Fingerprint Seeds
+
+Pass `fingerprint_seed` when you want Camoufox to reproduce the same generated
+fingerprint values across launches or contexts:
+
+```python
+from camoufox.sync_api import Camoufox, NewContext
+
+with Camoufox(fingerprint_seed="account-123") as browser:
+    page = browser.new_page()
+    page.goto("https://example.com")
+
+    context = NewContext(browser, fingerprint_seed="account-123:context-2")
+    page = context.new_page()
+    page.goto("https://example.com")
+```
+
+The seed controls generated identity values such as BrowserForge sampling,
+font and voice subsets, WebGL sampling, and audio/canvas/font noise seeds. It
+does not persist cookies, storage, cache, or profile state.
+
+To keep browser state tied to the same generated identity, reuse the same
+`fingerprint_seed` and the same `user_data_dir` with a persistent context:
+
+```python
+from pathlib import Path
+
+from camoufox.sync_api import Camoufox
+
+with Camoufox(
+    persistent_context=True,
+    user_data_dir=Path("profiles/account-123"),
+    fingerprint_seed="account-123",
+) as context:
+    page = context.new_page()
+    page.goto("https://example.com")
+```
+
+---
+
 ## Installation
 
 First, install the `camoufox` package:

--- a/pythonlib/camoufox/async_api.py
+++ b/pythonlib/camoufox/async_api.py
@@ -147,10 +147,10 @@ async def AsyncNewContext(
     """
     Creates a new browser context with a unique fingerprint identity.
 
-    By default, each context gets a BrowserForge synthetic fingerprint with
-    unique audio, canvas, font spacing, font, voice, and WebGL values. Pass a
-    preset dict to use a real bundled fingerprint instead. Values are applied
-    via addInitScript so they self-destruct before page scripts can detect them.
+    By default, each context gets a BrowserForge synthetic fingerprint. Supported
+    per-context values are applied via addInitScript so they self-destruct before
+    page scripts can detect them. Pass a preset dict to use a real bundled
+    fingerprint instead.
 
     Parameters:
         browser: A Browser instance from AsyncNewBrowser or AsyncCamoufox.

--- a/pythonlib/camoufox/async_api.py
+++ b/pythonlib/camoufox/async_api.py
@@ -15,6 +15,7 @@ from typing_extensions import Literal
 
 from camoufox.virtdisplay import VirtualDisplay
 
+from .fingerprint_seed import FingerprintSeed
 from .fingerprints import generate_context_fingerprint
 from .utils import async_attach_vd, launch_options
 
@@ -138,6 +139,7 @@ async def AsyncNewContext(
     os: Optional[str] = None,
     ff_version: Optional[str] = None,
     webrtc_ip: Optional[str] = None,
+    fingerprint_seed: Optional[FingerprintSeed] = None,
     proxy: Optional[Dict[str, str]] = None,
     geolocation: Optional[Dict[str, float]] = None,
     **context_kwargs: Any,
@@ -155,6 +157,7 @@ async def AsyncNewContext(
         os: Target OS for preset selection ("windows", "macos", "linux").
         ff_version: Firefox version string for UA patching.
         webrtc_ip: IPv4 address to spoof for WebRTC ICE candidates.
+        fingerprint_seed: Stable seed for Camoufox-generated fingerprint values.
         proxy: Per-context proxy (Playwright format: {"server": "...", "username": "...", "password": "..."}).
         geolocation: Per-context geolocation ({"latitude": float, "longitude": float}).
         **context_kwargs: Additional Playwright new_context() options.
@@ -169,7 +172,13 @@ async def AsyncNewContext(
 
     fp = await asyncio.get_event_loop().run_in_executor(
         None,
-        lambda: generate_context_fingerprint(preset=preset, os=os, ff_version=ff_version, webrtc_ip=webrtc_ip),
+        lambda: generate_context_fingerprint(
+            preset=preset,
+            os=os,
+            ff_version=ff_version,
+            webrtc_ip=webrtc_ip,
+            fingerprint_seed=fingerprint_seed,
+        ),
     )
 
     # Merge generated context options with user overrides (user wins)

--- a/pythonlib/camoufox/async_api.py
+++ b/pythonlib/camoufox/async_api.py
@@ -147,14 +147,15 @@ async def AsyncNewContext(
     """
     Creates a new browser context with a unique fingerprint identity.
 
-    Each context gets its own real fingerprint preset (navigator, screen, WebGL, fonts, etc.)
-    with unique seeds for audio, canvas, and font spacing noise. All values are applied
+    By default, each context gets a BrowserForge synthetic fingerprint with
+    unique audio, canvas, font spacing, font, voice, and WebGL values. Pass a
+    preset dict to use a real bundled fingerprint instead. Values are applied
     via addInitScript so they self-destruct before page scripts can detect them.
 
     Parameters:
         browser: A Browser instance from AsyncNewBrowser or AsyncCamoufox.
-        preset: A specific fingerprint preset dict to use. If None, picks randomly.
-        os: Target OS for preset selection ("windows", "macos", "linux").
+        preset: A specific fingerprint preset dict to use. If None, BrowserForge is used.
+        os: Target OS for synthetic fingerprint generation ("windows", "macos", "linux").
         ff_version: Firefox version string for UA patching.
         webrtc_ip: IPv4 address to spoof for WebRTC ICE candidates.
         fingerprint_seed: Stable seed for Camoufox-generated fingerprint values.

--- a/pythonlib/camoufox/fingerprint_seed.py
+++ b/pythonlib/camoufox/fingerprint_seed.py
@@ -1,0 +1,63 @@
+import hashlib
+import random
+from typing import Union
+
+FingerprintSeed = Union[str, int, bytes]
+
+_SEED_VERSION = b'camoufox:fingerprint-seed:v1'
+_UINT32_MAX = 4_294_967_295
+
+
+def _seed_bytes(seed: FingerprintSeed) -> bytes:
+    if isinstance(seed, bool):
+        raise TypeError('fingerprint seed must be str, int, or bytes')
+    if isinstance(seed, bytes):
+        return b'bytes:' + seed
+    if isinstance(seed, int):
+        return b'int:' + str(seed).encode('ascii')
+    if isinstance(seed, str):
+        return b'str:' + seed.encode('utf-8')
+    raise TypeError('fingerprint seed must be str, int, or bytes')
+
+
+def _pack_component(value: bytes) -> bytes:
+    return len(value).to_bytes(8, 'big') + value
+
+
+def derive_seed(seed: FingerprintSeed, namespace: str, bits: int = 64) -> int:
+    """
+    Derive a deterministic integer seed for a specific fingerprint namespace.
+
+    The input is versioned and length-prefixed so different namespaces and seed
+    types do not collide when their raw byte representation overlaps.
+    """
+    if not isinstance(namespace, str):
+        raise TypeError('namespace must be a string')
+    if not namespace:
+        raise ValueError('namespace is required')
+    if isinstance(bits, bool) or not isinstance(bits, int):
+        raise TypeError('bits must be an integer')
+    if bits < 1 or bits > 256:
+        raise ValueError('bits must be between 1 and 256')
+
+    material = b''.join((
+        _pack_component(_SEED_VERSION),
+        _pack_component(namespace.encode('utf-8')),
+        _pack_component(_seed_bytes(seed)),
+    ))
+    value = int.from_bytes(hashlib.sha256(material).digest(), 'big')
+    return value >> (256 - bits)
+
+
+def deterministic_rng(seed: FingerprintSeed, namespace: str) -> random.Random:
+    """
+    Return a local random generator derived from a fingerprint seed namespace.
+    """
+    return random.Random(derive_seed(seed, namespace))
+
+
+def derive_uint32_seed(seed: FingerprintSeed, namespace: str) -> int:
+    """
+    Derive a non-zero uint32 seed for Camoufox fingerprint noise settings.
+    """
+    return derive_seed(seed, namespace) % _UINT32_MAX + 1

--- a/pythonlib/camoufox/fingerprints.py
+++ b/pythonlib/camoufox/fingerprints.py
@@ -412,7 +412,6 @@ def _build_init_script(values: Dict[str, Any]) -> str:
     setters = [
         ('fontSpacingSeed', 'setFontSpacingSeed', '{val}'),
         ('audioFingerprintSeed', 'setAudioFingerprintSeed', '{val}'),
-        ('canvasSeed', 'setCanvasSeed', '{val}'),
         ('navigatorPlatform', 'setNavigatorPlatform', '{val}'),
         ('navigatorOscpu', 'setNavigatorOscpu', '{val}'),
         ('navigatorUserAgent', 'setNavigatorUserAgent', '{val}'),
@@ -508,8 +507,8 @@ def generate_context_fingerprint(
         locale: BCP-47 locale string (e.g. 'en-GB'). When provided, parsed via
             normalize_locale() and injected into config. Also sets
             context_options['locale'] for Playwright.
-        fingerprint_seed: Stable seed for Camoufox-generated noise seeds and
-            font/voice/WebGL subsets.
+        fingerprint_seed: Stable seed for Camoufox-generated config values and
+            supported per-context surfaces.
     """
     if preset is not None:
         # Use real fingerprint preset
@@ -638,7 +637,6 @@ def generate_context_fingerprint(
     init_values: Dict[str, Any] = {
         'fontSpacingSeed': config.get('fonts:spacing_seed'),
         'audioFingerprintSeed': config.get('audio:seed'),
-        'canvasSeed': config.get('canvas:seed'),
         'navigatorPlatform': nav.get('platform'),
         'navigatorOscpu': config.get('navigator.oscpu'),
         'navigatorUserAgent': config.get('navigator.userAgent'),

--- a/pythonlib/camoufox/fingerprints.py
+++ b/pythonlib/camoufox/fingerprints.py
@@ -3,7 +3,7 @@ import os
 import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from random import choice, randint, randrange, random, sample, shuffle
+from random import Random, choice, randint, randrange, random, sample, shuffle
 from typing import Any, Dict, List, Optional, Tuple
 
 from browserforge.fingerprints import (
@@ -12,6 +12,11 @@ from browserforge.fingerprints import (
     ScreenFingerprint,
 )
 
+from camoufox.fingerprint_seed import (
+    FingerprintSeed,
+    derive_uint32_seed,
+    deterministic_rng,
+)
 from camoufox.pkgman import load_yaml
 from camoufox.webgl import sample_webgl
 
@@ -34,6 +39,20 @@ _LINUX_MARKER_FONTS = [
 _WINDOWS_MARKER_FONTS = [
     'Segoe UI', 'Tahoma', 'Cambria Math', 'Nirmala UI',
 ]
+_SYNTHETIC_OS_CHOICES = ('linux', 'macos', 'windows')
+
+
+def _uint32_noise_seed(
+    fingerprint_seed: Optional[FingerprintSeed],
+    namespace: str,
+) -> int:
+    if fingerprint_seed is None:
+        return randint(1, 4_294_967_295)  # nosec
+    return derive_uint32_seed(fingerprint_seed, namespace)
+
+
+def _synthetic_os_for_seed(fingerprint_seed: FingerprintSeed) -> str:
+    return deterministic_rng(fingerprint_seed, 'os').choice(_SYNTHETIC_OS_CHOICES)
 
 
 def _ensure_marker_fonts(fonts: List[str], markers: List[str]) -> None:
@@ -77,7 +96,10 @@ _ESSENTIAL_FONTS_LINUX = [
 ]
 
 
-def _generate_random_font_subset(target_os: str) -> List[str]:
+def _generate_random_font_subset(
+    target_os: str,
+    rng: Optional[Random] = None,
+) -> List[str]:
     """
     Generate a random subset of fonts for the given OS.
     Picks a random percentage between 30-78% of non-essential fonts,
@@ -102,12 +124,15 @@ def _generate_random_font_subset(target_os: str) -> List[str]:
     non_essential = [f for f in full_list if f not in essential]
 
     # Random percentage between 30-78%
-    pct = 30 + int(random() * 49)
+    random_float = rng.random if rng is not None else random
+    random_sample = rng.sample if rng is not None else sample
+
+    pct = 30 + int(random_float() * 49)
     count = round((pct / 100) * len(non_essential))
 
     # Randomly select non-essential fonts
     if count < len(non_essential):
-        selected = sample(non_essential, count)
+        selected = random_sample(non_essential, count)
     else:
         selected = non_essential
     result.extend(selected)
@@ -149,7 +174,10 @@ _ESSENTIAL_VOICES_WINDOWS = [
 ]
 
 
-def _generate_random_voice_subset(target_os: str) -> List[str]:
+def _generate_random_voice_subset(
+    target_os: str,
+    rng: Optional[Random] = None,
+) -> List[str]:
     """
     Generate a random subset of speech voices for the given OS.
     macOS: random 40-80% of non-essential + essential always included.
@@ -172,11 +200,14 @@ def _generate_random_voice_subset(target_os: str) -> List[str]:
     result = [v for v in full_list if v in essential]
     non_essential = [v for v in full_list if v not in essential]
 
-    pct = 40 + int(random() * 41)  # 40-80%
+    random_float = rng.random if rng is not None else random
+    random_sample = rng.sample if rng is not None else sample
+
+    pct = 40 + int(random_float() * 41)  # 40-80%
     count = round((pct / 100) * len(non_essential))
 
     if count < len(non_essential):
-        selected = sample(non_essential, count)
+        selected = random_sample(non_essential, count)
     else:
         selected = non_essential
     result.extend(selected)
@@ -240,9 +271,16 @@ def get_random_preset(
     return choice(candidates)  # nosec
 
 
-def from_preset(preset: Dict, ff_version: Optional[str] = None) -> Dict[str, Any]:
+def from_preset(
+    preset: Dict,
+    ff_version: Optional[str] = None,
+    fingerprint_seed: Optional[FingerprintSeed] = None,
+) -> Dict[str, Any]:
     """
     Convert a real fingerprint preset to CAMOU_CONFIG format.
+
+    When fingerprint_seed is supplied, Camoufox-owned noise seeds and
+    font/voice subsets are deterministic for that preset.
     """
     config: Dict[str, Any] = {}
 
@@ -291,15 +329,14 @@ def from_preset(preset: Dict, ff_version: Optional[str] = None) -> Dict[str, Any
     if webgl.get('unmaskedRenderer'):
         config['webGl:renderer'] = webgl['unmaskedRenderer']
 
-    # Generate unique random seeds per launch (1 to 2^32-1, excluding 0 which is a no-op in C++)
-    config['fonts:spacing_seed'] = randint(1, 4_294_967_295)  # nosec
-    config['audio:seed'] = randint(1, 4_294_967_295)  # nosec
-    config['canvas:seed'] = randint(1, 4_294_967_295)  # nosec
+    config['fonts:spacing_seed'] = _uint32_noise_seed(fingerprint_seed, 'fonts:spacing_seed')
+    config['audio:seed'] = _uint32_noise_seed(fingerprint_seed, 'audio:seed')
+    config['canvas:seed'] = _uint32_noise_seed(fingerprint_seed, 'canvas:seed')
 
     if preset.get('timezone'):
         config['timezone'] = preset['timezone']
 
-    # Generate a unique random font subset from the OS font list.
+    # Generate a context-local font subset from the OS font list.
     plat = nav.get('platform', '')
     if plat == 'MacIntel':
         target_os = 'macos'
@@ -309,8 +346,18 @@ def from_preset(preset: Dict, ff_version: Optional[str] = None) -> Dict[str, Any
         target_os = 'linux'
     else:
         target_os = 'macos'
+    font_rng = (
+        deterministic_rng(fingerprint_seed, 'fonts')
+        if fingerprint_seed is not None
+        else None
+    )
+    voice_rng = (
+        deterministic_rng(fingerprint_seed, 'voices')
+        if fingerprint_seed is not None
+        else None
+    )
     try:
-        config['fonts'] = _generate_random_font_subset(target_os)
+        config['fonts'] = _generate_random_font_subset(target_os, font_rng)
     except Exception:
         # Fallback to preset fonts if font generation fails
         if preset.get('fonts'):
@@ -321,9 +368,9 @@ def from_preset(preset: Dict, ff_version: Optional[str] = None) -> Dict[str, Any
                 'linux': _LINUX_MARKER_FONTS,
             }.get(target_os, _MACOS_MARKER_FONTS))
             config['fonts'] = fonts
-    # Generate a unique random voice subset from the OS voice list
+    # Generate a context-local voice subset from the OS voice list
     try:
-        config['voices'] = _generate_random_voice_subset(target_os)
+        config['voices'] = _generate_random_voice_subset(target_os, voice_rng)
     except Exception:
         if preset.get('speechVoices'):
             config['voices'] = preset['speechVoices']
@@ -423,6 +470,7 @@ def generate_context_fingerprint(
     webrtc_ip: Optional[str] = None,
     timezone: Optional[str] = None,
     locale: Optional[str] = None,
+    fingerprint_seed: Optional[FingerprintSeed] = None,
 ) -> Dict[str, Any]:
     """
     Generate fingerprint values for a single per-context identity.
@@ -438,22 +486,36 @@ def generate_context_fingerprint(
         locale: BCP-47 locale string (e.g. 'en-GB'). When provided, parsed via
             normalize_locale() and injected into config. Also sets
             context_options['locale'] for Playwright.
+        fingerprint_seed: Stable seed for Camoufox-generated noise seeds and
+            font/voice/WebGL subsets.
     """
     if preset is not None:
         # Use real fingerprint preset
-        config = from_preset(preset, ff_version)
+        config = from_preset(preset, ff_version, fingerprint_seed)
         nav = preset.get('navigator', {})
         screen = preset.get('screen', {})
         webgl = preset.get('webgl', {})
     else:
         # Fall back to BrowserForge synthetic generation
-        fp = generate_fingerprint(os=os)
+        synthetic_os = os
+        if synthetic_os is None and fingerprint_seed is not None:
+            synthetic_os = _synthetic_os_for_seed(fingerprint_seed)
+        fp = generate_fingerprint(os=synthetic_os)
         config = from_browserforge(fp, ff_version)
 
         # Add seeds (BrowserForge doesn't generate these)
-        config.setdefault('fonts:spacing_seed', randint(1, 4_294_967_295))  # nosec
-        config.setdefault('audio:seed', randint(1, 4_294_967_295))  # nosec
-        config.setdefault('canvas:seed', randint(1, 4_294_967_295))  # nosec
+        config.setdefault(
+            'fonts:spacing_seed',
+            _uint32_noise_seed(fingerprint_seed, 'fonts:spacing_seed'),
+        )
+        config.setdefault(
+            'audio:seed',
+            _uint32_noise_seed(fingerprint_seed, 'audio:seed'),
+        )
+        config.setdefault(
+            'canvas:seed',
+            _uint32_noise_seed(fingerprint_seed, 'canvas:seed'),
+        )
 
         # Determine target OS from platform for font/voice generation
         plat = config.get('navigator.platform', '')
@@ -466,14 +528,24 @@ def generate_context_fingerprint(
         # Add fonts (BrowserForge doesn't generate these)
         if 'fonts' not in config:
             try:
-                config['fonts'] = _generate_random_font_subset(os_name)
+                font_rng = (
+                    deterministic_rng(fingerprint_seed, 'fonts')
+                    if fingerprint_seed is not None
+                    else None
+                )
+                config['fonts'] = _generate_random_font_subset(os_name, font_rng)
             except Exception:
                 pass
 
         # Add voices (BrowserForge doesn't generate these)
         if 'voices' not in config:
             try:
-                config['voices'] = _generate_random_voice_subset(os_name)
+                voice_rng = (
+                    deterministic_rng(fingerprint_seed, 'voices')
+                    if fingerprint_seed is not None
+                    else None
+                )
+                config['voices'] = _generate_random_voice_subset(os_name, voice_rng)
             except Exception:
                 pass
 
@@ -490,7 +562,7 @@ def generate_context_fingerprint(
         # Sample WebGL vendor/renderer from database (BrowserForge doesn't generate these)
         if not config.get('webGl:vendor') or not config.get('webGl:renderer'):
             _os_map = {'macos': 'mac', 'linux': 'lin', 'windows': 'win'}
-            _target_os = _os_map.get(os or '', None)
+            _target_os = _os_map.get(synthetic_os or '', None)
             if not _target_os:
                 plat = config.get('navigator.platform', '')
                 if plat == 'Win32':
@@ -500,7 +572,12 @@ def generate_context_fingerprint(
                 else:
                     _target_os = 'mac'
             try:
-                webgl_fp = sample_webgl(_target_os)
+                webgl_seed = (
+                    derive_uint32_seed(fingerprint_seed, 'webgl')
+                    if fingerprint_seed is not None
+                    else None
+                )
+                webgl_fp = sample_webgl(_target_os, random_seed=webgl_seed)
                 webgl_fp.pop('webGl2Enabled', None)
                 config.update(webgl_fp)
             except Exception:

--- a/pythonlib/camoufox/fingerprints.py
+++ b/pythonlib/camoufox/fingerprints.py
@@ -1,11 +1,14 @@
 import json
 import os
 import re
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from random import Random, choice, randint, randrange, random, sample, shuffle
-from typing import Any, Dict, List, Optional, Tuple
+from random import Random, choice, randint, randrange, random, sample
+from threading import Lock
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
+import browserforge.bayesian_network as browserforge_bayesian_network
 from browserforge.fingerprints import (
     Fingerprint,
     FingerprintGenerator,
@@ -40,6 +43,7 @@ _WINDOWS_MARKER_FONTS = [
     'Segoe UI', 'Tahoma', 'Cambria Math', 'Nirmala UI',
 ]
 _SYNTHETIC_OS_CHOICES = ('linux', 'macos', 'windows')
+_BROWSERFORGE_RNG_LOCK = Lock()
 
 
 def _uint32_noise_seed(
@@ -53,6 +57,22 @@ def _uint32_noise_seed(
 
 def _synthetic_os_for_seed(fingerprint_seed: FingerprintSeed) -> str:
     return deterministic_rng(fingerprint_seed, 'os').choice(_SYNTHETIC_OS_CHOICES)
+
+
+@contextmanager
+def _browserforge_rng(fingerprint_seed: Optional[FingerprintSeed]) -> Iterator[None]:
+    with _BROWSERFORGE_RNG_LOCK:
+        if fingerprint_seed is None:
+            yield
+            return
+
+        rng = deterministic_rng(fingerprint_seed, 'browserforge')
+        previous_random = browserforge_bayesian_network.random
+        browserforge_bayesian_network.random = rng
+        try:
+            yield
+        finally:
+            browserforge_bayesian_network.random = previous_random
 
 
 def _ensure_marker_fonts(fonts: List[str], markers: List[str]) -> None:
@@ -240,6 +260,7 @@ _OS_TO_PRESET_KEY = {
 
 def get_random_preset(
     os: Optional[str] = None,
+    rng: Optional[Random] = None,
 ) -> Optional[Dict]:
     """
     Get a random preset for the given OS.
@@ -268,7 +289,8 @@ def get_random_preset(
     if not candidates:
         return None
 
-    return choice(candidates)  # nosec
+    random_choice = rng.choice if rng is not None else choice
+    return random_choice(candidates)  # nosec
 
 
 def from_preset(
@@ -500,8 +522,8 @@ def generate_context_fingerprint(
         synthetic_os = os
         if synthetic_os is None and fingerprint_seed is not None:
             synthetic_os = _synthetic_os_for_seed(fingerprint_seed)
-        fp = generate_fingerprint(os=synthetic_os)
-        config = from_browserforge(fp, ff_version)
+        fp = generate_fingerprint(os=synthetic_os, fingerprint_seed=fingerprint_seed)
+        config = from_browserforge(fp, ff_version, fingerprint_seed)
 
         # Add seeds (BrowserForge doesn't generate these)
         config.setdefault(
@@ -705,7 +727,11 @@ def _cast_to_properties(
         camoufox_data[type_key] = data
 
 
-def handle_screenXY(camoufox_data: Dict[str, Any], fp_screen: ScreenFingerprint) -> None:
+def handle_screenXY(
+    camoufox_data: Dict[str, Any],
+    fp_screen: ScreenFingerprint,
+    rng: Optional[Random] = None,
+) -> None:
     """
     Helper method to set window.screenY based on Browserforge's screenX value.
     """
@@ -729,12 +755,18 @@ def handle_screenXY(camoufox_data: Dict[str, Any], fp_screen: ScreenFingerprint)
     if screenY == 0:
         camoufox_data['window.screenY'] = 0
     elif screenY > 0:
-        camoufox_data['window.screenY'] = randrange(0, screenY)  # nosec
+        random_range = rng.randrange if rng is not None else randrange
+        camoufox_data['window.screenY'] = random_range(0, screenY)  # nosec
     else:
-        camoufox_data['window.screenY'] = randrange(screenY, 0)  # nosec
+        random_range = rng.randrange if rng is not None else randrange
+        camoufox_data['window.screenY'] = random_range(screenY, 0)  # nosec
 
 
-def from_browserforge(fingerprint: Fingerprint, ff_version: Optional[str] = None) -> Dict[str, Any]:
+def from_browserforge(
+    fingerprint: Fingerprint,
+    ff_version: Optional[str] = None,
+    fingerprint_seed: Optional[FingerprintSeed] = None,
+) -> Dict[str, Any]:
     """
     Converts a Browserforge fingerprint to a Camoufox config.
     """
@@ -745,7 +777,12 @@ def from_browserforge(fingerprint: Fingerprint, ff_version: Optional[str] = None
         bf_dict=asdict(fingerprint),
         ff_version=ff_version,
     )
-    handle_screenXY(camoufox_data, fingerprint.screen)
+    screen_rng = (
+        deterministic_rng(fingerprint_seed, 'screen')
+        if fingerprint_seed is not None
+        else None
+    )
+    handle_screenXY(camoufox_data, fingerprint.screen, screen_rng)
 
     return camoufox_data
 
@@ -773,15 +810,20 @@ def handle_window_size(fp: Fingerprint, outer_width: int, outer_height: int) -> 
     sc.outerHeight = outer_height
 
 
-def generate_fingerprint(window: Optional[Tuple[int, int]] = None, **config) -> Fingerprint:
+def generate_fingerprint(
+    window: Optional[Tuple[int, int]] = None,
+    fingerprint_seed: Optional[FingerprintSeed] = None,
+    **config,
+) -> Fingerprint:
     """
     Generates a Firefox fingerprint with Browserforge.
     """
-    if window:  # User-specified outer window size
-        fingerprint = FP_GENERATOR.generate(**config)
-        handle_window_size(fingerprint, *window)
-        return fingerprint
-    return FP_GENERATOR.generate(**config)
+    with _browserforge_rng(fingerprint_seed):
+        if window:  # User-specified outer window size
+            fingerprint = FP_GENERATOR.generate(**config)
+            handle_window_size(fingerprint, *window)
+            return fingerprint
+        return FP_GENERATOR.generate(**config)
 
 
 if __name__ == "__main__":

--- a/pythonlib/camoufox/sync_api.py
+++ b/pythonlib/camoufox/sync_api.py
@@ -14,6 +14,7 @@ from typing_extensions import Literal
 from camoufox.virtdisplay import VirtualDisplay
 
 from .exceptions import InvalidProxy
+from .fingerprint_seed import FingerprintSeed
 from .fingerprints import generate_context_fingerprint
 from .utils import launch_options, sync_attach_vd
 
@@ -134,6 +135,7 @@ def NewContext(
     os: Optional[str] = None,
     ff_version: Optional[str] = None,
     webrtc_ip: Optional[str] = None,
+    fingerprint_seed: Optional[FingerprintSeed] = None,
     proxy: Optional[Dict[str, str]] = None,
     geolocation: Optional[Dict[str, float]] = None,
     **context_kwargs: Any,
@@ -151,6 +153,7 @@ def NewContext(
         os: Target OS for preset selection ("windows", "macos", "linux").
         ff_version: Firefox version string for UA patching.
         webrtc_ip: IPv4 address to spoof for WebRTC ICE candidates.
+        fingerprint_seed: Stable seed for Camoufox-generated fingerprint values.
         proxy: Per-context proxy (Playwright format: {"server": "...", "username": "...", "password": "..."}).
         geolocation: Per-context geolocation ({"latitude": float, "longitude": float}).
         **context_kwargs: Additional Playwright new_context() options.
@@ -163,7 +166,13 @@ def NewContext(
         if "timezone_id" not in context_kwargs and geo["timezone"]:
             context_kwargs["timezone_id"] = geo["timezone"]
 
-    fp = generate_context_fingerprint(preset=preset, os=os, ff_version=ff_version, webrtc_ip=webrtc_ip)
+    fp = generate_context_fingerprint(
+        preset=preset,
+        os=os,
+        ff_version=ff_version,
+        webrtc_ip=webrtc_ip,
+        fingerprint_seed=fingerprint_seed,
+    )
 
     # Merge generated context options with user overrides (user wins)
     opts: Dict[str, Any] = {**fp['context_options'], **context_kwargs}

--- a/pythonlib/camoufox/sync_api.py
+++ b/pythonlib/camoufox/sync_api.py
@@ -143,14 +143,15 @@ def NewContext(
     """
     Creates a new browser context with a unique fingerprint identity.
 
-    Each context gets its own real fingerprint preset
-    with unique seeds for audio, canvas, and font spacing noise. All values are applied
+    By default, each context gets a BrowserForge synthetic fingerprint with
+    unique audio, canvas, font spacing, font, voice, and WebGL values. Pass a
+    preset dict to use a real bundled fingerprint instead. Values are applied
     via addInitScript so they self-destruct before page scripts can detect them.
 
     Parameters:
         browser: A Browser instance from NewBrowser or Camoufox.
-        preset: A specific fingerprint preset dict to use. If None, picks randomly.
-        os: Target OS for preset selection ("windows", "macos", "linux").
+        preset: A specific fingerprint preset dict to use. If None, BrowserForge is used.
+        os: Target OS for synthetic fingerprint generation ("windows", "macos", "linux").
         ff_version: Firefox version string for UA patching.
         webrtc_ip: IPv4 address to spoof for WebRTC ICE candidates.
         fingerprint_seed: Stable seed for Camoufox-generated fingerprint values.

--- a/pythonlib/camoufox/sync_api.py
+++ b/pythonlib/camoufox/sync_api.py
@@ -143,10 +143,10 @@ def NewContext(
     """
     Creates a new browser context with a unique fingerprint identity.
 
-    By default, each context gets a BrowserForge synthetic fingerprint with
-    unique audio, canvas, font spacing, font, voice, and WebGL values. Pass a
-    preset dict to use a real bundled fingerprint instead. Values are applied
-    via addInitScript so they self-destruct before page scripts can detect them.
+    By default, each context gets a BrowserForge synthetic fingerprint. Supported
+    per-context values are applied via addInitScript so they self-destruct before
+    page scripts can detect them. Pass a preset dict to use a real bundled
+    fingerprint instead.
 
     Parameters:
         browser: A Browser instance from NewBrowser or Camoufox.

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -4,7 +4,7 @@ from os import environ
 from os.path import abspath
 from pathlib import Path
 from pprint import pprint
-from random import randint, randrange
+from random import randrange
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 import numpy as np
@@ -20,7 +20,17 @@ from .exceptions import (
     InvalidPropertyType,
     NonFirefoxFingerprint,
 )
-from .fingerprints import from_browserforge, from_preset, generate_fingerprint, get_random_preset, _generate_random_font_subset, _generate_random_voice_subset
+from .fingerprint_seed import FingerprintSeed, derive_uint32_seed, deterministic_rng
+from .fingerprints import (
+    _generate_random_font_subset,
+    _generate_random_voice_subset,
+    _synthetic_os_for_seed,
+    _uint32_noise_seed,
+    from_browserforge,
+    from_preset,
+    generate_fingerprint,
+    get_random_preset,
+)
 from .geolocation import geoip_allowed, get_geolocation
 from .ip import Proxy, public_ip, valid_ipv4, valid_ipv6
 from .locales import handle_locales
@@ -271,6 +281,21 @@ def check_valid_os(os: ListOrString) -> None:
         raise InvalidOS(f"Camoufox does not support the OS: '{os}'")
 
 
+def _seeded_os(
+    os: Optional[ListOrString],
+    fingerprint_seed: Optional[FingerprintSeed],
+) -> Optional[ListOrString]:
+    if fingerprint_seed is None:
+        return os
+    if os is None:
+        return _synthetic_os_for_seed(fingerprint_seed)
+    if isinstance(os, str):
+        return os
+    if not os:
+        return os
+    return deterministic_rng(fingerprint_seed, 'os').choice(tuple(os))
+
+
 def _clean_locals(data: Dict[str, Any]) -> Dict[str, Any]:
     """
     Gets the launch options from the locals of the function.
@@ -414,6 +439,7 @@ def launch_options(
     window: Optional[Tuple[int, int]] = None,
     fingerprint: Optional[Fingerprint] = None,
     fingerprint_preset: Optional[Union[bool, Dict[str, Any]]] = None,
+    fingerprint_seed: Optional[FingerprintSeed] = None,
     ff_version: Optional[int] = None,
     headless: Optional[bool] = None,
     main_world_eval: Optional[bool] = None,
@@ -483,6 +509,8 @@ def launch_options(
             Opt into using real fingerprint presets instead of BrowserForge.
             Pass `True` to use a random bundled preset, or pass a preset dict directly.
             By default (None), BrowserForge is used for infinite unique fingerprints.
+        fingerprint_seed (Optional[FingerprintSeed]):
+            Stable seed for Camoufox-generated fingerprint values.
         ff_version (Optional[int]):
             Firefox version to use. Defaults to the current Camoufox version.
             To prevent leaks, only use this for special cases.
@@ -564,6 +592,7 @@ def launch_options(
     # webgl_config requires OS to be set
     elif webgl_config:
         raise ValueError('OS must be set when using webgl_config')
+    fingerprint_os = _seeded_os(os, fingerprint_seed)
 
     # Add the default addons
     add_default_addons(addons, exclude_addons)
@@ -591,9 +620,14 @@ def launch_options(
         if isinstance(fingerprint_preset, dict):
             preset = fingerprint_preset
         else:
-            preset = get_random_preset(os=os)
+            preset_rng = (
+                deterministic_rng(fingerprint_seed, 'preset')
+                if fingerprint_seed is not None
+                else None
+            )
+            preset = get_random_preset(os=os, rng=preset_rng)
         if preset:
-            merge_into(config, from_preset(preset, ff_version_str))
+            merge_into(config, from_preset(preset, ff_version_str, fingerprint_seed))
             _used_preset = True
 
     if not _used_preset and fingerprint is None:
@@ -601,20 +635,26 @@ def launch_options(
         fingerprint = generate_fingerprint(
             screen=screen or get_screen_cons(headless or 'DISPLAY' in env),
             window=window,
-            os=os,
+            os=fingerprint_os,
+            fingerprint_seed=fingerprint_seed,
         )
 
     if not _used_preset and fingerprint is not None:
         # Inject the BrowserForge fingerprint into the config
         merge_into(
             config,
-            from_browserforge(fingerprint, ff_version_str),
+            from_browserforge(fingerprint, ff_version_str, fingerprint_seed),
         )
 
     target_os = get_target_os(config)
 
     # Set a random window.history.length
-    set_into(config, 'window.history.length', randrange(1, 6))  # nosec
+    history_length = (
+        deterministic_rng(fingerprint_seed, 'history').randrange(1, 6)
+        if fingerprint_seed is not None
+        else randrange(1, 6)  # nosec
+    )
+    set_into(config, 'window.history.length', history_length)
 
     # Update fonts list
     if fonts:
@@ -630,7 +670,12 @@ def launch_options(
         # Generate a unique random font subset from the OS font list
         os_name = {'win': 'windows', 'mac': 'macos', 'lin': 'linux'}.get(target_os, 'macos')
         try:
-            config['fonts'] = _generate_random_font_subset(os_name)
+            font_rng = (
+                deterministic_rng(fingerprint_seed, 'fonts')
+                if fingerprint_seed is not None
+                else None
+            )
+            config['fonts'] = _generate_random_font_subset(os_name, font_rng)
         except Exception:
             update_fonts(config, target_os)
 
@@ -638,14 +683,23 @@ def launch_options(
     if 'voices' not in config:
         os_name_v = {'win': 'windows', 'mac': 'macos', 'lin': 'linux'}.get(target_os, 'macos')
         try:
-            config['voices'] = _generate_random_voice_subset(os_name_v)
+            voice_rng = (
+                deterministic_rng(fingerprint_seed, 'voices')
+                if fingerprint_seed is not None
+                else None
+            )
+            config['voices'] = _generate_random_voice_subset(os_name_v, voice_rng)
         except Exception:
             pass
 
     # Set random seeds for fingerprint noise (per launch)
-    set_into(config, 'fonts:spacing_seed', randint(1, 4_294_967_295))  # nosec
-    set_into(config, 'audio:seed', randint(1, 4_294_967_295))  # nosec
-    set_into(config, 'canvas:seed', randint(1, 4_294_967_295))  # nosec
+    set_into(
+        config,
+        'fonts:spacing_seed',
+        _uint32_noise_seed(fingerprint_seed, 'fonts:spacing_seed'),
+    )
+    set_into(config, 'audio:seed', _uint32_noise_seed(fingerprint_seed, 'audio:seed'))
+    set_into(config, 'canvas:seed', _uint32_noise_seed(fingerprint_seed, 'canvas:seed'))
 
     # Set geolocation
     if geoip:
@@ -719,7 +773,12 @@ def launch_options(
             # Preset already set vendor/renderer — sample matching WebGL params
             webgl_fp = sample_webgl(target_os, config['webGl:vendor'], config['webGl:renderer'])
         else:
-            webgl_fp = sample_webgl(target_os)
+            webgl_seed = (
+                derive_uint32_seed(fingerprint_seed, 'webgl')
+                if fingerprint_seed is not None
+                else None
+            )
+            webgl_fp = sample_webgl(target_os, random_seed=webgl_seed)
         enable_webgl2 = webgl_fp.pop('webGl2Enabled')
 
         # Merge the WebGL fingerprint into the config

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -139,7 +139,12 @@ def _load_properties(path: Optional[Path] = None) -> Dict[str, str]:
     Loads the properties.json file.
     """
     if path:
-        prop_file = str(path.parent / "properties.json")
+        prop_file = path.parent / "properties.json"
+        if not prop_file.exists() and path.parent.name == "MacOS":
+            app_prop_file = path.parent.parent / "Resources" / "properties.json"
+            if app_prop_file.exists():
+                prop_file = app_prop_file
+        prop_file = str(prop_file)
     else:
         prop_file = get_path("properties.json")
     with open(prop_file, "rb") as f:

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -648,7 +648,7 @@ def launch_options(
 
     target_os = get_target_os(config)
 
-    # Set a random window.history.length
+    # Set a per-launch window.history.length, deterministic when seeded.
     history_length = (
         deterministic_rng(fingerprint_seed, 'history').randrange(1, 6)
         if fingerprint_seed is not None
@@ -667,7 +667,7 @@ def launch_options(
         else:
             raise ValueError('No custom fonts were passed, but `custom_fonts_only` is enabled.')
     elif 'fonts' not in config or not config.get('fonts'):
-        # Generate a unique random font subset from the OS font list
+        # Generate a per-launch font subset from the OS font list.
         os_name = {'win': 'windows', 'mac': 'macos', 'lin': 'linux'}.get(target_os, 'macos')
         try:
             font_rng = (
@@ -679,7 +679,7 @@ def launch_options(
         except Exception:
             update_fonts(config, target_os)
 
-    # Generate a unique random voice subset
+    # Generate a per-launch voice subset.
     if 'voices' not in config:
         os_name_v = {'win': 'windows', 'mac': 'macos', 'lin': 'linux'}.get(target_os, 'macos')
         try:
@@ -692,7 +692,7 @@ def launch_options(
         except Exception:
             pass
 
-    # Set random seeds for fingerprint noise (per launch)
+    # Set per-launch seeds for fingerprint noise.
     set_into(
         config,
         'fonts:spacing_seed',

--- a/pythonlib/camoufox/webgl/sample.py
+++ b/pythonlib/camoufox/webgl/sample.py
@@ -12,7 +12,10 @@ DB_PATH = Path(__file__).parent / 'webgl_data.db'
 
 
 def sample_webgl(
-    os: str, vendor: Optional[str] = None, renderer: Optional[str] = None
+    os: str,
+    vendor: Optional[str] = None,
+    renderer: Optional[str] = None,
+    random_seed: Optional[int] = None,
 ) -> Dict[str, str]:
     """
     Sample a random WebGL vendor/renderer combination and its data based on OS probabilities.
@@ -22,6 +25,7 @@ def sample_webgl(
         os: Operating system ('win', 'mac', or 'lin')
         vendor: Optional specific vendor to use
         renderer: Optional specific renderer to use (requires vendor to be set)
+        random_seed: Optional seed for deterministic probability sampling
 
     Returns:
         Dict containing WebGL data including vendor, renderer and additional parameters
@@ -65,7 +69,8 @@ def sample_webgl(
 
     # Get all vendor/renderer pairs and their probabilities for this OS
     cursor.execute(
-        f'SELECT vendor, renderer, data, {os} FROM webgl_fingerprints WHERE {os} > 0'  # nosec
+        f'SELECT vendor, renderer, data, {os} FROM webgl_fingerprints '  # nosec
+        f'WHERE {os} > 0 ORDER BY vendor, renderer'
     )
     results = cursor.fetchall()
     conn.close()
@@ -81,7 +86,8 @@ def sample_webgl(
     probs_array = probs_array / probs_array.sum()
 
     # Sample based on probabilities
-    idx = np.random.choice(len(probs_array), p=probs_array)
+    rng = np.random.default_rng(random_seed) if random_seed is not None else np.random
+    idx = rng.choice(len(probs_array), p=probs_array)
 
     # Parse the JSON data string
     return orjson.loads(data_strs[idx])

--- a/tests/patches/context-api-seed.py
+++ b/tests/patches/context-api-seed.py
@@ -1,0 +1,122 @@
+"""
+Verify public context helpers forward fingerprint_seed to fingerprint generation.
+
+Run directly:
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib python3 tests/patches/context-api-seed.py
+
+Or with pytest:
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib python3 -m pytest --confcutdir=tests/patches tests/patches/context-api-seed.py
+"""
+
+import asyncio
+
+from camoufox import async_api, sync_api
+
+
+class SyncContext:
+    def __init__(self):
+        self.init_scripts = []
+
+    def add_init_script(self, script):
+        self.init_scripts.append(script)
+
+
+class SyncBrowser:
+    def __init__(self):
+        self.context_options = None
+        self.context = SyncContext()
+
+    def new_context(self, **options):
+        self.context_options = options
+        return self.context
+
+
+class AsyncContext:
+    def __init__(self):
+        self.init_scripts = []
+
+    async def add_init_script(self, script):
+        self.init_scripts.append(script)
+
+
+class AsyncBrowser:
+    def __init__(self):
+        self.context_options = None
+        self.context = AsyncContext()
+
+    async def new_context(self, **options):
+        self.context_options = options
+        return self.context
+
+
+def _fingerprint_result(**kwargs):
+    return {
+        "context_options": {"user_agent": "generated-agent"},
+        "init_script": "generated-init-script",
+        "config": {},
+        "preset": {},
+    }
+
+
+def test_sync_new_context_forwards_fingerprint_seed():
+    calls = []
+    original = sync_api.generate_context_fingerprint
+
+    def fake_generate(**kwargs):
+        calls.append(kwargs)
+        return _fingerprint_result(**kwargs)
+
+    sync_api.generate_context_fingerprint = fake_generate
+    try:
+        browser = SyncBrowser()
+        context = sync_api.NewContext(
+            browser,
+            fingerprint_seed="profile-a",
+            user_agent="caller-agent",
+        )
+    finally:
+        sync_api.generate_context_fingerprint = original
+
+    assert calls[0]["fingerprint_seed"] == "profile-a"
+    assert "fingerprint_seed" not in browser.context_options
+    assert browser.context_options["user_agent"] == "caller-agent"
+    assert context.init_scripts == ["generated-init-script"]
+
+
+async def _test_async_new_context_forwards_fingerprint_seed():
+    calls = []
+    original = async_api.generate_context_fingerprint
+
+    def fake_generate(**kwargs):
+        calls.append(kwargs)
+        return _fingerprint_result(**kwargs)
+
+    async_api.generate_context_fingerprint = fake_generate
+    try:
+        browser = AsyncBrowser()
+        context = await async_api.AsyncNewContext(
+            browser,
+            fingerprint_seed="profile-a",
+            user_agent="caller-agent",
+        )
+    finally:
+        async_api.generate_context_fingerprint = original
+
+    assert calls[0]["fingerprint_seed"] == "profile-a"
+    assert "fingerprint_seed" not in browser.context_options
+    assert browser.context_options["user_agent"] == "caller-agent"
+    assert context.init_scripts == ["generated-init-script"]
+
+
+def test_async_new_context_forwards_fingerprint_seed():
+    asyncio.run(_test_async_new_context_forwards_fingerprint_seed())
+
+
+def main():
+    test_sync_new_context_forwards_fingerprint_seed()
+    test_async_new_context_forwards_fingerprint_seed()
+    print("context API seed checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/patches/context-fingerprint-seed.py
+++ b/tests/patches/context-fingerprint-seed.py
@@ -1,0 +1,117 @@
+"""
+Verify seeded context fingerprint generation for Camoufox-owned values.
+
+Run directly:
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib python3 tests/patches/context-fingerprint-seed.py
+
+Or with pytest:
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib python3 -m pytest --confcutdir=tests/patches tests/patches/context-fingerprint-seed.py
+"""
+
+from camoufox.fingerprints import generate_context_fingerprint
+
+
+PRESET = {
+    "navigator": {
+        "userAgent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:146.0) "
+            "Gecko/20100101 Firefox/146.0"
+        ),
+        "platform": "MacIntel",
+        "hardwareConcurrency": 8,
+        "oscpu": "Intel Mac OS X 10.15",
+        "maxTouchPoints": 0,
+    },
+    "screen": {
+        "width": 1440,
+        "height": 900,
+        "colorDepth": 24,
+        "availWidth": 1440,
+        "availHeight": 875,
+    },
+    "webgl": {
+        "unmaskedVendor": "Apple Inc.",
+        "unmaskedRenderer": "Apple GPU",
+    },
+    "timezone": "America/New_York",
+    "fonts": ["Arial", "Helvetica", "Times New Roman"],
+    "speechVoices": ["Samantha", "Alex"],
+}
+
+SEEDED_CONFIG_KEYS = (
+    "fonts:spacing_seed",
+    "audio:seed",
+    "canvas:seed",
+    "fonts",
+    "voices",
+)
+SYNTHETIC_SEEDED_CONFIG_KEYS = SEEDED_CONFIG_KEYS + (
+    "webGl:vendor",
+    "webGl:renderer",
+)
+NOISE_SEED_KEYS = (
+    "fonts:spacing_seed",
+    "audio:seed",
+    "canvas:seed",
+)
+
+
+def _seeded_values(seed):
+    result = generate_context_fingerprint(preset=PRESET, fingerprint_seed=seed)
+    return {
+        "config": {key: result["config"].get(key) for key in SEEDED_CONFIG_KEYS},
+        "init_script": result["init_script"],
+        "context_options": result["context_options"],
+    }
+
+
+def test_same_seed_reuses_camoufox_values():
+    first = _seeded_values("profile-a")
+    second = _seeded_values("profile-a")
+    assert first == second
+
+
+def test_same_seed_reuses_synthetic_camoufox_values():
+    first = generate_context_fingerprint(os="macos", fingerprint_seed="profile-a")["config"]
+    second = generate_context_fingerprint(os="macos", fingerprint_seed="profile-a")["config"]
+    for key in SYNTHETIC_SEEDED_CONFIG_KEYS:
+        assert first.get(key) == second.get(key)
+
+
+def test_same_seed_reuses_default_synthetic_camoufox_values():
+    first = generate_context_fingerprint(fingerprint_seed="profile-a")["config"]
+    second = generate_context_fingerprint(fingerprint_seed="profile-a")["config"]
+    for key in SYNTHETIC_SEEDED_CONFIG_KEYS:
+        assert first.get(key) == second.get(key)
+
+
+def test_different_seed_changes_noise_seeds():
+    first = _seeded_values("profile-a")["config"]
+    second = _seeded_values("profile-b")["config"]
+    assert first["fonts:spacing_seed"] != second["fonts:spacing_seed"]
+    assert first["audio:seed"] != second["audio:seed"]
+    assert first["canvas:seed"] != second["canvas:seed"]
+
+
+def test_unseeded_context_still_sets_nonzero_noise_seeds():
+    first = generate_context_fingerprint(preset=PRESET)["config"]
+    second = generate_context_fingerprint(preset=PRESET)["config"]
+    for config in (first, second):
+        for key in NOISE_SEED_KEYS:
+            assert 1 <= config[key] <= 4_294_967_295
+    assert tuple(first[key] for key in NOISE_SEED_KEYS) != tuple(
+        second[key] for key in NOISE_SEED_KEYS
+    )
+
+
+def main():
+    test_same_seed_reuses_camoufox_values()
+    test_same_seed_reuses_synthetic_camoufox_values()
+    test_same_seed_reuses_default_synthetic_camoufox_values()
+    test_different_seed_changes_noise_seeds()
+    test_unseeded_context_still_sets_nonzero_noise_seeds()
+    print("context fingerprint seed checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/patches/context-fingerprint-seed.py
+++ b/tests/patches/context-fingerprint-seed.py
@@ -104,12 +104,18 @@ def test_unseeded_context_still_sets_nonzero_noise_seeds():
     )
 
 
+def test_context_init_script_does_not_call_unsupported_canvas_setter():
+    result = generate_context_fingerprint(preset=PRESET, fingerprint_seed="profile-a")
+    assert "setCanvasSeed" not in result["init_script"]
+
+
 def main():
     test_same_seed_reuses_camoufox_values()
     test_same_seed_reuses_synthetic_camoufox_values()
     test_same_seed_reuses_default_synthetic_camoufox_values()
     test_different_seed_changes_noise_seeds()
     test_unseeded_context_still_sets_nonzero_noise_seeds()
+    test_context_init_script_does_not_call_unsupported_canvas_setter()
     print("context fingerprint seed checks passed")
 
 

--- a/tests/patches/fingerprint-seed.py
+++ b/tests/patches/fingerprint-seed.py
@@ -1,0 +1,65 @@
+"""
+Verify deterministic fingerprint seed derivation helpers.
+
+This script is intentionally stdlib-only so it can run before the full
+Camoufox Python package dependencies are installed.
+
+Run directly:
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib python3 tests/patches/fingerprint-seed.py
+
+Or with pytest:
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib python3 -m pytest --confcutdir=tests/patches tests/patches/fingerprint-seed.py
+"""
+
+from camoufox.fingerprint_seed import derive_seed, derive_uint32_seed, deterministic_rng
+
+
+def assert_raises(exc_type, fn):
+    try:
+        fn()
+    except exc_type:
+        return
+    except Exception as exc:
+        raise AssertionError(f"expected {exc_type.__name__}, got {type(exc).__name__}") from exc
+    raise AssertionError(f"expected {exc_type.__name__}")
+
+
+def test_golden_vectors():
+    assert derive_seed("profile-a", "browserforge") == 8050642059126505217
+    assert derive_seed(123, "scope") == 17414721184063999779
+    assert derive_seed(b"abc", "scope") == 16480259190397790102
+    assert derive_seed("profile-a", "uint32", bits=32) == 2711891498
+    assert derive_uint32_seed("profile-a", "canvas") == 1519517379
+
+
+def test_namespace_and_type_boundaries():
+    assert derive_seed("profile-a", "browserforge") != derive_seed("profile-a", "webgl")
+    assert derive_seed("123", "scope") != derive_seed(123, "scope")
+    assert derive_seed(b"\0str:x", "a") != derive_seed("x", "a\0bytes:")
+
+
+def test_rng_reproducibility():
+    first = deterministic_rng("profile-a", "fonts")
+    second = deterministic_rng("profile-a", "fonts")
+    assert [first.random() for _ in range(5)] == [second.random() for _ in range(5)]
+
+
+def test_invalid_inputs():
+    assert_raises(ValueError, lambda: derive_seed("profile-a", ""))
+    assert_raises(TypeError, lambda: derive_seed("profile-a", None))
+    assert_raises(ValueError, lambda: derive_seed("profile-a", "scope", bits=0))
+    assert_raises(TypeError, lambda: derive_seed("profile-a", "scope", bits=1.5))
+    assert_raises(TypeError, lambda: derive_seed("profile-a", "scope", bits=True))
+    assert_raises(TypeError, lambda: derive_seed(True, "scope"))
+
+
+def main():
+    test_golden_vectors()
+    test_namespace_and_type_boundaries()
+    test_rng_reproducibility()
+    test_invalid_inputs()
+    print("fingerprint seed helper checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/patches/launch-options-seed.py
+++ b/tests/patches/launch-options-seed.py
@@ -9,7 +9,9 @@ Or with pytest:
 """
 
 import json
+from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
+from tempfile import TemporaryDirectory
 
 from camoufox import utils
 from camoufox.fingerprints import from_browserforge, generate_fingerprint
@@ -119,12 +121,28 @@ def test_seeded_browserforge_is_stable_with_concurrent_unseeded_calls():
     assert all(result == expected for result in seeded_results)
 
 
+def test_load_properties_supports_macos_app_bundle_layout():
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        exe = root / "Camoufox.app" / "Contents" / "MacOS" / "camoufox"
+        resources = root / "Camoufox.app" / "Contents" / "Resources"
+        exe.parent.mkdir(parents=True)
+        resources.mkdir(parents=True)
+        exe.write_text("")
+        (resources / "properties.json").write_text(
+            json.dumps([{"property": "navigator.userAgent", "type": "str"}])
+        )
+
+        assert utils._load_properties(exe) == {"navigator.userAgent": "str"}
+
+
 def main():
     test_same_seed_reuses_synthetic_launch_config()
     test_same_seed_reuses_preset_launch_config()
     test_different_seed_changes_noise_seeds()
     test_unseeded_launch_still_sets_nonzero_noise_seeds()
     test_seeded_browserforge_is_stable_with_concurrent_unseeded_calls()
+    test_load_properties_supports_macos_app_bundle_layout()
     print("launch options seed checks passed")
 
 

--- a/tests/patches/launch-options-seed.py
+++ b/tests/patches/launch-options-seed.py
@@ -1,0 +1,132 @@
+"""
+Verify launch_options forwards fingerprint_seed into launch-level fingerprint values.
+
+Run directly:
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib python3 tests/patches/launch-options-seed.py
+
+Or with pytest:
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib python3 -m pytest --confcutdir=tests/patches tests/patches/launch-options-seed.py
+"""
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+from camoufox import utils
+from camoufox.fingerprints import from_browserforge, generate_fingerprint
+
+
+NOISE_SEED_KEYS = (
+    "fonts:spacing_seed",
+    "audio:seed",
+    "canvas:seed",
+)
+
+
+def _config_from_env(env):
+    chunks = []
+    index = 1
+    while f"CAMOU_CONFIG_{index}" in env:
+        chunks.append(env[f"CAMOU_CONFIG_{index}"])
+        index += 1
+    return json.loads("".join(chunks))
+
+
+def _launch_config(**kwargs):
+    original_validate_config = utils.validate_config
+    original_get_screen_cons = utils.get_screen_cons
+    original_add_default_addons = utils.add_default_addons
+    original_confirm_paths = utils.confirm_paths
+
+    utils.validate_config = lambda config, path=None: None
+    utils.get_screen_cons = lambda headless=None: None
+    utils.add_default_addons = lambda addons, exclude_addons: None
+    utils.confirm_paths = lambda addons: None
+    try:
+        options = utils.launch_options(
+            env={},
+            headless=True,
+            executable_path="/tmp/camoufox",
+            ff_version=146,
+            i_know_what_im_doing=True,
+            **kwargs,
+        )
+    finally:
+        utils.validate_config = original_validate_config
+        utils.get_screen_cons = original_get_screen_cons
+        utils.add_default_addons = original_add_default_addons
+        utils.confirm_paths = original_confirm_paths
+
+    assert "fingerprint_seed" not in options
+    return _config_from_env(options["env"])
+
+
+def test_same_seed_reuses_synthetic_launch_config():
+    first = _launch_config(fingerprint_seed="profile-a")
+    second = _launch_config(fingerprint_seed="profile-a")
+    assert first == second
+
+
+def test_same_seed_reuses_preset_launch_config():
+    first = _launch_config(fingerprint_seed="profile-a", fingerprint_preset=True)
+    second = _launch_config(fingerprint_seed="profile-a", fingerprint_preset=True)
+    assert first == second
+
+
+def test_different_seed_changes_noise_seeds():
+    first = _launch_config(fingerprint_seed="profile-a")
+    second = _launch_config(fingerprint_seed="profile-b")
+    assert first["fonts:spacing_seed"] != second["fonts:spacing_seed"]
+    assert first["audio:seed"] != second["audio:seed"]
+    assert first["canvas:seed"] != second["canvas:seed"]
+
+
+def test_unseeded_launch_still_sets_nonzero_noise_seeds():
+    first = _launch_config()
+    second = _launch_config()
+    for config in (first, second):
+        for key in NOISE_SEED_KEYS:
+            assert 1 <= config[key] <= 4_294_967_295
+    assert tuple(first[key] for key in NOISE_SEED_KEYS) != tuple(
+        second[key] for key in NOISE_SEED_KEYS
+    )
+
+
+def test_seeded_browserforge_is_stable_with_concurrent_unseeded_calls():
+    expected = from_browserforge(
+        generate_fingerprint(os="macos", fingerprint_seed="profile-a"),
+        fingerprint_seed="profile-a",
+    )
+
+    def seeded_config():
+        fingerprint = generate_fingerprint(os="macos", fingerprint_seed="profile-a")
+        return from_browserforge(fingerprint, fingerprint_seed="profile-a")
+
+    def unseeded_config():
+        fingerprint = generate_fingerprint(os="macos")
+        return from_browserforge(fingerprint)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = []
+        for _ in range(20):
+            futures.append(executor.submit(seeded_config))
+            futures.append(executor.submit(unseeded_config))
+
+    results = [future.result() for future in futures]
+    seeded_results = [result for index, result in enumerate(results) if index % 2 == 0]
+    unseeded_results = [result for index, result in enumerate(results) if index % 2 == 1]
+    assert seeded_results
+    assert unseeded_results
+    assert all(result == expected for result in seeded_results)
+
+
+def main():
+    test_same_seed_reuses_synthetic_launch_config()
+    test_same_seed_reuses_preset_launch_config()
+    test_different_seed_changes_noise_seeds()
+    test_unseeded_launch_still_sets_nonzero_noise_seeds()
+    test_seeded_browserforge_is_stable_with_concurrent_unseeded_calls()
+    print("launch options seed checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/patches/live-fingerprint-seed.py
+++ b/tests/patches/live-fingerprint-seed.py
@@ -1,0 +1,169 @@
+"""
+Opt-in live browser readback for persistent fingerprint seeds.
+
+Run directly:
+    CAMOUFOX_EXECUTABLE_PATH=/path/to/camoufox \
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib \
+    python3 tests/patches/live-fingerprint-seed.py
+
+Or with pytest:
+    CAMOUFOX_EXECUTABLE_PATH=/path/to/camoufox \
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib \
+    python3 -m pytest --confcutdir=tests/patches tests/patches/live-fingerprint-seed.py
+"""
+
+import json
+import os
+from urllib.parse import quote
+
+from camoufox.sync_api import Camoufox, NewContext
+
+
+HTML = """<!doctype html><meta charset="utf-8"><pre id="out"></pre><script>
+function canvasHash() {
+  const c = document.createElement('canvas');
+  c.width = 240;
+  c.height = 80;
+  const ctx = c.getContext('2d');
+  ctx.textBaseline = 'top';
+  ctx.font = '18px Arial';
+  ctx.fillStyle = '#f60';
+  ctx.fillRect(10, 10, 100, 32);
+  ctx.fillStyle = '#069';
+  ctx.fillText('Camoufox seed test', 12, 18);
+  return c.toDataURL().slice(0, 96);
+}
+function webgl() {
+  const c = document.createElement('canvas');
+  const gl = c.getContext('webgl') || c.getContext('experimental-webgl');
+  if (!gl) return null;
+  const ext = gl.getExtension('WEBGL_debug_renderer_info');
+  return {
+    vendor: ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : gl.getParameter(gl.VENDOR),
+    renderer: ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER),
+  };
+}
+document.getElementById('out').textContent = JSON.stringify({
+  ua: navigator.userAgent,
+  platform: navigator.platform,
+  oscpu: navigator.oscpu,
+  hw: navigator.hardwareConcurrency,
+  language: navigator.language,
+  languages: navigator.languages,
+  screen: {
+    width: screen.width,
+    height: screen.height,
+    colorDepth: screen.colorDepth,
+    dpr: devicePixelRatio,
+  },
+  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  webgl: webgl(),
+  canvas: canvasHash(),
+});
+</script>"""
+
+URL = "data:text/html;charset=utf-8," + quote(HTML)
+RUNTIME_KEYS = (
+    "ua",
+    "platform",
+    "oscpu",
+    "hw",
+    "language",
+    "languages",
+    "screen",
+    "timezone",
+    "webgl",
+    "canvas",
+)
+CONTEXT_VARIANT_KEYS = ("ua", "platform", "oscpu", "hw", "screen")
+
+
+def _required_executable():
+    path = os.environ.get("CAMOUFOX_EXECUTABLE_PATH")
+    if path:
+        return path
+    try:
+        import pytest
+
+        pytest.skip("CAMOUFOX_EXECUTABLE_PATH is required for live browser checks")
+    except ImportError:
+        raise RuntimeError("CAMOUFOX_EXECUTABLE_PATH is required") from None
+
+
+def _read_page(page):
+    page.goto(URL)
+    page.wait_for_function(
+        "document.querySelector('#out').textContent.length > 0",
+        timeout=5000,
+    )
+    return json.loads(page.locator("#out").text_content(timeout=5000))
+
+
+def _read_launch(executable_path, seed):
+    with Camoufox(
+        executable_path=executable_path,
+        headless=True,
+        fingerprint_seed=seed,
+        ff_version=146,
+        i_know_what_im_doing=True,
+    ) as browser:
+        return _read_page(browser.new_page())
+
+
+def _read_context(executable_path, seed):
+    with Camoufox(
+        executable_path=executable_path,
+        headless=True,
+        fingerprint_seed="stable-parent-browser",
+        ff_version=146,
+        i_know_what_im_doing=True,
+    ) as browser:
+        context = NewContext(browser, fingerprint_seed=seed, ff_version="146")
+        try:
+            return _read_page(context.new_page())
+        finally:
+            context.close()
+
+
+def _assert_same_seed_stable(reader, executable_path):
+    first = reader(executable_path, "profile-a")
+    second = reader(executable_path, "profile-a")
+    assert {key: first[key] for key in RUNTIME_KEYS} == {
+        key: second[key] for key in RUNTIME_KEYS
+    }
+
+
+def _assert_different_seed_changes_identity(reader, executable_path, keys):
+    first = reader(executable_path, "profile-a")
+    second = reader(executable_path, "profile-b")
+    assert any(first[key] != second[key] for key in keys)
+
+
+def test_launch_seed_runtime_readback_is_stable():
+    executable_path = _required_executable()
+    _assert_same_seed_stable(_read_launch, executable_path)
+    _assert_different_seed_changes_identity(_read_launch, executable_path, RUNTIME_KEYS)
+
+
+def test_context_seed_runtime_readback_is_stable_with_seeded_parent():
+    executable_path = _required_executable()
+    _assert_same_seed_stable(_read_context, executable_path)
+    _assert_different_seed_changes_identity(
+        _read_context,
+        executable_path,
+        CONTEXT_VARIANT_KEYS,
+    )
+
+
+def main():
+    path = os.environ.get("CAMOUFOX_EXECUTABLE_PATH")
+    if not path:
+        print("skipped live seed readback checks: CAMOUFOX_EXECUTABLE_PATH is not set")
+        return
+    test_launch_seed_runtime_readback_is_stable()
+    test_context_seed_runtime_readback_is_stable_with_seeded_parent()
+    print("live seed readback checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

  Adds an optional `fingerprint_seed` parameter for Camoufox-generated
  fingerprints so callers can reproduce stable generated identity values across
  launches and browser contexts.

  Related issues/discussions:

  - Addresses #442
  - Addresses #38
  - Addresses #71
  - Addresses #328
  - Addresses #378
  - Related to discussions #263, #373, #151, and #255

  This is intentionally Python/API-level only. It does not include browser engine,
  C++, TLS, networking, or renderer-level fingerprinting changes.

  ## Motivation

  Camoufox is good at generating fresh fingerprints, but persistent profiles need
  a way to keep generated fingerprint values stable across restarts. Several users
  have reported that cookies/storage can persist while generated fingerprint
  surfaces still rotate, causing CreepJS/fingerprint IDs or browser identity
  signals to change between runs.

  `fingerprint_seed` gives callers a stable generation input while preserving the
  current random-by-default behavior when no seed is supplied.

  ## What Changed

  - Added deterministic seed derivation helpers in `pythonlib/camoufox/` & `fingerprint_seed.py`.
  - Added optional `fingerprint_seed` support to:
    - `launch_options()`
    - sync `NewContext()`
    - async `AsyncNewContext()`
    - `generate_context_fingerprint()`
    - BrowserForge generation/conversion
    - WebGL sampling
  - Supports `str`, `int`, and `bytes` seeds.
  - Rejects unsupported seed types such as `bool`.
  - Uses versioned, length-prefixed SHA-256 material to derive independent
  namespace-specific sub-seeds.
  - Keeps unseeded behavior random.
  - Ensures `fingerprint_seed` is consumed by Camoufox and not forwarded to
  Playwright.
  - Avoids unsupported context-level canvas setter calls in generated init
  scripts.
  - Adds a macOS `.app` bundle fallback for locating `properties.json`.

  ## Seeded Surfaces

  Seeded generation now covers Camoufox-owned generated values including:

  - BrowserForge sampling
  - preset selection
  - OS choice where applicable
  - WebGL sampling
  - font and voice subsets
  - screen offset sampling
  - `window.history.length`
  - audio/canvas/font spacing config seeds

  ## Compatibility / Caveats

  - Existing callers are unaffected unless they pass `fingerprint_seed`.
  - `fingerprint_seed` controls generated fingerprint values only.
  - It does not persist cookies, local storage, cache, or browser profile state.
  - Persistent state should still use a stable `user_data_dir` / persistent
  context.
  - Context-level seeds apply only to surfaces exposed by the current per-context
  init-script path.
  - This PR does not change TLS, proxy, network, or renderer-level behavior.

  ## Testing

  Regression tests added for:

  - deterministic seed derivation
  - namespace/type separation
  - invalid seed input handling
  - sync and async context API forwarding
  - deterministic launch config generation
  - deterministic context fingerprint generation
  - different seeds producing different noise values
  - unseeded launch/context paths remaining randomized
  - BrowserForge stability with concurrent seeded and unseeded calls
  - macOS app bundle `properties.json` fallback

  Local checks run:

  ```bash
  PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib python3 -m pytest
  --confcutdir=tests/patches tests/patches/fingerprint-seed.py tests/patches/
  context-api-seed.py tests/patches/context-fingerprint-seed.py tests/patches/
  launch-options-seed.py tests/patches/live-fingerprint-seed.py
```

  Result:

  18 passed, 2 skipped

  ## Dogfooding

  This branch is being dogfooded in VulpineOS for long-lived agent identities:

  - stable profile/account identifier -> fingerprint_seed
  - stable browser profile directory -> user_data_dir
  - generated Camoufox fingerprint values stay reproducible across restarts
  - cookies/storage/profile state remain handled separately by the persistent
    profile layer