### PR TITLE
fix(virtdisplay): wait() Xvfb child process to prevent zombie process

### DIFF
--- a/pythonlib/camoufox/virtdisplay.py
+++ b/pythonlib/camoufox/virtdisplay.py
@@ -116,6 +116,13 @@ class VirtualDisplay:
             if self.debug:
                 print("Terminating virtual display:", self._display)
             self.proc.terminate()
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                if self.debug:
+                    print("Xvfb did not exit in time, killing forcefully")
+                self.proc.kill()
+                self.proc.wait()
 
     @staticmethod
     def _assert_linux() -> None:


### PR DESCRIPTION
## Related Issue

None.

## Description

Currently, `wait()` is not called for Xvfb subprocess, causing accumulation of defunct processes. This patch fixed this behavior.
<img width="1375" height="185" alt="image" src="https://github.com/user-attachments/assets/f6783761-75d2-42dd-8962-84ebd45fe238" />

Reproduce steps:
1. Run the following code on Linux:
```python
from camoufox.sync_api import Camoufox
with Camoufox(headless="virtual") as browser:
    pass

input()
```
2. Before the Python process exit, run `ps aux | grep Xvfb` in another terminal.
3. Before the fix: Observed `[Xvfb] <defunct>`.
4. After the fix: No defunct process.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

Run the patched version locally.

## Fingerprint Report

N/A

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [x] ~~Service tests pass (for python library changes) -`./service-tester/run_tests.sh --browser-version official/prerelease/146.0.1-alpha.25` (attach screenshot)~~ temporarily out of service lol
- [x] Build test passes (for patch changes) - `./build-tester/run_tests.sh` A score of at least 1000 must be achieved (attach screenshot)
