### PR TITLE
fix(stealth): make MaskConfig the single source for screen/device dims

### DIFF
--- a/patches/screen-spoofing.patch
+++ b/patches/screen-spoofing.patch
@@ -1,354 +1,28 @@
-diff --git a/dom/base/ScreenDimensionManager.cpp b/dom/base/ScreenDimensionManager.cpp
-new file mode 100644
-index 0000000000..f5d2c23df5
---- /dev/null
-+++ b/dom/base/ScreenDimensionManager.cpp
-@@ -0,0 +1,104 @@
-+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
-+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
-+/* This Source Code Form is subject to the terms of the Mozilla Public
-+ * License, v. 2.0. If a copy of the MPL was not distributed with this
-+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-+
-+#include "ScreenDimensionManager.h"
-+#include "RoverfoxStorageManager.h"
-+#include "nsGlobalWindowInner.h"
-+#include "xpcpublic.h"
-+#include "mozilla/dom/BrowsingContext.h"
-+#include "mozilla/dom/Document.h"
-+#include "nsDocShell.h"
-+
-+namespace mozilla {
-+namespace dom {
-+
-+/* static */ uint32_t
-+ScreenDimensionManager::GetUserContextIdFromWindow(nsGlobalWindowInner* aWindow) {
-+  if (!aWindow) {
-+    return 0;
-+  }
-+  uint32_t userContextId = 0;
-+  if (BrowsingContext* bc = aWindow->GetBrowsingContext()) {
-+    userContextId = bc->OriginAttributesRef().mUserContextId;
-+  }
-+  return userContextId;
-+}
-+
-+/* static */ void
-+ScreenDimensionManager::SetDimensions(uint32_t aUserContextId, int32_t aWidth, int32_t aHeight) {
-+  nsString widthKey, heightKey;
-+  widthKey.AppendPrintf("screenWidth_%u", aUserContextId);
-+  heightKey.AppendPrintf("screenHeight_%u", aUserContextId);
-+  RoverfoxStorageManager::PutUint(widthKey, static_cast<uint32_t>(aWidth));
-+  RoverfoxStorageManager::PutUint(heightKey, static_cast<uint32_t>(aHeight));
-+}
-+
-+/* static */ bool
-+ScreenDimensionManager::GetDimensions(uint32_t aUserContextId, int32_t* aWidth, int32_t* aHeight) {
-+  nsString widthKey, heightKey;
-+  widthKey.AppendPrintf("screenWidth_%u", aUserContextId);
-+  heightKey.AppendPrintf("screenHeight_%u", aUserContextId);
-+
-+  uint32_t width = 0, height = 0;
-+  RoverfoxStorageManager::GetUint(widthKey, width);
-+  RoverfoxStorageManager::GetUint(heightKey, height);
-+
-+  if (width > 0 && height > 0) {
-+    *aWidth = static_cast<int32_t>(width);
-+    *aHeight = static_cast<int32_t>(height);
-+    return true;
-+  }
-+  return false;
-+}
-+
-+/* static */ void
-+ScreenDimensionManager::SetColorDepth(uint32_t aUserContextId, int32_t aColorDepth) {
-+  nsString key;
-+  key.AppendPrintf("screenColorDepth_%u", aUserContextId);
-+  RoverfoxStorageManager::PutUint(key, static_cast<uint32_t>(aColorDepth));
-+}
-+
-+/* static */ int32_t
-+ScreenDimensionManager::GetColorDepth(uint32_t aUserContextId) {
-+  nsString key;
-+  key.AppendPrintf("screenColorDepth_%u", aUserContextId);
-+  uint32_t depth = 0;
-+  RoverfoxStorageManager::GetUint(key, depth);
-+  return static_cast<int32_t>(depth);
-+}
-+
-+/* static */ nsString
-+ScreenDimensionManager::DisabledKeyForUserContext(uint32_t userContextId) {
-+  nsString key;
-+  key.AppendPrintf("screen_disabled_%u", userContextId);
-+  return key;
-+}
-+
-+/* static */ void
-+ScreenDimensionManager::DisableFunction(uint32_t userContextId) {
-+  nsString key = DisabledKeyForUserContext(userContextId);
-+  RoverfoxStorageManager::PutBool(key, true);
-+}
-+
-+/* static */ bool
-+ScreenDimensionManager::IsFunctionEnabledForWebIDL(JSContext* aCx, JSObject* aObj) {
-+  nsGlobalWindowInner* win = xpc::WindowOrNull(aObj);
-+  if (!win) {
-+    return false;
-+  }
-+
-+  uint32_t userContextId = 0;
-+  if (BrowsingContext* bc = win->GetBrowsingContext()) {
-+    userContextId = bc->OriginAttributesRef().mUserContextId;
-+  }
-+
-+  bool disabled = false;
-+  RoverfoxStorageManager::GetBool(DisabledKeyForUserContext(userContextId), disabled);
-+  return !disabled;
-+}
-+
-+}  // namespace dom
-+}  // namespace mozilla
-diff --git a/dom/base/ScreenDimensionManager.h b/dom/base/ScreenDimensionManager.h
-new file mode 100644
-index 0000000000..329f709a60
---- /dev/null
-+++ b/dom/base/ScreenDimensionManager.h
-@@ -0,0 +1,47 @@
-+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
-+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
-+/* This Source Code Form is subject to the terms of the Mozilla Public
-+ * License, v. 2.0. If a copy of the MPL was not distributed with this
-+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-+
-+#ifndef mozilla_dom_ScreenDimensionManager_h
-+#define mozilla_dom_ScreenDimensionManager_h
-+
-+#include "nsString.h"
-+
-+// Forward declarations for WebIDL binding (avoid js/TypeDecls.h namespace pollution)
-+struct JSContext;
-+class JSObject;
-+
-+class nsGlobalWindowInner;
-+
-+namespace mozilla {
-+namespace dom {
-+
-+class ScreenDimensionManager {
-+ public:
-+  // Get userContextId from window for storage key
-+  static uint32_t GetUserContextIdFromWindow(nsGlobalWindowInner* aWindow);
-+
-+  // Set/get screen dimensions for a user context
-+  static void SetDimensions(uint32_t aUserContextId, int32_t aWidth, int32_t aHeight);
-+  static bool GetDimensions(uint32_t aUserContextId, int32_t* aWidth, int32_t* aHeight);
-+
-+  // Set/get color depth for a user context
-+  static void SetColorDepth(uint32_t aUserContextId, int32_t aColorDepth);
-+  static int32_t GetColorDepth(uint32_t aUserContextId);
-+
-+  // Self-destruct support
-+  static void DisableFunction(uint32_t userContextId);
-+
-+  // WebIDL exposure check
-+  static bool IsFunctionEnabledForWebIDL(JSContext* aCx, JSObject* aObj);
-+
-+ private:
-+  static nsString DisabledKeyForUserContext(uint32_t userContextId);
-+};
-+
-+}  // namespace dom
-+}  // namespace mozilla
-+
-+#endif  // mozilla_dom_ScreenDimensionManager_h
-diff --git a/dom/base/moz.build b/dom/base/moz.build
-index 39952f9af8..c471c97936 100644
---- a/dom/base/moz.build
-+++ b/dom/base/moz.build
-@@ -260,6 +260,7 @@ EXPORTS.mozilla.dom += [
-     "ResponsiveImageSelector.h",
-     "RoverfoxStorageManager.h",
-     "SameProcessMessageQueue.h",
-+    "ScreenDimensionManager.h",
-     "ScreenLuminance.h",
-     "ScreenOrientation.h",
-     "Selection.h",
-@@ -471,6 +472,7 @@ UNIFIED_SOURCES += [
-     "ResponsiveImageSelector.cpp",
-     "RoverfoxStorageManager.cpp",
-     "SameProcessMessageQueue.cpp",
-+    "ScreenDimensionManager.cpp",
-     "ScreenLuminance.cpp",
-     "ScreenOrientation.cpp",
-     "ScriptableContentIterator.cpp",
-diff --git a/dom/base/nsGlobalWindowInner.cpp b/dom/base/nsGlobalWindowInner.cpp
-index a72b2b478a..babefb850c 100644
---- a/dom/base/nsGlobalWindowInner.cpp
-+++ b/dom/base/nsGlobalWindowInner.cpp
-@@ -286,6 +286,7 @@
- #include "nsISizeOfEventTarget.h"
- #include "nsISlowScriptDebug.h"
- #include "nsISupportsUtils.h"
-+#include "ScreenDimensionManager.h"
- #include "nsIThread.h"
- #include "nsITimedChannel.h"
- #include "nsIURI.h"
-@@ -7706,6 +7707,52 @@ nsISerialEventTarget* nsGlobalWindowInner::SerialEventTarget() const {
-   return GetMainThreadSerialEventTarget();
- }
- 
-+void nsGlobalWindowInner::SetScreenDimensions(int32_t aWidth, int32_t aHeight,
-+                                              ErrorResult& aRv) {
-+  uint32_t userContextId = ScreenDimensionManager::GetUserContextIdFromWindow(this);
-+
-+  if (aWidth <= 0 || aHeight <= 0) {
-+    aRv.ThrowTypeError("Screen dimensions must be positive integers");
-+    return;
-+  }
-+
-+  ScreenDimensionManager::SetDimensions(userContextId, aWidth, aHeight);
-+  ScreenDimensionManager::DisableFunction(userContextId);
-+
-+  // Self-destruct: set to undefined first to bust IC/shape caches on ARM64.
-+  if (JSContext* cx = nsContentUtils::GetCurrentJSContext()) {
-+    JS::Rooted<JSObject*> global(cx, JS::CurrentGlobalOrNull(cx));
-+    if (global) {
-+      JS::Rooted<JS::Value> undef(cx, JS::UndefinedValue());
-+      JS_SetProperty(cx, global, "setScreenDimensions", undef);
-+      JS_DeleteProperty(cx, global, "setScreenDimensions");
-+    }
-+  }
-+}
-+
-+void nsGlobalWindowInner::SetScreenColorDepth(int32_t aColorDepth,
-+                                              ErrorResult& aRv) {
-+  uint32_t userContextId = ScreenDimensionManager::GetUserContextIdFromWindow(this);
-+
-+  if (aColorDepth <= 0) {
-+    aRv.ThrowTypeError("Color depth must be a positive integer");
-+    return;
-+  }
-+
-+  ScreenDimensionManager::SetColorDepth(userContextId, aColorDepth);
-+  ScreenDimensionManager::DisableFunction(userContextId);
-+
-+  // Self-destruct: set to undefined first to bust IC/shape caches on ARM64.
-+  if (JSContext* cx = nsContentUtils::GetCurrentJSContext()) {
-+    JS::Rooted<JSObject*> global(cx, JS::CurrentGlobalOrNull(cx));
-+    if (global) {
-+      JS::Rooted<JS::Value> undef(cx, JS::UndefinedValue());
-+      JS_SetProperty(cx, global, "setScreenColorDepth", undef);
-+      JS_DeleteProperty(cx, global, "setScreenColorDepth");
-+    }
-+  }
-+}
-+
- Worklet* nsGlobalWindowInner::GetPaintWorklet(ErrorResult& aRv) {
-   if (!mPaintWorklet) {
-     nsIPrincipal* principal = GetPrincipal();
-diff --git a/dom/base/nsGlobalWindowInner.h b/dom/base/nsGlobalWindowInner.h
-index 9f1ce33fdc..42584898fa 100644
---- a/dom/base/nsGlobalWindowInner.h
-+++ b/dom/base/nsGlobalWindowInner.h
-@@ -677,6 +677,10 @@ class nsGlobalWindowInner final : public mozilla::dom::EventTarget,
-   // Audio fingerprint seed for per-context audio fingerprinting
-   void SetAudioFingerprintSeed(uint32_t seed, mozilla::ErrorResult& aRv);
- 
-+  // Screen dimension methods for per-context screen spoofing
-+  void SetScreenDimensions(int32_t aWidth, int32_t aHeight, mozilla::ErrorResult& aRv);
-+  void SetScreenColorDepth(int32_t aColorDepth, mozilla::ErrorResult& aRv);
-+
-   void GetWebExposedLocales(nsTArray<nsString>& aLocales);
- 
-   mozilla::dom::IntlUtils* GetIntlUtils(mozilla::ErrorResult& aRv);
 diff --git a/dom/base/nsScreen.cpp b/dom/base/nsScreen.cpp
-index 8ebb3e575a..f157ff7da8 100644
+index 8ebb3e575a..2dc4dc6b21 100644
 --- a/dom/base/nsScreen.cpp
 +++ b/dom/base/nsScreen.cpp
-@@ -12,6 +12,8 @@
- #include "mozilla/dom/DocumentInlines.h"
- #include "mozilla/widget/ScreenManager.h"
- #include "nsCOMPtr.h"
-+#include "ScreenDimensionManager.h"
-+#include "nsContentUtils.h"
- #include "nsDeviceContext.h"
- #include "nsGlobalWindowInner.h"
- #include "nsGlobalWindowOuter.h"
-@@ -73,6 +75,26 @@ nsDeviceContext* nsScreen::GetDeviceContext() const {
+@@ -73,6 +73,12 @@ nsDeviceContext* nsScreen::GetDeviceContext() const {
  }
  
  CSSIntRect nsScreen::GetRect() {
-+  // Check for per-context screen dimensions first
-+  if (nsPIDOMWindowOuter* outer = GetOuter()) {
-+    if (nsPIDOMWindowInner* inner = outer->GetCurrentInnerWindow()) {
-+      nsGlobalWindowInner* win = nsGlobalWindowInner::Cast(inner);
-+      if (win) {
-+        uint32_t userContextId = mozilla::dom::ScreenDimensionManager::GetUserContextIdFromWindow(win);
-+        int32_t w = 0, h = 0;
-+        if (mozilla::dom::ScreenDimensionManager::GetDimensions(userContextId, &w, &h)) {
-+          return {0, 0, w, h};
-+        }
-+      }
-+    }
-+  }
-+
-+  // Fallback to global MaskConfig override
-+  if (auto height = MaskConfig::GetInt32("screen.height"),
-+      width = MaskConfig::GetInt32("screen.width");
-+      height && width) {
++  // Camoufox: report the spoofed screen size from the injected config.
++  if (auto width = MaskConfig::GetInt32("screen.width"),
++      height = MaskConfig::GetInt32("screen.height");
++      width && height) {
 +    return {0, 0, width.value(), height.value()};
 +  }
    // Return window inner rect to prevent fingerprinting.
    if (ShouldResistFingerprinting(RFPTarget::ScreenRect)) {
      return GetTopWindowInnerRectForRFP();
-@@ -105,6 +127,24 @@ CSSIntRect nsScreen::GetRect() {
+@@ -105,6 +111,7 @@ CSSIntRect nsScreen::GetRect() {
  }
  
  CSSIntRect nsScreen::GetAvailRect() {
-+  // Check for per-context screen avail dimensions first
-+  if (nsPIDOMWindowOuter* outer = GetOuter()) {
-+    if (nsPIDOMWindowInner* inner = outer->GetCurrentInnerWindow()) {
-+      nsGlobalWindowInner* win = nsGlobalWindowInner::Cast(inner);
-+      if (win) {
-+        uint32_t userContextId = mozilla::dom::ScreenDimensionManager::GetUserContextIdFromWindow(win);
-+        int32_t w = 0, h = 0;
-+        if (mozilla::dom::ScreenDimensionManager::GetDimensions(userContextId, &w, &h)) {
-+          int32_t availTop = 25;
-+          if (auto top = MaskConfig::GetInt32("screen.availTop"); top.has_value()) {
-+            availTop = top.value();
-+          }
-+          return {0, availTop, w, h - availTop};
-+        }
-+      }
-+    }
-+  }
-+
++  // Camoufox: report the spoofed available screen rect from the injected config.
    auto rect = MaskConfig::GetRect("screen.availLeft", "screen.availTop",
                                    "screen.availWidth", "screen.availHeight");
    if (rect.has_value()) {
-diff --git a/dom/webidl/Window.webidl b/dom/webidl/Window.webidl
-index 1aa2baa931..4f5479fc2e 100644
---- a/dom/webidl/Window.webidl
-+++ b/dom/webidl/Window.webidl
-@@ -929,6 +929,18 @@ partial interface Window {
-   readonly attribute IntlUtils intlUtils;
- };
- 
-+// Screen dimension for per-context screen spoofing
-+partial interface Window {
-+  [Throws, Func="mozilla::dom::ScreenDimensionManager::IsFunctionEnabledForWebIDL"]
-+  undefined setScreenDimensions(long width, long height);
-+};
-+
-+// Screen color depth for per-context screen spoofing
-+partial interface Window {
-+  [Throws, Func="mozilla::dom::ScreenDimensionManager::IsFunctionEnabledForWebIDL"]
-+  undefined setScreenColorDepth(long colorDepth);
-+};
-+
- partial interface Window {
-   [SameObject, Replaceable]
-   readonly attribute VisualViewport visualViewport;
 diff --git a/gfx/src/moz.build b/gfx/src/moz.build
 index d1e1cdf387..54fbb8ad08 100644
 --- a/gfx/src/moz.build
@@ -387,34 +61,32 @@ index 06b86c6c75..9641c8457c 100644
  }
  
 diff --git a/layout/style/nsMediaFeatures.cpp b/layout/style/nsMediaFeatures.cpp
-index 07564ab15b..ae6b70f3b6 100644
+index 07564ab15b..a9015c6982 100644
 --- a/layout/style/nsMediaFeatures.cpp
 +++ b/layout/style/nsMediaFeatures.cpp
-@@ -22,6 +22,8 @@
+@@ -22,6 +22,7 @@
  #include "nsDeviceContext.h"
  #include "nsGkAtoms.h"
  #include "nsGlobalWindowOuter.h"
-+#include "nsGlobalWindowInner.h"
-+#include "mozilla/dom/ScreenDimensionManager.h"
++#include "MaskConfig.hpp"
  #include "nsIBaseWindow.h"
  #include "nsIDocShell.h"
  #include "nsIPrintSettings.h"
-@@ -62,6 +64,18 @@ static nsSize GetDeviceSize(const Document& aDocument) {
-     return GetSize(aDocument);
-   }
+@@ -58,6 +59,17 @@ static nsSize GetSize(const Document& aDocument) {
  
-+  // Camoufox: per-context screen dimensions for CSS device-width/height queries
-+  if (nsPIDOMWindowInner* inner = aDocument.GetInnerWindow()) {
-+    nsGlobalWindowInner* win = nsGlobalWindowInner::Cast(inner);
-+    if (win) {
-+      uint32_t ucid = mozilla::dom::ScreenDimensionManager::GetUserContextIdFromWindow(win);
-+      int32_t w = 0, h = 0;
-+      if (mozilla::dom::ScreenDimensionManager::GetDimensions(ucid, &w, &h)) {
-+        return CSSPixel::ToAppUnits(CSSIntSize(w, h));
-+      }
-+    }
+ // A helper for three features below.
+ static nsSize GetDeviceSize(const Document& aDocument) {
++  // Camoufox: report the spoofed screen size for CSS device-width/height so
++  // they agree with screen.width/height (nsScreen::GetRect). This must run
++  // before the RFP early-return below, since Camoufox runs with
++  // ResistFingerprinting enabled and RFPTarget::CSSDeviceSize would otherwise
++  // return the real window size -- an internal-inconsistency lie signal.
++  if (auto width = MaskConfig::GetInt32("screen.width"),
++      height = MaskConfig::GetInt32("screen.height");
++      width && height) {
++    return CSSPixel::ToAppUnits(CSSIntSize(width.value(), height.value()));
 +  }
 +
-   // Media queries in documents in an RDM pane should use the simulated
-   // device size.
-   Maybe<CSSIntSize> deviceSize =
+   if (aDocument.ShouldResistFingerprinting(RFPTarget::CSSDeviceSize)) {
+     return GetSize(aDocument);
+   }


### PR DESCRIPTION
On FF150 the CSS media-feature device dimensions (device-width /
device-height) no longer matched the spoofed screen.width/height, because
the screen-spoofing patch resolved them from a different source than the
MaskConfig-driven screen object. matchMedia(device-width) therefore
disagreed with screen.width — an internal inconsistency. Re-anchor the
patch so screen and device dimensions both read from MaskConfig.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>