### PR TITLE
Fix fontconfig path typo

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -103,14 +103,14 @@ def get_env_vars(
     if OS_NAME == 'lin':
         # https://github.com/coryking/camoufox/commit/f21eeb2850a74cc104fb57e17e0a2fa27b7a2a28
         # Thanks @coryking
-        # the user_agent_os is either 'lin', 'mac', or 'win' but our fontconfigs directory is 'linux', 'macos', or 'windows'
+        # the user_agent_os is either 'lin', 'mac', or 'win' but our fontconfig directory is 'linux', 'macos', or 'windows'
         directory_map = {
             'lin': 'linux',
             'mac': 'macos',
             'win': 'windows',
         }
         os_dir = directory_map.get(user_agent_os, user_agent_os)
-        fontconfig_path = get_path(os.path.join("fontconfigs", os_dir))
+        fontconfig_path = get_path(os.path.join("fontconfig", os_dir))
 
         # assert that fonts.conf exists in the directory
         if not os.path.exists(os.path.join(fontconfig_path, "fonts.conf")):


### PR DESCRIPTION
Fixes #602. The filesystem path inside the cache directory uses `fontconfig` instead of `fontconfigs`, which was causing a `FileNotFoundError` on Ubuntu virtual environments when trying to load `fonts.conf`.