### PR TITLE
fix(locale): propagate launch-arg locale to BrowsingContext

### DIFF
--- a/additions/juggler/content/main.js
+++ b/additions/juggler/content/main.js
@@ -48,6 +48,15 @@ export function initialize(browsingContext, docShell) {
     },
 
     locale: (locale) => {
+      // Camoufox: also propagate to BrowsingContext so the LanguageOverride
+      // synced field reaches Navigator.language consumers
+      // (dom/base/Navigator.cpp reads bc->Top()->GetLanguageOverride()).
+      // docShell.languageOverride alone only updates ICU + JS default locale.
+      try {
+        if (browsingContext && browsingContext.top) {
+          browsingContext.top.languageOverride = locale || "";
+        }
+      } catch (e) { /* fall through */ }
       docShell.languageOverride = locale;
     },
 


### PR DESCRIPTION
A locale supplied as a launch argument wasn't propagated to the
BrowsingContext, so the page's effective locale (Accept-Language /
Intl defaults) didn't match the requested one. Apply the launch-arg
locale to the BrowsingContext in the juggler content main.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>