### PR TITLE
fix(juggler): filepicker reliability + skip coalescing for synthetic mouse moves

### DIFF
--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -537,7 +537,8 @@ export class PageHandler {
       this._pageTarget.ensureContextMenuClosed();
       // If someone asks us to dispatch mouse event outside of viewport, then we normally would drop it.
       const boundingBox = this._pageTarget._linkedBrowser.getBoundingClientRect();
-      if (x < 0 || y < 0 || x > boundingBox.width || y > boundingBox.height) {
+      // Treat exact-edge coordinates as out-of-viewport: a mousemove at x==width or y==height fires as an exit event instead of eMouseMove, so the hit-renderer signal never arrives and every later input event hangs behind it forever.
+      if (x < 0 || y < 0 || x >= boundingBox.width || y >= boundingBox.height) {
         if (type !== 'mousemove')
           return;
 

--- a/patches/playwright/0-playwright.patch
+++ b/patches/playwright/0-playwright.patch
@@ -1498,7 +1498,14 @@ diff --git a/dom/html/HTMLInputElement.cpp b/dom/html/HTMLInputElement.cpp
 index 6e31658fba..20ca8b511d 100644
 --- a/dom/html/HTMLInputElement.cpp
 +++ b/dom/html/HTMLInputElement.cpp
-@@ -46,6 +46,7 @@
+@@ -39,20 +39,21 @@
+ #include "mozilla/dom/Document.h"
+ #include "mozilla/dom/DocumentInlines.h"
+ #include "mozilla/dom/DocumentOrShadowRoot.h"
+ #include "mozilla/dom/ElementBinding.h"
+ #include "mozilla/dom/FileSystemUtils.h"
+ #include "mozilla/dom/FormData.h"
+ #include "mozilla/dom/GetFilesHelper.h"
  #include "mozilla/dom/HTMLDataListElement.h"
  #include "mozilla/dom/HTMLOptionElement.h"
  #include "mozilla/dom/InputType.h"
@@ -1506,7 +1513,21 @@ index 6e31658fba..20ca8b511d 100644
  #include "mozilla/dom/MouseEvent.h"
  #include "mozilla/dom/NumericInputTypes.h"
  #include "mozilla/dom/ProgressEvent.h"
-@@ -870,6 +871,13 @@ nsresult HTMLInputElement::InitColorPicker() {
+ #include "mozilla/dom/UnionTypes.h"
+ #include "mozilla/dom/UserActivation.h"
+ #include "mozilla/dom/WheelEventBinding.h"
+ #include "mozilla/dom/WindowContext.h"
+ #include "mozilla/dom/WindowGlobalChild.h"
+ #include "mozilla/glean/DomMetrics.h"
+ #include "nsAttrValueInlines.h"
+@@ -922,20 +923,27 @@
+   }
+ 
+   // Get parent nsPIDOMWindow object.
+   nsCOMPtr<Document> doc = OwnerDoc();
+ 
+   RefPtr<BrowsingContext> bc = doc->GetBrowsingContext();
+   if (!bc) {
      return NS_ERROR_FAILURE;
    }
  
@@ -1520,6 +1541,14 @@ index 6e31658fba..20ca8b511d 100644
    if (IsPickerBlocked(doc)) {
      return NS_OK;
    }
+ 
+   // Get Loc title
+   nsAutoString title;
+   nsAutoString okButtonLabel;
+   if (aType == FILE_PICKER_DIRECTORY) {
+     nsContentUtils::GetMaybeLocalizedString(PropertiesFile::FORMS_PROPERTIES,
+                                             "DirectoryUpload", doc, title);
+
 diff --git a/dom/interfaces/base/nsIDOMWindowUtils.idl b/dom/interfaces/base/nsIDOMWindowUtils.idl
 index 1d90478329..8b7b9eecfe 100644
 --- a/dom/interfaces/base/nsIDOMWindowUtils.idl
@@ -1555,7 +1584,26 @@ diff --git a/dom/ipc/BrowserChild.cpp b/dom/ipc/BrowserChild.cpp
 index 2f7f261445..c5fc28182c 100644
 --- a/dom/ipc/BrowserChild.cpp
 +++ b/dom/ipc/BrowserChild.cpp
-@@ -1822,6 +1822,21 @@ void BrowserChild::HandleRealMouseButtonEvent(const WidgetMouseEvent& aEvent,
+@@ -1594,7 +1594,17 @@ mozilla::ipc::IPCResult BrowserChild::RecvNormalPriorityRealMouseMoveEvent(
+ mozilla::ipc::IPCResult BrowserChild::RecvRealMouseMoveEvent(
+     const WidgetMouseEvent& aEvent, const ScrollableLayerGuid& aGuid,
+     const uint64_t& aInputBlockId) {
+-  if (mCoalesceMouseMoveEvents && mCoalescedMouseEventFlusher) {
++  // Playwright/juggler: synthesized mouse events (mJugglerEventId != 0) await a
++  // per-event "juggler-mouse-event-hit-renderer" observer notification that is
++  // only fired from HandleRealMouseButtonEvent. Coalescing defers dispatch to
++  // the next nsRefreshDriver tick, which under heavy parallel load (many
++  // browsers, software rendering) can be many seconds late — long enough to
++  // pin activateAndRun's serialization chain. Skip the coalescing branch for
++  // juggler-originated events so they dispatch immediately and ack in
++  // milliseconds; real (non-juggler) events still benefit from the coalescing
++  // optimization.
++  if (mCoalesceMouseMoveEvents && mCoalescedMouseEventFlusher &&
++      !aEvent.mJugglerEventId) {
+     CoalescedMouseData* data =
+         mCoalescedMouseData.GetOrInsertNew(aEvent.pointerId);
+     MOZ_ASSERT(data);
+@@ -1822,6 +1832,21 @@ void BrowserChild::HandleRealMouseButtonEvent(const WidgetMouseEvent& aEvent,
    if (postLayerization) {
      postLayerization->Register();
    }


### PR DESCRIPTION
Two related juggler/input fixes in the playwright patch and PageHandler:

1. File picker: re-anchor the InitFilePicker hunk to the correct function
   (it had drifted onto InitColorPicker on FF150) and fix the page-edge
   mousemove case — a mousemove at exactly x==width or y==height fired as
   an exit event instead of eMouseMove, so the hit-renderer signal never
   arrived and every later input event hung behind it. Treat exact-edge
   coordinates (x >= width || y >= height) as out-of-viewport.

2. Mouse-move coalescing: skip the coalescing branch for juggler-
   synthesized events (mJugglerEventId != 0). Coalescing defers dispatch
   to the next refresh-driver tick, which under heavy parallel load can be
   seconds late and pins activateAndRun's serialization chain. Synthetic
   events now dispatch immediately; real events keep the optimization.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>