### PR TITLE
Fix playwright session leak when launch or close raises (fixes #82)

### DIFF
--- a/pythonlib/camoufox/async_api.py
+++ b/pythonlib/camoufox/async_api.py
@@ -32,13 +32,24 @@ class AsyncCamoufox(PlaywrightContextManager):
 
     async def __aenter__(self) -> Union[Browser, BrowserContext]:
         _playwright = await super().__aenter__()
-        self.browser = await AsyncNewBrowser(_playwright, **self.launch_options)
+        try:
+            self.browser = await AsyncNewBrowser(_playwright, **self.launch_options)
+        except BaseException as e:
+            # Any launch failure (InvalidProxy, missing browser, bad options, ...)
+            # must tear down the playwright session started above so the driver
+            # process/connection is not leaked.
+            await super().__aexit__(type(e), e, e.__traceback__)
+            raise
         return self.browser
 
     async def __aexit__(self, *args: Any):
-        if self.browser:
-            await self.browser.close()
-        await super().__aexit__(*args)
+        # Run the base teardown even if browser.close() raises (e.g. the browser
+        # process already crashed), so the playwright driver/connection is not leaked.
+        try:
+            if self.browser:
+                await self.browser.close()
+        finally:
+            await super().__aexit__(*args)
 
 
 @overload

--- a/pythonlib/camoufox/sync_api.py
+++ b/pythonlib/camoufox/sync_api.py
@@ -13,7 +13,6 @@ from typing_extensions import Literal
 
 from camoufox.virtdisplay import VirtualDisplay
 
-from .exceptions import InvalidProxy
 from .fingerprints import generate_context_fingerprint
 from .utils import launch_options, sync_attach_vd
 
@@ -33,15 +32,26 @@ class Camoufox(PlaywrightContextManager):
         super().__enter__()
         try:
             self.browser = NewBrowser(self._playwright, **self.launch_options)
-        except InvalidProxy as e:
-            super().__exit__(InvalidProxy, e, None)
+        except BaseException as e:
+            # Any launch failure (InvalidProxy, missing browser, bad options, ...)
+            # must tear down the playwright session started above. Leaking it leaves
+            # the sync API's event loop in a "running" state, so every later sync
+            # Camoufox/Playwright start in this thread fails with "Sync API inside
+            # the asyncio loop" until the process restarts (#82).
+            super().__exit__(type(e), e, e.__traceback__)
             raise
         return self.browser
 
     def __exit__(self, *args: Any):
-        if self.browser:
-            self.browser.close()
-        super().__exit__(*args)
+        # Run the base teardown even if browser.close() raises (e.g. the browser
+        # process already crashed). Skipping it leaks the sync API's event loop in a
+        # "running" state, so every later sync Camoufox/Playwright start in the same
+        # thread fails with "Sync API inside the asyncio loop" until process restart.
+        try:
+            if self.browser:
+                self.browser.close()
+        finally:
+            super().__exit__(*args)
 
 
 @overload


### PR DESCRIPTION
## Related Issue

Closes #82

## Description

`Camoufox.__enter__`/`__exit__` (and the async variants) can leak the playwright session they wrap, and in the sync API that leak is fatal to the whole process:

In sync playwright, the event loop stays running for the entire life of a session — only a completed `PlaywrightContextManager.__exit__` clears the thread's running-loop marker. If the session is started but its teardown never runs, every later sync `Camoufox()`/playwright start in that thread fails instantly with:

```
Error: It looks like you are using Playwright Sync API inside the asyncio loop.
Please use the Async API instead.
```

…until the process restarts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

Repro (`repro.py`) — session 1 hits a launch/close failure, session 2 shows whether the process is poisoned:

```python
from camoufox.sync_api import Camoufox

# session 1: geoip proxy check fails after playwright has started
try:
    with Camoufox(headless=True, geoip=True, proxy={"server": "http://127.0.0.1:9"}) as b:
        pass
except Exception as e:
    print(f"session 1 raised: {type(e).__name__}")

# session 2: no proxy, plain launch
try:
    with Camoufox(headless=True) as b2:
        print(f"session 2 launched OK (firefox {b2.version})")
except Exception as e:
    print(f"session 2 failed: {type(e).__name__}: {e}")
```

## Fingerprint Report

<details>
<summary>Fingerprint report</summary>

N/A — pythonlib exception-handling only; no fingerprint-related code touched.

</details>

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass (for python library changes)~~ noted as temporarily out of service
- [ ] Build test N/A (no patch changes)