### PR TITLE
fix: per-context WebGL overrides when launch parameters are set

### DIFF
--- a/patches/webgl-spoofing.patch
+++ b/patches/webgl-spoofing.patch
@@ -381,14 +381,21 @@ index 11578f425f..6c77acd7f3 100644
    }
 
    return ret;
-@@ -2114,6 +2172,57 @@ void ClientWebGLContext::GetParameter(JSContext* cx, GLenum pname,
+@@ -2114,6 +2172,64 @@ void ClientWebGLContext::GetParameter(JSContext* cx, GLenum pname,
    const auto& state = State();
 
    // -
 +  std::optional<
 +      std::variant<int64_t, bool, double, std::string, std::nullptr_t>>
 +      data;
-+  data = MaskConfig::GLParam(pname, mIsWebGL2);
++  switch (pname) {
++    case dom::WEBGL_debug_renderer_info_Binding::UNMASKED_RENDERER_WEBGL:
++    case dom::WEBGL_debug_renderer_info_Binding::UNMASKED_VENDOR_WEBGL:
++      break;
++    default:
++      data = MaskConfig::GLParam(pname, mIsWebGL2);
++      break;
++  }
 +
 +  if (data.has_value()) {
 +    const auto& value = data.value();

--- a/tests/patches/live-webgl-context.py
+++ b/tests/patches/live-webgl-context.py
@@ -154,6 +154,51 @@ def test_context_webgl_overrides_launch_config_webgl():
     }
 
 
+def test_context_webgl_overrides_launch_parameter_webgl():
+    executable_path = _required_executable()
+    parent_vendor = "Vulpine Parent Parameter Vendor"
+    parent_renderer = "Vulpine Parent Parameter Renderer"
+    context_vendor = "Vulpine Context Parameter Vendor"
+    context_renderer = "Vulpine Context Parameter Renderer"
+
+    env = {
+        **os.environ,
+        **get_env_vars(
+            {
+                "webGl:vendor": parent_vendor,
+                "webGl:renderer": parent_renderer,
+                "webGl:parameters": {
+                    "37445": parent_vendor,
+                    "37446": parent_renderer,
+                },
+            },
+            "mac",
+        ),
+    }
+    with sync_playwright() as playwright:
+        browser = playwright.firefox.launch(
+            executable_path=executable_path,
+            headless=True,
+            env=env,
+            firefox_user_prefs={
+                "webgl.force-enabled": True,
+            },
+        )
+        try:
+            context_result = _read_context(
+                browser,
+                context_vendor,
+                context_renderer,
+            )
+        finally:
+            browser.close()
+
+    assert context_result["webgl"] == {
+        "vendor": context_vendor,
+        "renderer": context_renderer,
+    }
+
+
 def _preset(vendor, renderer, platform="Win32", cores=8):
     return {
         "navigator": {
@@ -225,6 +270,7 @@ def test_new_context_applies_preset_webgl_vendor_renderer():
 def main():
     test_context_webgl_vendor_renderer_are_isolated_and_reusable()
     test_context_webgl_overrides_launch_config_webgl()
+    test_context_webgl_overrides_launch_parameter_webgl()
     test_new_context_applies_preset_webgl_vendor_renderer()
     print("live per-context WebGL checks passed")
 

--- a/tests/patches/live-webgl-context.py
+++ b/tests/patches/live-webgl-context.py
@@ -1,0 +1,233 @@
+"""
+Opt-in live browser readback for per-context WebGL spoofing.
+
+Run directly:
+    CAMOUFOX_EXECUTABLE_PATH=/path/to/camoufox \
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib \
+    python3 tests/patches/live-webgl-context.py
+
+Or with pytest:
+    CAMOUFOX_EXECUTABLE_PATH=/path/to/camoufox \
+    PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=pythonlib \
+    python3 -m pytest --confcutdir=tests/patches tests/patches/live-webgl-context.py
+"""
+
+import json
+import os
+from urllib.parse import quote
+
+from camoufox.sync_api import NewContext
+from camoufox.utils import get_env_vars
+from playwright.sync_api import sync_playwright
+
+
+HTML = """<!doctype html><meta charset="utf-8"><pre id="out"></pre><script>
+function readWebGL() {
+  const c = document.createElement('canvas');
+  const gl = c.getContext('webgl') || c.getContext('experimental-webgl');
+  if (!gl) return null;
+  const ext = gl.getExtension('WEBGL_debug_renderer_info');
+  if (!ext) return null;
+  return {
+    vendor: gl.getParameter(ext.UNMASKED_VENDOR_WEBGL),
+    renderer: gl.getParameter(ext.UNMASKED_RENDERER_WEBGL),
+  };
+}
+document.getElementById('out').textContent = JSON.stringify({
+  setters: [typeof window.setWebGLVendor, typeof window.setWebGLRenderer],
+  webgl: readWebGL(),
+});
+</script>"""
+
+URL = "data:text/html;charset=utf-8," + quote(HTML)
+
+
+def _required_executable():
+    path = os.environ.get("CAMOUFOX_EXECUTABLE_PATH")
+    if path:
+        return path
+    try:
+        import pytest
+
+        pytest.skip("CAMOUFOX_EXECUTABLE_PATH is required for live browser checks")
+    except ImportError:
+        raise RuntimeError("CAMOUFOX_EXECUTABLE_PATH is required") from None
+
+
+def _read_page(page):
+    page.goto(URL)
+    page.wait_for_function(
+        "document.querySelector('#out').textContent.length > 0",
+        timeout=5000,
+    )
+    return json.loads(page.locator("#out").text_content(timeout=5000))
+
+
+def _read_context(browser, vendor, renderer):
+    context = browser.new_context()
+    context.add_init_script(
+        f"""(() => {{
+          if (typeof window.setWebGLVendor === "function") {{
+            window.setWebGLVendor({json.dumps(vendor)});
+          }}
+          if (typeof window.setWebGLRenderer === "function") {{
+            window.setWebGLRenderer({json.dumps(renderer)});
+          }}
+        }})()"""
+    )
+    try:
+        page = context.new_page()
+        try:
+            return _read_page(page)
+        finally:
+            page.close()
+    finally:
+        context.close()
+
+
+def test_context_webgl_vendor_renderer_are_isolated_and_reusable():
+    executable_path = _required_executable()
+    vendor_a = "Vulpine Test Vendor A"
+    renderer_a = "Vulpine Test Renderer A"
+    vendor_b = "Vulpine Test Vendor B"
+    renderer_b = "Vulpine Test Renderer B"
+
+    with sync_playwright() as playwright:
+        browser = playwright.firefox.launch(
+            executable_path=executable_path,
+            headless=True,
+            firefox_user_prefs={
+                "webgl.force-enabled": True,
+            },
+        )
+        try:
+            first_a = _read_context(browser, vendor_a, renderer_a)
+            first_b = _read_context(browser, vendor_b, renderer_b)
+            second_a = _read_context(browser, vendor_a, renderer_a)
+        finally:
+            browser.close()
+
+    assert first_a["webgl"] == {"vendor": vendor_a, "renderer": renderer_a}
+    assert first_b["webgl"] == {"vendor": vendor_b, "renderer": renderer_b}
+    assert second_a["webgl"] == {"vendor": vendor_a, "renderer": renderer_a}
+    assert first_a["webgl"] != first_b["webgl"]
+
+
+def test_context_webgl_overrides_launch_config_webgl():
+    executable_path = _required_executable()
+    parent_vendor = "Vulpine Parent Vendor"
+    parent_renderer = "Vulpine Parent Renderer"
+    context_vendor = "Vulpine Context Vendor"
+    context_renderer = "Vulpine Context Renderer"
+
+    env = {
+        **os.environ,
+        **get_env_vars(
+            {
+                "webGl:vendor": parent_vendor,
+                "webGl:renderer": parent_renderer,
+            },
+            "mac",
+        ),
+    }
+    with sync_playwright() as playwright:
+        browser = playwright.firefox.launch(
+            executable_path=executable_path,
+            headless=True,
+            env=env,
+            firefox_user_prefs={
+                "webgl.force-enabled": True,
+            },
+        )
+        try:
+            context_result = _read_context(
+                browser,
+                context_vendor,
+                context_renderer,
+            )
+        finally:
+            browser.close()
+
+    assert context_result["webgl"] == {
+        "vendor": context_vendor,
+        "renderer": context_renderer,
+    }
+
+
+def _preset(vendor, renderer, platform="Win32", cores=8):
+    return {
+        "navigator": {
+            "userAgent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:146.0) "
+                "Gecko/20100101 Firefox/146.0"
+            ),
+            "platform": platform,
+            "hardwareConcurrency": cores,
+            "oscpu": "Windows NT 10.0; Win64; x64",
+            "maxTouchPoints": 0,
+        },
+        "screen": {
+            "width": 1366,
+            "height": 768,
+            "colorDepth": 24,
+            "availWidth": 1366,
+            "availHeight": 728,
+        },
+        "webgl": {
+            "unmaskedVendor": vendor,
+            "unmaskedRenderer": renderer,
+        },
+        "fonts": ["Arial", "Segoe UI"],
+        "speechVoices": ["Microsoft David"],
+    }
+
+
+def _read_new_context(browser, vendor, renderer):
+    context = NewContext(browser, preset=_preset(vendor, renderer), ff_version="146")
+    try:
+        page = context.new_page()
+        try:
+            return _read_page(page)
+        finally:
+            page.close()
+    finally:
+        context.close()
+
+
+def test_new_context_applies_preset_webgl_vendor_renderer():
+    executable_path = _required_executable()
+    vendor_a = "Vulpine Preset Vendor A"
+    renderer_a = "Vulpine Preset Renderer A"
+    vendor_b = "Vulpine Preset Vendor B"
+    renderer_b = "Vulpine Preset Renderer B"
+
+    with sync_playwright() as playwright:
+        browser = playwright.firefox.launch(
+            executable_path=executable_path,
+            headless=True,
+            firefox_user_prefs={
+                "webgl.force-enabled": True,
+            },
+        )
+        try:
+            first_a = _read_new_context(browser, vendor_a, renderer_a)
+            first_b = _read_new_context(browser, vendor_b, renderer_b)
+            second_a = _read_new_context(browser, vendor_a, renderer_a)
+        finally:
+            browser.close()
+
+    assert first_a["webgl"] == {"vendor": vendor_a, "renderer": renderer_a}
+    assert first_b["webgl"] == {"vendor": vendor_b, "renderer": renderer_b}
+    assert second_a["webgl"] == {"vendor": vendor_a, "renderer": renderer_a}
+    assert first_a["webgl"] != first_b["webgl"]
+
+
+def main():
+    test_context_webgl_vendor_renderer_are_isolated_and_reusable()
+    test_context_webgl_overrides_launch_config_webgl()
+    test_new_context_applies_preset_webgl_vendor_renderer()
+    print("live per-context WebGL checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

  Fixes a WebGL spoofing precedence issue where launch-level `webGl:parameters`
  entries for `UNMASKED_VENDOR_WEBGL` and `UNMASKED_RENDERER_WEBGL` could override
  per-context WebGL vendor/renderer values.

  The affected WebGL constants are:

  - `37445` / `UNMASKED_VENDOR_WEBGL`
  - `37446` / `UNMASKED_RENDERER_WEBGL`

  Previously, `ClientWebGLContext::GetParameter()` checked the generic
  `MaskConfig::GLParam()` path before the existing per-context
  `WebGLParamsManager` path. If the launch fingerprint included
  `webGl:parameters["37445"]` or `webGl:parameters["37446"]`, those global values
  won even when a context had its own WebGL vendor/renderer configured.

  This change skips the generic parameter lookup for those two debug-renderer
  constants so the existing order is preserved:

  1. Require `WEBGL_debug_renderer_info` to be enabled.
  2. Use per-context WebGL vendor/renderer when present.
  3. Fall back to global `webGl:vendor` / `webGl:renderer`.

  ## Testing

  - Separate contexts can report separate WebGL vendor/renderer values.
  - Per-context WebGL overrides launch-level `webGl:vendor` / `webGl:renderer`.
  - Per-context WebGL overrides launch-level `webGl:parameters["37445"]` /
  `["37446"]`.
  - `NewContext` presets apply WebGL vendor/renderer values.

  Verified locally against a rebuilt Camoufox binary:

  ```text
  tests/patches/live-webgl-
  context.py::test_context_webgl_vendor_renderer_are_isolated_and_reusable PASSED
  tests/patches/live-webgl-
  context.py::test_context_webgl_overrides_launch_config_webgl PASSED
  tests/patches/live-webgl-
  context.py::test_context_webgl_overrides_launch_parameter_webgl PASSED
  tests/patches/live-webgl-
  context.py::test_new_context_applies_preset_webgl_vendor_renderer PASSED
```
  4 passed

  Also verified manually with CreepJS:

  - CreepJS saw the context-specific WebGL vendor/renderer.
  - CreepJS did not show the conflicting parent/global launch values.
  - Two separate contexts reported separate WebGL GPU identities.
 
+ Validated with [VulpineOS](https://github.com/VulpineOS/VulpineOS) against a rebuilt local Camoufox binary to cover the browser-agent runtime case: multiple isolated contexts in one launched browser process, each with its own WebGL vendor/renderer. CreepJS observed the context-specific GPU values and did not show the conflicting launch-level `webGl:parameters["37445"]` / `["37446"]` values. 