### PR TITLE
docs: fix typo in README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Camoufox is an open source browser built for AI agents. It is lightweight, mimic
 ---
 
 > [!NOTE]
-> **All of the latest documentation is avaliable at [camoufox.com](https://camoufox.com).**
+> **All of the latest documentation is available at [camoufox.com](https://camoufox.com).**
 
 > [!NOTE]
 > Browser development is active at [github.com/CloverLabsAI/camoufox](https://github.com/CloverLabsAI/camoufox) and [github.com/VulpineOS/VulpineOS](https://github.com/VulpineOS/VulpineOS).<br>This repo is being used to merge checkpoint releases and should be used as the source of truth.


### PR DESCRIPTION
Fixes a small typo in the README note by changing `avaliable` to `available`.