### PR TITLE
fix: kill Xvfb with SIGKILL and clean up X11 lock/socket files

### DIFF
--- a/pythonlib/camoufox/virtdisplay.py
+++ b/pythonlib/camoufox/virtdisplay.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import select
 import subprocess  # nosec
 import time
@@ -115,14 +116,20 @@ class VirtualDisplay:
         if self.proc and self.proc.poll() is None:
             if self.debug:
                 print("Terminating virtual display:", self._display)
-            self.proc.terminate()
             try:
+                self.proc.send_signal(signal.SIGKILL)
                 self.proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                if self.debug:
-                    print("Xvfb did not exit in time, killing forcefully")
-                self.proc.kill()
-                self.proc.wait()
+            except Exception:
+                pass
+            try:
+                os.remove(f"/tmp/.X{self._display}-lock")
+            except FileNotFoundError:
+                pass
+            try:
+                os.remove(f"/tmp/.X11-unix/X{self._display}")
+            except FileNotFoundError:
+                pass
+            self.proc = None
 
     @staticmethod
     def _assert_linux() -> None:


### PR DESCRIPTION
Replace the terminate→wait→kill fallback in VirtualDisplay.kill() with a direct SIGKILL to prevent zombie Xvfb processes. After the process exits, remove the stale /tmp/.X{n}-lock and /tmp/.X11-unix/X{n} files so future display allocations are not blocked. Also set self.proc = None to mark the display as fully cleaned up.

## Related Issue

Closes #

## Description

<!-- What does this PR change and why? -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

<!-- How did you test your changes? -->

## Fingerprint Report

Please submit a report from both the service tester and build tester.

<details>
<summary>Fingerprint report</summary>

<!-- Paste your report here -->

</details>

## Checklist

- [ ] I have linked a related issue above
- [ ] My changes are focused on a single logical change
- [ ] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass (for python library changes) -`./service-tester/run_tests.sh --browser-version official/prerelease/146.0.1-alpha.25` (attach screenshot)~~ temporarily out of service lol
- [ ] Build test passes (for patch changes) - `./build-tester/run_tests.sh` A score of at least 1000 must be achieved (attach screenshot)
