### PR TITLE
fix(proxy): re-enable launch-arg proxy by disabling https_first

### DIFF
--- a/settings/camoufox.cfg
+++ b/settings/camoufox.cfg
@@ -762,3 +762,9 @@ defaultPref("browser.translations.enable", false);
 
 // Disable spell check
 defaultPref("layout.spellcheckDefault", 0);
+
+// Camoufox: Disable HTTPS-First so plain http:// requests aren't rewritten
+// to https:// before the launch-arg proxy filter sees them. With https_first
+// enabled (Firefox 146 default), simple HTTP proxies (CONNECT-only) like the
+// Playwright test fixture break. Stock Playwright Firefox builds disable this.
+defaultPref("dom.security.https_first", false);


### PR DESCRIPTION
Firefox 146 enables dom.security.https_first by default, which rewrites
plain http:// requests to https:// before the launch-arg proxy filter
sees them. Simple CONNECT-only HTTP proxies (like the Playwright test
fixture) then break. Stock Playwright Firefox builds disable this pref;
do the same in camoufox.cfg.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>