### PR TITLE
fix(juggler): emit location on uncaughtError for playwright 1.60

### DIFF
--- a/additions/juggler/content/PageAgent.js
+++ b/additions/juggler/content/PageAgent.js
@@ -126,7 +126,7 @@ export class PageAgent {
         }
       }),
       helper.addObserver(this._onWindowOpen.bind(this), 'webNavigation-createdNavigationTarget-from-js'),
-      this._runtime.events.onErrorFromWorker((domWindow, message, stack) => {
+      this._runtime.events.onErrorFromWorker((domWindow, message, stack, location) => {
         const frame = this._frameTree.frameForDocShell(domWindow.docShell);
         if (!frame)
           return;
@@ -134,6 +134,7 @@ export class PageAgent {
           frameId: frame.id(),
           message,
           stack,
+          location,
         });
       }),
       this._runtime.events.onConsoleMessage(msg => this._browserPage.emit('runtimeConsole', msg)),
@@ -263,11 +264,12 @@ export class PageAgent {
     });
   }
 
-  _onRuntimeError({ executionContext, message, stack }) {
+  _onRuntimeError({ executionContext, message, stack, location }) {
     this._browserPage.emit('pageUncaughtError', {
       frameId: executionContext.auxData().frameId,
       message: message.toString(),
       stack: stack.toString(),
+      location,
     });
   }
 

--- a/additions/juggler/content/Runtime.js
+++ b/additions/juggler/content/Runtime.js
@@ -133,8 +133,13 @@ class Runtime {
           return;
         }
         const errorWindow = Services.wm.getOuterWindowWithId(message.outerWindowID);
+        const errorLocation = {
+          lineNumber: message.lineNumber - 1,
+          columnNumber: message.columnNumber - 1,
+          url: message.sourceName,
+        };
         if (message.category === 'Web Worker' && message.logLevel === Ci.nsIConsoleMessage.error) {
-          emitEvent(this.events.onErrorFromWorker, errorWindow, message.message, '' + message.stack);
+          emitEvent(this.events.onErrorFromWorker, errorWindow, message.message, '' + message.stack, errorLocation);
           return;
         }
         const executionContext = this._windowToExecutionContext.get(errorWindow);
@@ -164,7 +169,8 @@ class Runtime {
           emitEvent(this.events.onRuntimeError, {
             executionContext,
             message: message.errorMessage,
-            stack: message.stack.toString(),
+            stack: message.stack ? message.stack.toString() : '',
+            location: errorLocation,
           });
         }
       },

--- a/additions/juggler/protocol/Protocol.js
+++ b/additions/juggler/protocol/Protocol.js
@@ -673,6 +673,7 @@ const Page = {
       frameId: t.String,
       message: t.String,
       stack: t.String,
+      location: runtimeTypes.ScriptLocation,
     },
     'frameAttached': {
       frameId: t.String,


### PR DESCRIPTION
## Related Issue

Closes #617

## Description

Playwright 1.60's dispatcher reads `pageError.location.url` unconditionally ([microsoft/playwright#39767](https://github.com/microsoft/playwright/pull/39767)), which crashes the driver subprocess (`TypeError: Cannot read properties of undefined (reading 'url')`) whenever the juggler emits a `Page.uncaughtError` event without a `location` field. Camoufox's juggler fork had dropped `location` from the uncaughtError emit path — upstream Playwright's juggler still emits it.

This PR mirrors upstream's behavior by forwarding the script location through the runtime event, the PageAgent emit, and the protocol schema:

- `additions/juggler/content/Runtime.js` — build `errorLocation` from `message.lineNumber/columnNumber/sourceName` (one-based → zero-based, matching the upstream comment), pass it as the 5th arg to `onErrorFromWorker`, include it in the `onRuntimeError` payload. Also guards `message.stack` with an existence check to match upstream behavior (previously could crash on `undefined.toString()`).
- `additions/juggler/content/PageAgent.js` — destructure `location` in both the `onErrorFromWorker` callback signature and `_onRuntimeError`, forward it in both `pageUncaughtError` emits.
- `additions/juggler/protocol/Protocol.js` — add `location: runtimeTypes.ScriptLocation` to the `uncaughtError` event schema so the protocol validator doesn't strip it.

Three files, +13 / -4. No version pin needed — Playwright <1.60 ignores the extra `location` field; Playwright >=1.60 requires it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

Reproduced the exact issue #617 stack trace against an **unpatched** v135.0.1-beta.24 binary, then ran the same script against a copy of the binary with `omni.ja` repacked to include the patched juggler files. Repro:

```python
import asyncio
from playwright.async_api import async_playwright

THROW_PAGE = "data:text/html,<html><body><script>throw new Error('boom');</script></body></html>"

async def main():
    async with async_playwright() as pw:
        browser = await pw.firefox.launch(executable_path="<camoufox-bin>", headless=True)
        context = await browser.new_context()
        page = await context.new_page()
        page.on("pageerror", lambda e: print(f"pageerror: {e}"))
        await page.goto(THROW_PAGE, wait_until="load", timeout=15_000)
        await asyncio.sleep(0.5)
        await browser.close()

asyncio.run(main())
```

**Unpatched (current camoufox):**
```
TypeError: Cannot read properties of undefined (reading 'url')
    at FFBrowserContext.<anonymous> (.../coreBundle.js:49624:39)
    ...
RESULT: exception: Browser.close: Connection closed while reading from the driver
```

**Patched (this PR):**
```
pageerror: boom
RESULT: clean exit, pageerror_count=1
```

Node `--check` passes for all three patched files. The fix is entirely orthogonal to fingerprinting — it touches only the error-reporting / protocol-event path.

## Fingerprint Report

<details>
<summary>Fingerprint report</summary>

Build-tester was not run for this PR. This fix touches only juggler error-reporting (`Page.uncaughtError` protocol event); no fingerprinting, canvas, WebGL, audio, font, WebRTC, or any other detection-surface code is modified. Fingerprint scores produced by build-tester are determined entirely by the underlying release tag (v150.0.2-beta.25) and would be identical to whatever has already been scored for that tag.

Happy to attach a screenshot if maintainers want one — I can build locally and run it on request. Skipped here to keep this PR minimal and unblock #617 reporters quickly.

</details>

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass (for python library changes) -`./service-tester/run_tests.sh --browser-version official/prerelease/146.0.1-alpha.25` (attach screenshot)~~ temporarily out of service lol
- [ ] Build test passes (for patch changes) - `./build-tester/run_tests.sh` A score of at least 1000 must be achieved (attach screenshot) — *see note in Fingerprint Report; happy to run on request*