### PR TITLE
ci: fix build.yml on GitHub-hosted runners (source wipe, ccache, OOM)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y msitools p7zip-full aria2
+          # ccache: the mozconfig enables --with-ccache, but the runner image no
+          # longer ships it, so configure fails with "Cannot find ccache".
+          sudo apt-get install -y msitools p7zip-full aria2 ccache
 
       - name: Fetch source
         env:
@@ -92,19 +94,34 @@ jobs:
 
       - name: Setup and bootstrap
         run: |
-          make setup-minimal
+          # `setup-minimal` is docker-only (no local git repo). On a GitHub runner,
+          # actions/checkout leaves a .git at the repo root, so patch.py's
+          # `git clean -fdx && git reset --hard unpatched` (run inside the non-git
+          # source dir) escalates to that checkout .git and deletes the entire
+          # (untracked) Firefox source -> "./mach: not found" and set-target fails.
+          # `make setup` creates a NESTED git repo in the source dir with the
+          # `unpatched` tag patch.py expects, isolating the reset.
+          git config --global user.email "ci@camoufox.local"
+          git config --global user.name "Camoufox CI"
+          make setup
           make mozbootstrap
           mkdir -p dist
 
       - name: Create swap space
         run: |
-          sudo fallocate -l 16G /swapfile
+          # libxul/Rust can exceed 16 GB RAM + 16 GB swap and the runner gets
+          # SIGTERM'd (exit 143) mid-build; disk is plentiful (~115 GB free).
+          sudo fallocate -l 32G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile
           free -h
 
       - name: Build
+        env:
+          # Cap Rust parallelism to lower peak memory (avoids OOM/SIGTERM).
+          # Tune to taste: higher = faster but more RAM.
+          CARGO_BUILD_JOBS: "2"
         run: python3 ./multibuild.py --target ${{ matrix.target }} --arch ${{ matrix.arch }}
 
       - name: Upload artifacts


### PR DESCRIPTION
## Problem

`.github/workflows/build.yml` currently fails on GitHub-hosted `ubuntu-24.04` runners at the **Build** step, so no artifacts are produced. There are three independent issues; fixing all three yields a green `windows/x86_64` build (verified on a fork — the resulting `camoufox.exe` launches on Windows 11 with `navigator.platform=Win32` and no WebRTC leak). The same fixes apply to every matrix target.

### 1. `make setup-minimal` wipes the Firefox source on GitHub runners
`setup-minimal` is documented as docker-only (it deliberately skips the local git repo). On a GitHub runner, `actions/checkout` leaves a `.git` at the repo root. `patch.py` then runs, inside the (non-git) source dir:

```
git clean -fdx && ./mach clobber && git reset --hard unpatched
```

With no nested git repo, git escalates to the checkout's `.git` and `git clean -fdx` deletes the entire (untracked) Firefox source, so `set-target` fails with `./mach: not found` and `cp ... services/settings/dumps/main/search-config.json: No such file or directory`.

**Fix:** use `make setup` (which creates the nested git repo + `unpatched` tag that `patch.py` expects) and set a git identity.

### 2. `configure` fails: `Cannot find ccache`
The mozconfig enables `--with-ccache`, but the current `ubuntu-24.04` image no longer ships `ccache`, so configure aborts.

**Fix:** add `ccache` to the apt install step.

### 3. Build OOM (SIGTERM, exit 143) mid-compile
libxul/Rust can exceed the runner's 16 GB RAM + 16 GB swap and the VM is terminated ~46 min in; disk is plentiful (~115 GB free).

**Fix:** bump swap to 32 GB and cap Rust parallelism with `CARGO_BUILD_JOBS=2` (trades build speed for lower peak memory — tune as preferred).

## Verification
With these three changes, `python3 ./multibuild.py --target windows --arch x86_64` completes and uploads `camoufox-*-win.x86_64.zip`, restoring the automated Windows builds that have been missing from CI.
