### PR TITLE
fix(stealth): consolidated stealth/juggler/build fixes (rebased onto Firefox 152)

### DIFF
--- a/additions/camoucfg/MaskConfig.hpp
+++ b/additions/camoucfg/MaskConfig.hpp
@@ -295,10 +295,17 @@ MVoices() {
   std::vector<std::tuple<std::string, std::string, std::string, bool, bool>>
       voices;
   for (const auto& voice : data["voices"]) {
-    // Check if voice has all required fields
-    if (!voice.contains("lang") || !voice.contains("name") ||
-        !voice.contains("voiceUri") || !voice.contains("isDefault") ||
-        !voice.contains("isLocalService")) {
+    // Each voice must be a full object with all five fields. A bare string
+    // (e.g. "Name:lang:type") or an object missing a field registers NOTHING
+    // and would silently leave the host's native voices exposed, so warn
+    // loudly instead of dropping it quietly.
+    if (!voice.is_object() || !voice.contains("lang") ||
+        !voice.contains("name") || !voice.contains("voiceUri") ||
+        !voice.contains("isDefault") || !voice.contains("isLocalService")) {
+      printf_stderr(
+          "ERROR: 'voices' entry is not a complete object "
+          "{lang,name,voiceUri,isDefault,isLocalService}; skipping: %s\n",
+          voice.dump().c_str());
       continue;
     }
 

--- a/additions/juggler/JugglerFrameParent.sys.mjs
+++ b/additions/juggler/JugglerFrameParent.sys.mjs
@@ -20,21 +20,17 @@ export class JugglerFrameParent extends JSWindowActorParent {
     if (!this.manager?.isCurrentGlobal)
       return;
 
-    // Only interested in main frames for now.
-    if (this.browsingContext.parent)
-      return;
-
-    this._target = TargetRegistry.instance()?.targetForBrowserId(this.browsingContext.browserId);
-    if (!this._target)
-      return;
-
-    this.actorName = `browser::page[${this._target.id()}]/${this.browsingContext.browserId}/${this.browsingContext.id}/${this._target.nextActorSequenceNumber()}`;
-    this._target.setActor(this);
+    // Firefox 152+: the actor may be created BEFORE the chrome-side PageTarget
+    // exists (notably for window.open popups, where the content WindowGlobal is
+    // created before the `TabOpen` event fires). Delegate to the registry, which
+    // tracks the actor and binds it whenever the target appears — in either
+    // order. The previous implementation looked up the target here and bailed
+    // with no retry when it was missing, leaving the popup's page channel
+    // permanently unbound (Page.ready never sent -> no `popup` event).
+    TargetRegistry.instance()?.onActorCreated(this);
   }
 
   didDestroy() {
-    if (!this._target)
-      return;
-    this._target.removeActor(this);
+    TargetRegistry.instance()?.onActorDestroyed(this);
   }
 }

--- a/additions/juggler/TargetRegistry.js
+++ b/additions/juggler/TargetRegistry.js
@@ -115,6 +115,14 @@ export class TargetRegistry {
     this._userContextIdToBrowserContext = new Map();
     this._browserToTarget = new Map();
     this._browserIdToTarget = new Map();
+    // Firefox 152+: a window.open() popup's content-process WindowGlobal actor
+    // (JugglerFrameParent.actorCreated) can be created BEFORE the chrome-side
+    // `TabOpen` fires and the PageTarget is registered. The old self-binding
+    // actor then found no target and bailed with no retry, so the popup's page
+    // channel never became ready -> `Page.ready` never reached the client ->
+    // `page.on('popup')` never fired. Track actors here so binding happens
+    // whenever either side appears, in either order (matches upstream Playwright).
+    this._browserIdToActor = new Map();
 
     this._proxiesWithClashingAuthCacheKeys = new Set();
     this._browserProxy = null;
@@ -388,6 +396,38 @@ export class TargetRegistry {
   targetForBrowserId(browserId) {
     return this._browserIdToTarget.get(browserId);
   }
+
+  // Called from JugglerFrameParent.actorCreated for every main-frame
+  // WindowGlobalParent. Records the actor and binds it to its PageTarget if the
+  // target already exists; if not, PageTarget's constructor will bind it later.
+  onActorCreated(actor) {
+    // Only interested in main frames for now.
+    if (actor.browsingContext.parent)
+      return;
+    const browserId = actor.browsingContext.browserId;
+    this._browserIdToActor.set(browserId, actor);
+    const target = this._browserIdToTarget.get(browserId);
+    target?.setActor(actor);
+  }
+
+  onActorDestroyed(actor) {
+    // browsingContext can be null once the WindowGlobal is fully torn down.
+    const browserId = actor.browsingContext?.browserId;
+    if (browserId === undefined) {
+      // Fall back to clearing whichever entry points at this actor.
+      for (const [id, a] of this._browserIdToActor) {
+        if (a === actor) {
+          this._browserIdToTarget.get(id)?.removeActor(actor);
+          this._browserIdToActor.delete(id);
+        }
+      }
+      return;
+    }
+    const target = this._browserIdToTarget.get(browserId);
+    target?.removeActor(actor);
+    if (this._browserIdToActor.get(browserId) === actor)
+      this._browserIdToActor.delete(browserId);
+  }
 }
 
 export class PageTarget {
@@ -435,13 +475,21 @@ export class PageTarget {
     this._disposed = false;
     browserContext.pages.add(this);
     this._registry._browserToTarget.set(this._linkedBrowser, this);
-    this._registry._browserIdToTarget.set(this._linkedBrowser.browsingContext.browserId, this);
+    const browserId = this._linkedBrowser.browsingContext.browserId;
+    this._registry._browserIdToTarget.set(browserId, this);
+    // Firefox 152+: the content-process actor may already exist (window.open
+    // popups create the actor before TabOpen). Bind it now so the page channel
+    // becomes ready and `Page.ready` reaches the client. See _browserIdToActor.
+    const actor = this._registry._browserIdToActor.get(browserId);
+    if (actor)
+      this.setActor(actor);
 
     this._registry.emit(TargetRegistry.Events.TargetCreated, this);
   }
 
   async activateAndRun(callback = () => {}, { muteNotificationsPopup = false } = {}) {
-    const ownerWindow = this._tab.linkedBrowser.ownerGlobal;
+    // Firefox 152 renamed `ownerGlobal` to `documentGlobal` on nodes.
+    const ownerWindow = this._tab.linkedBrowser.documentGlobal || this._tab.linkedBrowser.ownerGlobal;
     const tabBrowser = ownerWindow.gBrowser;
     // Serialize all tab-switching commands per tabbed browser
     // to disallow concurrent tab switching.
@@ -474,6 +522,10 @@ export class PageTarget {
 
   setActor(actor) {
     this._actor = actor;
+    // Name the actor here (target-side) rather than in JugglerFrameParent so it
+    // is set no matter which side binds first. SimpleChannel.bindToActor reads
+    // actor.actorName for its debug channel name.
+    actor.actorName = `browser::page[${this.id()}]/${actor.browsingContext.browserId}/${actor.browsingContext.id}/${this.nextActorSequenceNumber()}`;
     this._channel.bindToActor(actor);
   }
 
@@ -767,7 +819,8 @@ export class PageTarget {
     if (width < 10 || width > 10000 || height < 10 || height > 10000)
       throw new Error("Invalid size");
 
-    const docShell = this._gBrowser.ownerGlobal.docShell;
+    // Firefox 152 renamed `ownerGlobal` to `documentGlobal` on nodes.
+    const docShell = (this._gBrowser.documentGlobal || this._gBrowser.ownerGlobal).docShell;
     // Exclude address bar and navigation control from the video.
     const rect = this.linkedBrowser().getBoundingClientRect();
     const devicePixelRatio = this._window.devicePixelRatio;
@@ -807,7 +860,8 @@ export class PageTarget {
     if (width < 10 || width > 10000 || height < 10 || height > 10000)
       throw new Error("Invalid size");
 
-    const docShell = this._gBrowser.ownerGlobal.docShell;
+    // Firefox 152 renamed `ownerGlobal` to `documentGlobal` on nodes.
+    const docShell = (this._gBrowser.documentGlobal || this._gBrowser.ownerGlobal).docShell;
     // Exclude address bar and navigation control from the video.
     const rect = this.linkedBrowser().getBoundingClientRect();
     const devicePixelRatio = this._window.devicePixelRatio;

--- a/additions/juggler/content/PageAgent.js
+++ b/additions/juggler/content/PageAgent.js
@@ -574,6 +574,37 @@ export class PageAgent {
 
   async _insertText({text}) {
     const frame = this._frameTree.mainFrame();
+    const win = frame.domWindow();
+    const doc = win.document;
+    const active = doc.activeElement;
+    // Fast path: if focus is on an editable input/textarea, set the value
+    // directly and fire a single trusted-shape input event. This avoids the
+    // double `input` event we get from nsITextInputProcessor on Firefox 146
+    // (one for compositionupdate, one after compositionend), and matches the
+    // upstream test expectation of exactly one `input` event.
+    const isEditableField = active && (
+      (active.tagName === 'INPUT' && /^(text|search|url|tel|email|password|number|)$/i.test(active.type || '')) ||
+      active.tagName === 'TEXTAREA'
+    );
+    if (isEditableField) {
+      const start = active.selectionStart ?? active.value.length;
+      const end = active.selectionEnd ?? active.value.length;
+      const before = active.value.slice(0, start);
+      const after = active.value.slice(end);
+      active.value = before + text + after;
+      const caret = (before + text).length;
+      try { active.setSelectionRange(caret, caret); } catch (e) {}
+      const InputEvent = win.InputEvent;
+      active.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        inputType: 'insertText',
+        data: text,
+      }));
+      return;
+    }
+    // Fallback: contenteditable / other editing hosts use the TIP path.
     frame.textInputProcessor().commitCompositionWith(text);
   }
 

--- a/additions/juggler/content/PageAgent.js
+++ b/additions/juggler/content/PageAgent.js
@@ -219,7 +219,8 @@ export class PageAgent {
   }
 
   _linkClicked(sync, anchorElement) {
-    if (anchorElement.ownerGlobal.docShell !== this._docShell)
+    // Firefox 152 renamed `ownerGlobal` to `documentGlobal` on nodes.
+    if ((anchorElement.documentGlobal || anchorElement.ownerGlobal).docShell !== this._docShell)
       return;
     this._browserPage.emit('pageLinkClicked', { phase: sync ? 'after' : 'before' });
   }
@@ -497,20 +498,26 @@ export class PageAgent {
   }
 
   async _dispatchTouchEvent({type, touchPoints, modifiers}) {
+    // Firefox 152+: windowUtils.sendTouchEvent (parallel-array API) was removed.
+    // Synthetic touch now goes through Window.synthesizeTouchEvent, which takes a
+    // sequence of SynthesizeTouchEventData objects. Mirrors upstream Playwright.
     const frame = this._frameTree.mainFrame();
-    const defaultPrevented = frame.domWindow().windowUtils.sendTouchEvent(
+    const defaultPrevented = frame.domWindow().synthesizeTouchEvent(
       type.toLowerCase(),
-      touchPoints.map((point, id) => id),
-      touchPoints.map(point => point.x),
-      touchPoints.map(point => point.y),
-      touchPoints.map(point => point.radiusX === undefined ? 1.0 : point.radiusX),
-      touchPoints.map(point => point.radiusY === undefined ? 1.0 : point.radiusY),
-      touchPoints.map(point => point.rotationAngle === undefined ? 0.0 : point.rotationAngle),
-      touchPoints.map(point => point.force === undefined ? 1.0 : point.force),
-      touchPoints.map(point => 0),
-      touchPoints.map(point => 0),
-      touchPoints.map(point => 0),
-      modifiers);
+      touchPoints.map((point, id) => ({
+        identifier: id,
+        offsetX: point.x,
+        offsetY: point.y,
+        radiiX: point.radiusX ?? 1.0,
+        radiiY: point.radiusY ?? 1.0,
+        rotationAngle: point.rotationAngle ?? 0.0,
+        pressure: point.force ?? 1.0,
+        tiltX: 0,
+        tiltY: 0,
+        twist: 0,
+      })),
+      modifiers
+    );
     return {defaultPrevented};
   }
 

--- a/additions/juggler/content/main.js
+++ b/additions/juggler/content/main.js
@@ -48,6 +48,15 @@ export function initialize(browsingContext, docShell) {
     },
 
     locale: (locale) => {
+      // Camoufox: also propagate to BrowsingContext so the LanguageOverride
+      // synced field reaches Navigator.language consumers
+      // (dom/base/Navigator.cpp reads bc->Top()->GetLanguageOverride()).
+      // docShell.languageOverride alone only updates ICU + JS default locale.
+      try {
+        if (browsingContext && browsingContext.top) {
+          browsingContext.top.languageOverride = locale || "";
+        }
+      } catch (e) { /* fall through */ }
       docShell.languageOverride = locale;
     },
 

--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -450,7 +450,24 @@ export class PageHandler {
 
   async ['Page.reload']() {
     await this._pageTarget.activateAndRun(() => {
-      const doc = this._pageTarget._tab.linkedBrowser.ownerDocument;
+      const browser = this._pageTarget._tab.linkedBrowser;
+      // Camoufox: Firefox 146's Browser:Reload command is a no-op on about:blank
+      // (no history entry to reload). Fall back to a forced reloadWithFlags via
+      // browsingContext so the load event still fires and init scripts run.
+      try {
+        const uri = browser.currentURI?.spec;
+        if (uri === 'about:blank' || !uri) {
+          const bc = browser.browsingContext;
+          if (bc && typeof bc.reload === 'function') {
+            const Ci = Components.interfaces;
+            bc.reload(Ci.nsIWebNavigation.LOAD_FLAGS_NONE);
+            return;
+          }
+        }
+      } catch (e) {
+        dump(`juggler: reload-fallback failed: ${e}\n`);
+      }
+      const doc = browser.ownerDocument;
       doc.getElementById('Browser:Reload').doCommand();
     });
   }
@@ -537,7 +554,8 @@ export class PageHandler {
       this._pageTarget.ensureContextMenuClosed();
       // If someone asks us to dispatch mouse event outside of viewport, then we normally would drop it.
       const boundingBox = this._pageTarget._linkedBrowser.getBoundingClientRect();
-      if (x < 0 || y < 0 || x > boundingBox.width || y > boundingBox.height) {
+      // Treat exact-edge coordinates as out-of-viewport: a mousemove at x==width or y==height fires as an exit event instead of eMouseMove, so the hit-renderer signal never arrives and every later input event hangs behind it forever.
+      if (x < 0 || y < 0 || x >= boundingBox.width || y >= boundingBox.height) {
         if (type !== 'mousemove')
           return;
 

--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -362,7 +362,8 @@ export class PageHandler {
       }
     }
 
-    const win = browsingContext.topChromeWindow.ownerGlobal;
+    // Firefox 152 removed `ownerGlobal`; `topChromeWindow` is already the chrome window.
+    const win = browsingContext.topChromeWindow;
     const canvas = win.document.createElementNS('http://www.w3.org/1999/xhtml', 'canvas');
     canvas.width = canvasWidth;
     canvas.height = canvasHeight;

--- a/patches/cross-process-storage.patch
+++ b/patches/cross-process-storage.patch
@@ -80,13 +80,15 @@ index abcdef1234..1234abcdef 100644
  [PRemoteQuotaObject::MaybeUpdateSize]
  description = This must be synchronous until quota file streams become non-blocking. The synchronous message is never used on the main thread or the PBackground thread or a DOM worker threed.
 diff --git a/modules/libpref/Preferences.cpp b/modules/libpref/Preferences.cpp
-index aaaaaa0000..bbbbbb0000 100644
+index c307035819..4402775905 100644
 --- a/modules/libpref/Preferences.cpp
 +++ b/modules/libpref/Preferences.cpp
-@@ -6364,6 +6364,8 @@ static const PrefListEntry sDynamicPrefOverrideList[]{
+@@ -6519,6 +6519,8 @@ static const PrefListEntry sDynamicPrefOverrideList[]{
      PREF_LIST_ENTRY("toolkit.mozprotocol.url"),
      PREF_LIST_ENTRY("toolkit.telemetry.log.level"),
      PREF_LIST_ENTRY("ui."),
 +    // Roverfox: allow cross-process sync of per-context fingerprint storage
 +    PREF_LIST_ENTRY("roverfox.s."),
  };
+ 
+ #undef PREF_LIST_ENTRY

--- a/patches/font-system-fonts-css2.patch
+++ b/patches/font-system-fonts-css2.patch
@@ -1,0 +1,292 @@
+Camoufox: spoof CSS2 system-font keyword resolution to match navigator.platform.
+
+Sibling to font-system-ui.patch. That patch covers the `system-ui` generic
+via gfxPlatformFontList::GetSystemUIFontFamilies(). It does NOT cover the
+older CSS2 system-font shorthand keywords:
+
+    font: caption | icon | menu | message-box | small-caption | status-bar
+
+CreepJS's headless detector (headless/getSystemFonts.ts) probes all six
+keywords:
+
+    SYSTEM_FONTS = ['caption','icon','menu','message-box','small-caption','status-bar']
+    for (const f of SYSTEM_FONTS) {
+      el.setAttribute('style', `font: ${f} !important`);
+      set.add(getComputedStyle(el).fontFamily);
+    }
+    // Linux: set = {"Sans"} or {"sans-serif"}, regardless of navigator.platform
+    // GeckoFonts["Sans"] === GeckoFonts["sans-serif"] === "Linux"
+    //   -> emits "Sans:Linux" / "sans-serif:Linux"
+
+Firefox routes CSS system-font resolution through TWO different paths
+depending on whether RFP's FontVisibilityRestrictGenerics target is on:
+
+  1. RFP off (or target off): nsLookAndFeel::PerThemeData::GetFont()
+     returns the GTK system font (e.g. "Cantarell").
+  2. RFP on (Camoufox default):   nsLayoutUtils::GetSpoofedSystemFontForRFP()
+     returns "sans-serif" (Linux build) or "-apple-system" (Mac build) etc.
+
+Camoufox runs RFP on by default, so CreepJS sees path 2 — which on the
+Linux build hardcodes "sans-serif" and entirely bypasses the
+LookAndFeel::GetFont call site.
+
+This patch hooks BOTH paths to honor navigator.platform:
+
+  - "-apple-system"  when navigator.platform starts with "Mac"
+                     (matches CreepJS GeckoFonts entry "-apple-system" -> "Mac")
+  - "Segoe UI"       when navigator.platform starts with "Win"
+                     (matches CreepJS GeckoFonts entry "Segoe UI" -> "Windows")
+  - (falls through)  otherwise (Linux / iPhone / unspoofed)
+
+For path 1 we patch widget/gtk/nsLookAndFeel.cpp's PerThemeData::GetFont.
+For path 2 we patch layout/base/nsLayoutUtils.cpp's
+GetSpoofedSystemFontForRFP (file-static) helper. Both files need
+LOCAL_INCLUDES += ["/camoucfg"] in their respective moz.build to expose
+MaskConfig.hpp.
+
+Both hooks classify navigator.platform once via a function-static and
+keep the result for the lifetime of the process. CreepJS calls the CSS
+resolver six times in tight succession (one per CSS2 keyword) and uses
+probe duration as a probabilistic headless signal, so we don't want to
+re-parse CAMOU_CONFIG on every call. The config is set at process start
+and never changes, so a single classification per process is safe.
+
+Bug: daijro/camoufox#598 (sibling of font-system-ui.patch)
+
+--- a/widget/gtk/moz.build
++++ b/widget/gtk/moz.build
+@@ -155,6 +155,7 @@
+ FINAL_LIBRARY = "xul"
+
+ LOCAL_INCLUDES += [
++    "/camoucfg",
+     "/layout/base",
+     "/layout/forms",
+     "/layout/generic",
+--- a/widget/gtk/nsLookAndFeel.cpp
++++ b/widget/gtk/nsLookAndFeel.cpp
+@@ -34,6 +34,7 @@
+ #include "mozilla/glean/WidgetGtkMetrics.h"
+ #include "mozilla/ScopeExit.h"
+ #include "mozilla/WidgetUtilsGtk.h"
++#include "MaskConfig.hpp"
+ #include "ScreenHelperGTK.h"
+ #include "ScrollbarDrawing.h"
+
+@@ -1302,6 +1303,48 @@
+ bool nsLookAndFeel::PerThemeData::GetFont(FontID aID, nsString& aFontName,
+                                           gfxFontStyle& aFontStyle,
+                                           float aTextScaleFactor) const {
++  // Camoufox: spoof the CSS2 system-font keyword family resolution
++  // (caption / icon / menu / message-box / small-caption / status-bar)
++  // based on navigator.platform so we don't leak the host's GTK system
++  // font through getComputedStyle().fontFamily. Sibling to
++  // font-system-ui.patch which handles the `system-ui` generic.
++  //
++  // The platform classification is cached in a function-static. CreepJS's
++  // headless detector calls getComputedStyle().fontFamily after setting
++  // `font: caption !important` six times in tight succession, and uses
++  // probe duration as a probabilistic headless signal. navigator.platform
++  // is set from CAMOU_CONFIG at process start and never changes, so a
++  // single lookup per process is safe and removes the per-call overhead.
++  enum class SpoofedOS { Other, Mac, Win };
++  static const SpoofedOS sSpoofedOS = []() {
++    auto platform = MaskConfig::GetString("navigator.platform");
++    if (!platform) return SpoofedOS::Other;
++    const std::string& p = platform.value();
++    auto starts_with = [&](const char* prefix) {
++      size_t n = std::strlen(prefix);
++      return p.size() >= n &&
++             std::equal(prefix, prefix + n, p.begin(),
++                        [](char a, char b) {
++                          return std::tolower(static_cast<unsigned char>(a)) ==
++                                 std::tolower(static_cast<unsigned char>(b));
++                        });
++    };
++    if (starts_with("mac")) return SpoofedOS::Mac;
++    if (starts_with("win")) return SpoofedOS::Win;
++    return SpoofedOS::Other;
++  }();
++  if (sSpoofedOS == SpoofedOS::Mac) {
++    aFontName.AssignLiteral(u"-apple-system");
++    aFontStyle = mDefaultFontStyle;
++    return true;
++  }
++  if (sSpoofedOS == SpoofedOS::Win) {
++    aFontName.AssignLiteral(u"Segoe UI");
++    aFontStyle = mDefaultFontStyle;
++    return true;
++  }
++  // Linux / iPhone / unknown: fall through to upstream behavior.
++
+   switch (aID) {
+     case FontID::Menu:             // css2
+     case FontID::MozPullDownMenu:  // css3
+--- a/layout/base/moz.build
++++ b/layout/base/moz.build
+@@ -146,6 +146,7 @@
+     "../tables",
+     "../xul",
+     "../xul/tree/",
++    "/camoucfg",
+     "/docshell/base",
+     "/dom/base",
+     "/dom/html",
+--- a/layout/base/nsLayoutUtils.cpp
++++ b/layout/base/nsLayoutUtils.cpp
+@@ -6,6 +6,7 @@
+
+ #include "nsLayoutUtils.h"
+
++#include "MaskConfig.hpp"
+ #include <algorithm>
+ #include <limits>
+
+@@ -9623,6 +9654,54 @@
+
+ static void GetSpoofedSystemFontForRFP(LookAndFeel::FontID aFontID,
+                                        gfxFontStyle& aStyle, nsAString& aName) {
++  // Camoufox: when navigator.platform is spoofed, return the family-name
++  // string the spoofed OS would. Firefox's CSS resolver routes the CSS2
++  // system-font keywords (caption / icon / menu / message-box /
++  // small-caption / status-bar) through this function whenever RFP's
++  // FontVisibilityRestrictGenerics target is on (default for Camoufox),
++  // bypassing nsLookAndFeel::PerThemeData::GetFont entirely. CreepJS's
++  // headless detector reads `getComputedStyle().fontFamily` after setting
++  // `font: caption !important` and emits "<family>:Linux" / "<family>:Mac"
++  // / "<family>:Windows" attributions. Without this hook the Linux build
++  // emits `sans-serif` (which fontconfig resolves to "Sans") for every
++  // spoofed OS, leaking Linux. Sibling to the nsLookAndFeel::GetFont hook
++  // in widget/gtk/nsLookAndFeel.cpp.
++  //
++  // The platform classification is cached in a function-static because
++  // CreepJS calls this six times in tight succession (one per CSS2
++  // keyword) and uses probe duration as a probabilistic headless signal.
++  // navigator.platform is set from CAMOU_CONFIG at process start and
++  // never changes, so a single lookup per process is safe.
++  enum class SpoofedOS { Other, Mac, Win };
++  static const SpoofedOS sSpoofedOS = []() {
++    auto platform = MaskConfig::GetString("navigator.platform");
++    if (!platform) return SpoofedOS::Other;
++    const std::string& p = platform.value();
++    auto starts_with = [&](const char* prefix) {
++      size_t n = std::strlen(prefix);
++      return p.size() >= n &&
++             std::equal(prefix, prefix + n, p.begin(),
++                        [](char a, char b) {
++                          return std::tolower(static_cast<unsigned char>(a)) ==
++                                 std::tolower(static_cast<unsigned char>(b));
++                        });
++    };
++    if (starts_with("mac")) return SpoofedOS::Mac;
++    if (starts_with("win")) return SpoofedOS::Win;
++    return SpoofedOS::Other;
++  }();
++  if (sSpoofedOS == SpoofedOS::Mac) {
++    aName = u"-apple-system"_ns;
++    aStyle.size = 13;
++    return;
++  }
++  if (sSpoofedOS == SpoofedOS::Win) {
++    aName = u"Segoe UI"_ns;
++    aStyle.size = 12;
++    return;
++  }
++  // Linux / iPhone / unknown: fall through to upstream behavior.
++
+ #if defined(XP_MACOSX) || defined(MOZ_WIDGET_UIKIT)
+   aName = u"-apple-system"_ns;
+   // Values taken from a macOS 10.15 system.
+@@ -9729,7 +9729,17 @@ void nsLayoutUtils::ComputeSystemFont(nsFont* aSystemFont,
+                                       const Document* aDocument) {
+   gfxFontStyle fontStyle;
+   nsAutoString systemFontName;
+-  if (aDocument->ShouldResistFingerprinting(
++  // Camoufox: take the spoof path whenever navigator.platform is spoofed, not
++  // only when the FontVisibilityRestrictGenerics RFP target is active. That
++  // target is NOT in Firefox's default-enabled set (RFPTargetsDefault.inc) and
++  // Camoufox never turns it on, so the original guard left the spoof dead: the
++  // real GTK system font ("sans-serif" on Linux) leaked through
++  // getComputedStyle().fontFamily for the CSS2 system-font keywords, exposing
++  // the host OS (CreepJS "platform hints: sans-serif:Linux"). When no platform
++  // is spoofed, GetSpoofedSystemFontForRFP falls through to the native value,
++  // so this is a no-op for unspoofed contexts.
++  if (MaskConfig::GetString("navigator.platform").has_value() ||
++      aDocument->ShouldResistFingerprinting(
+           RFPTarget::FontVisibilityRestrictGenerics)) {
+     GetSpoofedSystemFontForRFP(aFontID, fontStyle, systemFontName);
+   } else if (!LookAndFeel::GetFont(aFontID, systemFontName, fontStyle)) {
+diff --git a/gfx/thebes/gfxMacPlatformFontList.mm b/gfx/thebes/gfxMacPlatformFontList.mm
+--- a/gfx/thebes/gfxMacPlatformFontList.mm
++++ b/gfx/thebes/gfxMacPlatformFontList.mm
+@@ -17,6 +17,7 @@
+ #include "SharedFontList-impl.h"
+ 
+ #include "harfbuzz/hb.h"
++#include "MaskConfig.hpp"
+ 
+ #include "AppleUtils.h"
+ #include "MainThreadUtils.h"
+@@ -394,7 +395,48 @@ void gfxMacPlatformFontList::LookupSystemFont(LookAndFeel::FontID aSystemFontID,
+   }
+   NS_ASSERTION(font, "system font not set");
+ 
+-  aSystemFontName.AssignASCII("-apple-system");
++  // Camoufox: spoof the CSS2 system-font keyword family resolution
++  // (caption / icon / menu / message-box / small-caption / status-bar)
++  // based on navigator.platform. This is the cocoa sibling of the GTK
++  // hook in widget/gtk/nsLookAndFeel.cpp::PerThemeData::GetFont.
++  //
++  // Without this hook the Mac build always emits "-apple-system" here,
++  // which CreepJS's GeckoFonts map attributes to "Mac" — leaking the
++  // host OS through `getComputedStyle().fontFamily` even when
++  // navigator.platform is spoofed to Win32.
++  //
++  // The Camoufox-runs-RFP-by-default premise that the nsLayoutUtils.cpp
++  // hunk relied on is no longer true: privacy.resistFingerprinting is
++  // off and FontVisibilityRestrictGenerics is not in the default RFP
++  // target set, so ComputeSystemFont takes the LookAndFeel::GetFont
++  // branch on every call. On Mac that lands here.
++  //
++  // The platform classification is cached in a function-static for the
++  // same reason as the sibling hooks: CreepJS uses probe duration as a
++  // probabilistic headless signal.
++  enum class SpoofedOS { Other, Mac, Win };
++  static const SpoofedOS sSpoofedOS = []() {
++    auto platform = MaskConfig::GetString("navigator.platform");
++    if (!platform) return SpoofedOS::Other;
++    const std::string& p = platform.value();
++    auto starts_with = [&](const char* prefix) {
++      size_t n = std::strlen(prefix);
++      return p.size() >= n &&
++             std::equal(prefix, prefix + n, p.begin(),
++                        [](char a, char b) {
++                          return std::tolower(static_cast<unsigned char>(a)) ==
++                                 std::tolower(static_cast<unsigned char>(b));
++                        });
++    };
++    if (starts_with("mac")) return SpoofedOS::Mac;
++    if (starts_with("win")) return SpoofedOS::Win;
++    return SpoofedOS::Other;
++  }();
++  if (sSpoofedOS == SpoofedOS::Win) {
++    aSystemFontName.AssignASCII("Segoe UI");
++  } else {
++    aSystemFontName.AssignASCII("-apple-system");
++  }
+ 
+   NSFontSymbolicTraits traits = font.fontDescriptor.symbolicTraits;
+   aFontStyle.style = (traits & NSFontItalicTrait) ? FontSlantStyle::ITALIC
+
+--- a/gfx/thebes/moz.build
++++ b/gfx/thebes/moz.build
+@@ -302,3 +302,9 @@
+
+ # DOM Mask
+ LOCAL_INCLUDES += ["/camoucfg"]
++
++# Objective-C++ compilation in this directory keeps exceptions enabled for
++# ObjC @try/@catch even when C++ has -fno-exceptions, which makes
++# nlohmann/json (transitively included via MaskConfig.hpp) emit `throw`
++# expressions that don't compile. Force the JSON_THROW=std::abort path.
++DEFINES["JSON_NOEXCEPTION"] = True

--- a/patches/playwright/0-playwright.patch
+++ b/patches/playwright/0-playwright.patch
@@ -1440,7 +1440,14 @@ diff --git a/dom/html/HTMLInputElement.cpp b/dom/html/HTMLInputElement.cpp
 index e3698a2cbc..dce23cb29d 100644
 --- a/dom/html/HTMLInputElement.cpp
 +++ b/dom/html/HTMLInputElement.cpp
-@@ -46,6 +46,7 @@
+@@ -39,20 +39,21 @@
+ #include "mozilla/dom/Document.h"
+ #include "mozilla/dom/DocumentInlines.h"
+ #include "mozilla/dom/DocumentOrShadowRoot.h"
+ #include "mozilla/dom/ElementBinding.h"
+ #include "mozilla/dom/FileSystemUtils.h"
+ #include "mozilla/dom/FormData.h"
+ #include "mozilla/dom/GetFilesHelper.h"
  #include "mozilla/dom/HTMLDataListElement.h"
  #include "mozilla/dom/HTMLOptionElement.h"
  #include "mozilla/dom/InputType.h"
@@ -1448,7 +1455,21 @@ index e3698a2cbc..dce23cb29d 100644
  #include "mozilla/dom/MouseEvent.h"
  #include "mozilla/dom/NumericInputTypes.h"
  #include "mozilla/dom/ProgressEvent.h"
-@@ -870,6 +871,13 @@ nsresult HTMLInputElement::InitColorPicker() {
+ #include "mozilla/dom/UnionTypes.h"
+ #include "mozilla/dom/UserActivation.h"
+ #include "mozilla/dom/WheelEventBinding.h"
+ #include "mozilla/dom/WindowContext.h"
+ #include "mozilla/dom/WindowGlobalChild.h"
+ #include "mozilla/glean/DomMetrics.h"
+ #include "nsAttrValueInlines.h"
+@@ -922,20 +923,27 @@
+   }
+ 
+   // Get parent nsPIDOMWindow object.
+   nsCOMPtr<Document> doc = OwnerDoc();
+ 
+   RefPtr<BrowsingContext> bc = doc->GetBrowsingContext();
+   if (!bc) {
      return NS_ERROR_FAILURE;
    }
  
@@ -1462,6 +1483,14 @@ index e3698a2cbc..dce23cb29d 100644
    if (IsPickerBlocked(doc)) {
      return NS_OK;
    }
+ 
+   // Get Loc title
+   nsAutoString title;
+   nsAutoString okButtonLabel;
+   if (aType == FILE_PICKER_DIRECTORY) {
+     nsContentUtils::GetMaybeLocalizedString(PropertiesFile::FORMS_PROPERTIES,
+                                             "DirectoryUpload", doc, title);
+
 diff --git a/dom/interfaces/base/nsIDOMWindowUtils.idl b/dom/interfaces/base/nsIDOMWindowUtils.idl
 index 5c0c24dc52..44284cc319 100644
 --- a/dom/interfaces/base/nsIDOMWindowUtils.idl
@@ -1497,7 +1526,28 @@ diff --git a/dom/ipc/BrowserChild.cpp b/dom/ipc/BrowserChild.cpp
 index c6d774103c..9389fb3742 100644
 --- a/dom/ipc/BrowserChild.cpp
 +++ b/dom/ipc/BrowserChild.cpp
-@@ -1840,6 +1840,21 @@ void BrowserChild::HandleRealMouseButtonEvent(
+@@ -1609,9 +1609,19 @@ mozilla::ipc::IPCResult BrowserChild::RecvNormalPriorityRealMouseMoveEvent(
+ mozilla::ipc::IPCResult BrowserChild::RecvRealMouseMoveEvent(
+     const WidgetMouseEvent& aMouseEvent, const ScrollableLayerGuid& aGuid,
+     const uint64_t& aInputBlockId) {
+   MOZ_ASSERT(!aMouseEvent.AsPointerEvent());
+   MOZ_ASSERT(!aMouseEvent.AsDragEvent());
+-  if (mCoalesceMouseMoveEvents && mCoalescedMouseEventFlusher) {
++  // Playwright/juggler: synthesized mouse events (mJugglerEventId != 0) await a
++  // per-event "juggler-mouse-event-hit-renderer" observer notification that is
++  // only fired from HandleRealMouseButtonEvent. Coalescing defers dispatch to
++  // the next nsRefreshDriver tick, which under heavy parallel load (many
++  // browsers, software rendering) can be many seconds late — long enough to
++  // pin activateAndRun's serialization chain. Skip the coalescing branch for
++  // juggler-originated events so they dispatch immediately and ack in
++  // milliseconds; real (non-juggler) events still benefit from the coalescing
++  // optimization.
++  if (mCoalesceMouseMoveEvents && mCoalescedMouseEventFlusher &&
++      !aMouseEvent.mJugglerEventId) {
+     CoalescedMouseData* data =
+         mCoalescedMouseData.GetOrInsertNew(aMouseEvent.pointerId);
+     MOZ_ASSERT(data);
+@@ -1840,6 +1850,21 @@ void BrowserChild::HandleRealMouseButtonEvent(
    if (postLayerization) {
      postLayerization->Register();
    }

--- a/patches/screen-spoofing.patch
+++ b/patches/screen-spoofing.patch
@@ -1,354 +1,28 @@
-diff --git a/dom/base/ScreenDimensionManager.cpp b/dom/base/ScreenDimensionManager.cpp
-new file mode 100644
-index 0000000000..f5d2c23df5
---- /dev/null
-+++ b/dom/base/ScreenDimensionManager.cpp
-@@ -0,0 +1,104 @@
-+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
-+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
-+/* This Source Code Form is subject to the terms of the Mozilla Public
-+ * License, v. 2.0. If a copy of the MPL was not distributed with this
-+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-+
-+#include "ScreenDimensionManager.h"
-+#include "RoverfoxStorageManager.h"
-+#include "nsGlobalWindowInner.h"
-+#include "xpcpublic.h"
-+#include "mozilla/dom/BrowsingContext.h"
-+#include "mozilla/dom/Document.h"
-+#include "nsDocShell.h"
-+
-+namespace mozilla {
-+namespace dom {
-+
-+/* static */ uint32_t
-+ScreenDimensionManager::GetUserContextIdFromWindow(nsGlobalWindowInner* aWindow) {
-+  if (!aWindow) {
-+    return 0;
-+  }
-+  uint32_t userContextId = 0;
-+  if (BrowsingContext* bc = aWindow->GetBrowsingContext()) {
-+    userContextId = bc->OriginAttributesRef().mUserContextId;
-+  }
-+  return userContextId;
-+}
-+
-+/* static */ void
-+ScreenDimensionManager::SetDimensions(uint32_t aUserContextId, int32_t aWidth, int32_t aHeight) {
-+  nsString widthKey, heightKey;
-+  widthKey.AppendPrintf("screenWidth_%u", aUserContextId);
-+  heightKey.AppendPrintf("screenHeight_%u", aUserContextId);
-+  RoverfoxStorageManager::PutUint(widthKey, static_cast<uint32_t>(aWidth));
-+  RoverfoxStorageManager::PutUint(heightKey, static_cast<uint32_t>(aHeight));
-+}
-+
-+/* static */ bool
-+ScreenDimensionManager::GetDimensions(uint32_t aUserContextId, int32_t* aWidth, int32_t* aHeight) {
-+  nsString widthKey, heightKey;
-+  widthKey.AppendPrintf("screenWidth_%u", aUserContextId);
-+  heightKey.AppendPrintf("screenHeight_%u", aUserContextId);
-+
-+  uint32_t width = 0, height = 0;
-+  RoverfoxStorageManager::GetUint(widthKey, width);
-+  RoverfoxStorageManager::GetUint(heightKey, height);
-+
-+  if (width > 0 && height > 0) {
-+    *aWidth = static_cast<int32_t>(width);
-+    *aHeight = static_cast<int32_t>(height);
-+    return true;
-+  }
-+  return false;
-+}
-+
-+/* static */ void
-+ScreenDimensionManager::SetColorDepth(uint32_t aUserContextId, int32_t aColorDepth) {
-+  nsString key;
-+  key.AppendPrintf("screenColorDepth_%u", aUserContextId);
-+  RoverfoxStorageManager::PutUint(key, static_cast<uint32_t>(aColorDepth));
-+}
-+
-+/* static */ int32_t
-+ScreenDimensionManager::GetColorDepth(uint32_t aUserContextId) {
-+  nsString key;
-+  key.AppendPrintf("screenColorDepth_%u", aUserContextId);
-+  uint32_t depth = 0;
-+  RoverfoxStorageManager::GetUint(key, depth);
-+  return static_cast<int32_t>(depth);
-+}
-+
-+/* static */ nsString
-+ScreenDimensionManager::DisabledKeyForUserContext(uint32_t userContextId) {
-+  nsString key;
-+  key.AppendPrintf("screen_disabled_%u", userContextId);
-+  return key;
-+}
-+
-+/* static */ void
-+ScreenDimensionManager::DisableFunction(uint32_t userContextId) {
-+  nsString key = DisabledKeyForUserContext(userContextId);
-+  RoverfoxStorageManager::PutBool(key, true);
-+}
-+
-+/* static */ bool
-+ScreenDimensionManager::IsFunctionEnabledForWebIDL(JSContext* aCx, JSObject* aObj) {
-+  nsGlobalWindowInner* win = xpc::WindowOrNull(aObj);
-+  if (!win) {
-+    return false;
-+  }
-+
-+  uint32_t userContextId = 0;
-+  if (BrowsingContext* bc = win->GetBrowsingContext()) {
-+    userContextId = bc->OriginAttributesRef().mUserContextId;
-+  }
-+
-+  bool disabled = false;
-+  RoverfoxStorageManager::GetBool(DisabledKeyForUserContext(userContextId), disabled);
-+  return !disabled;
-+}
-+
-+}  // namespace dom
-+}  // namespace mozilla
-diff --git a/dom/base/ScreenDimensionManager.h b/dom/base/ScreenDimensionManager.h
-new file mode 100644
-index 0000000000..329f709a60
---- /dev/null
-+++ b/dom/base/ScreenDimensionManager.h
-@@ -0,0 +1,47 @@
-+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
-+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
-+/* This Source Code Form is subject to the terms of the Mozilla Public
-+ * License, v. 2.0. If a copy of the MPL was not distributed with this
-+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-+
-+#ifndef mozilla_dom_ScreenDimensionManager_h
-+#define mozilla_dom_ScreenDimensionManager_h
-+
-+#include "nsString.h"
-+
-+// Forward declarations for WebIDL binding (avoid js/TypeDecls.h namespace pollution)
-+struct JSContext;
-+class JSObject;
-+
-+class nsGlobalWindowInner;
-+
-+namespace mozilla {
-+namespace dom {
-+
-+class ScreenDimensionManager {
-+ public:
-+  // Get userContextId from window for storage key
-+  static uint32_t GetUserContextIdFromWindow(nsGlobalWindowInner* aWindow);
-+
-+  // Set/get screen dimensions for a user context
-+  static void SetDimensions(uint32_t aUserContextId, int32_t aWidth, int32_t aHeight);
-+  static bool GetDimensions(uint32_t aUserContextId, int32_t* aWidth, int32_t* aHeight);
-+
-+  // Set/get color depth for a user context
-+  static void SetColorDepth(uint32_t aUserContextId, int32_t aColorDepth);
-+  static int32_t GetColorDepth(uint32_t aUserContextId);
-+
-+  // Self-destruct support
-+  static void DisableFunction(uint32_t userContextId);
-+
-+  // WebIDL exposure check
-+  static bool IsFunctionEnabledForWebIDL(JSContext* aCx, JSObject* aObj);
-+
-+ private:
-+  static nsString DisabledKeyForUserContext(uint32_t userContextId);
-+};
-+
-+}  // namespace dom
-+}  // namespace mozilla
-+
-+#endif  // mozilla_dom_ScreenDimensionManager_h
-diff --git a/dom/base/moz.build b/dom/base/moz.build
-index 8e94c6bd70..8787fc79f5 100644
---- a/dom/base/moz.build
-+++ b/dom/base/moz.build
-@@ -262,6 +262,7 @@ EXPORTS.mozilla.dom += [
-     "ResponsiveImageSelector.h",
-     "RoverfoxStorageManager.h",
-     "SameProcessMessageQueue.h",
-+    "ScreenDimensionManager.h",
-     "ScreenLuminance.h",
-     "ScreenOrientation.h",
-     "Selection.h",
-@@ -473,6 +474,7 @@ UNIFIED_SOURCES += [
-     "ResponsiveImageSelector.cpp",
-     "RoverfoxStorageManager.cpp",
-     "SameProcessMessageQueue.cpp",
-+    "ScreenDimensionManager.cpp",
-     "ScreenLuminance.cpp",
-     "ScreenOrientation.cpp",
-     "ScriptableContentIterator.cpp",
-diff --git a/dom/base/nsGlobalWindowInner.cpp b/dom/base/nsGlobalWindowInner.cpp
-index 5c3d639da9..bab87396cc 100644
---- a/dom/base/nsGlobalWindowInner.cpp
-+++ b/dom/base/nsGlobalWindowInner.cpp
-@@ -286,6 +286,7 @@
- #include "nsISlowScriptDebug.h"
- #include "nsISupportsPrimitives.h"
- #include "nsISupportsUtils.h"
-+#include "ScreenDimensionManager.h"
- #include "nsIThread.h"
- #include "nsITimedChannel.h"
- #include "nsIURI.h"
-@@ -7727,6 +7728,52 @@ nsISerialEventTarget* nsGlobalWindowInner::SerialEventTarget() const {
-   return GetMainThreadSerialEventTarget();
- }
- 
-+void nsGlobalWindowInner::SetScreenDimensions(int32_t aWidth, int32_t aHeight,
-+                                              ErrorResult& aRv) {
-+  uint32_t userContextId = ScreenDimensionManager::GetUserContextIdFromWindow(this);
-+
-+  if (aWidth <= 0 || aHeight <= 0) {
-+    aRv.ThrowTypeError("Screen dimensions must be positive integers");
-+    return;
-+  }
-+
-+  ScreenDimensionManager::SetDimensions(userContextId, aWidth, aHeight);
-+  ScreenDimensionManager::DisableFunction(userContextId);
-+
-+  // Self-destruct: set to undefined first to bust IC/shape caches on ARM64.
-+  if (JSContext* cx = nsContentUtils::GetCurrentJSContext()) {
-+    JS::Rooted<JSObject*> global(cx, JS::CurrentGlobalOrNull(cx));
-+    if (global) {
-+      JS::Rooted<JS::Value> undef(cx, JS::UndefinedValue());
-+      JS_SetProperty(cx, global, "setScreenDimensions", undef);
-+      JS_DeleteProperty(cx, global, "setScreenDimensions");
-+    }
-+  }
-+}
-+
-+void nsGlobalWindowInner::SetScreenColorDepth(int32_t aColorDepth,
-+                                              ErrorResult& aRv) {
-+  uint32_t userContextId = ScreenDimensionManager::GetUserContextIdFromWindow(this);
-+
-+  if (aColorDepth <= 0) {
-+    aRv.ThrowTypeError("Color depth must be a positive integer");
-+    return;
-+  }
-+
-+  ScreenDimensionManager::SetColorDepth(userContextId, aColorDepth);
-+  ScreenDimensionManager::DisableFunction(userContextId);
-+
-+  // Self-destruct: set to undefined first to bust IC/shape caches on ARM64.
-+  if (JSContext* cx = nsContentUtils::GetCurrentJSContext()) {
-+    JS::Rooted<JSObject*> global(cx, JS::CurrentGlobalOrNull(cx));
-+    if (global) {
-+      JS::Rooted<JS::Value> undef(cx, JS::UndefinedValue());
-+      JS_SetProperty(cx, global, "setScreenColorDepth", undef);
-+      JS_DeleteProperty(cx, global, "setScreenColorDepth");
-+    }
-+  }
-+}
-+
- Worklet* nsGlobalWindowInner::GetPaintWorklet(ErrorResult& aRv) {
-   if (!mPaintWorklet) {
-     nsIPrincipal* principal = GetPrincipal();
-diff --git a/dom/base/nsGlobalWindowInner.h b/dom/base/nsGlobalWindowInner.h
-index 54b50f7bb1..4f807813d1 100644
---- a/dom/base/nsGlobalWindowInner.h
-+++ b/dom/base/nsGlobalWindowInner.h
-@@ -679,6 +679,10 @@ class nsGlobalWindowInner final : public mozilla::dom::EventTarget,
-   // Audio fingerprint seed for per-context audio fingerprinting
-   void SetAudioFingerprintSeed(uint32_t seed, mozilla::ErrorResult& aRv);
- 
-+  // Screen dimension methods for per-context screen spoofing
-+  void SetScreenDimensions(int32_t aWidth, int32_t aHeight, mozilla::ErrorResult& aRv);
-+  void SetScreenColorDepth(int32_t aColorDepth, mozilla::ErrorResult& aRv);
-+
-   void GetWebExposedLocales(nsTArray<nsString>& aLocales);
- 
-   mozilla::dom::IntlUtils* GetIntlUtils(mozilla::ErrorResult& aRv);
 diff --git a/dom/base/nsScreen.cpp b/dom/base/nsScreen.cpp
 index 78849001c5..dc329c8424 100644
 --- a/dom/base/nsScreen.cpp
 +++ b/dom/base/nsScreen.cpp
-@@ -12,6 +12,8 @@
- #include "mozilla/dom/DocumentInlines.h"
- #include "mozilla/widget/ScreenManager.h"
- #include "nsCOMPtr.h"
-+#include "ScreenDimensionManager.h"
-+#include "nsContentUtils.h"
- #include "nsDeviceContext.h"
- #include "nsGlobalWindowInner.h"
- #include "nsGlobalWindowOuter.h"
-@@ -73,6 +75,26 @@ nsDeviceContext* nsScreen::GetDeviceContext() const {
+@@ -73,6 +73,12 @@ nsDeviceContext* nsScreen::GetDeviceContext() const {
  }
  
  CSSIntRect nsScreen::GetRect() {
-+  // Check for per-context screen dimensions first
-+  if (nsPIDOMWindowOuter* outer = GetOuter()) {
-+    if (nsPIDOMWindowInner* inner = outer->GetCurrentInnerWindow()) {
-+      nsGlobalWindowInner* win = nsGlobalWindowInner::Cast(inner);
-+      if (win) {
-+        uint32_t userContextId = mozilla::dom::ScreenDimensionManager::GetUserContextIdFromWindow(win);
-+        int32_t w = 0, h = 0;
-+        if (mozilla::dom::ScreenDimensionManager::GetDimensions(userContextId, &w, &h)) {
-+          return {0, 0, w, h};
-+        }
-+      }
-+    }
-+  }
-+
-+  // Fallback to global MaskConfig override
-+  if (auto height = MaskConfig::GetInt32("screen.height"),
-+      width = MaskConfig::GetInt32("screen.width");
-+      height && width) {
++  // Camoufox: report the spoofed screen size from the injected config.
++  if (auto width = MaskConfig::GetInt32("screen.width"),
++      height = MaskConfig::GetInt32("screen.height");
++      width && height) {
 +    return {0, 0, width.value(), height.value()};
 +  }
    // Return window inner rect to prevent fingerprinting.
    if (ShouldResistFingerprinting(RFPTarget::ScreenRect)) {
      return GetTopWindowInnerRectForRFP();
-@@ -105,6 +127,24 @@ CSSIntRect nsScreen::GetRect() {
+@@ -105,6 +111,7 @@ CSSIntRect nsScreen::GetRect() {
  }
  
  CSSIntRect nsScreen::GetAvailRect() {
-+  // Check for per-context screen avail dimensions first
-+  if (nsPIDOMWindowOuter* outer = GetOuter()) {
-+    if (nsPIDOMWindowInner* inner = outer->GetCurrentInnerWindow()) {
-+      nsGlobalWindowInner* win = nsGlobalWindowInner::Cast(inner);
-+      if (win) {
-+        uint32_t userContextId = mozilla::dom::ScreenDimensionManager::GetUserContextIdFromWindow(win);
-+        int32_t w = 0, h = 0;
-+        if (mozilla::dom::ScreenDimensionManager::GetDimensions(userContextId, &w, &h)) {
-+          int32_t availTop = 25;
-+          if (auto top = MaskConfig::GetInt32("screen.availTop"); top.has_value()) {
-+            availTop = top.value();
-+          }
-+          return {0, availTop, w, h - availTop};
-+        }
-+      }
-+    }
-+  }
-+
++  // Camoufox: report the spoofed available screen rect from the injected config.
    auto rect = MaskConfig::GetRect("screen.availLeft", "screen.availTop",
                                    "screen.availWidth", "screen.availHeight");
    if (rect.has_value()) {
-diff --git a/dom/webidl/Window.webidl b/dom/webidl/Window.webidl
-index 1aa2baa931..4f5479fc2e 100644
---- a/dom/webidl/Window.webidl
-+++ b/dom/webidl/Window.webidl
-@@ -929,6 +929,18 @@ partial interface Window {
-   readonly attribute IntlUtils intlUtils;
- };
- 
-+// Screen dimension for per-context screen spoofing
-+partial interface Window {
-+  [Throws, Func="mozilla::dom::ScreenDimensionManager::IsFunctionEnabledForWebIDL"]
-+  undefined setScreenDimensions(long width, long height);
-+};
-+
-+// Screen color depth for per-context screen spoofing
-+partial interface Window {
-+  [Throws, Func="mozilla::dom::ScreenDimensionManager::IsFunctionEnabledForWebIDL"]
-+  undefined setScreenColorDepth(long colorDepth);
-+};
-+
- partial interface Window {
-   [SameObject, Replaceable]
-   readonly attribute VisualViewport visualViewport;
 diff --git a/gfx/src/moz.build b/gfx/src/moz.build
 index 91fd96a691..03adf5d674 100644
 --- a/gfx/src/moz.build
@@ -393,31 +67,29 @@ diff --git a/layout/style/nsMediaFeatures.cpp b/layout/style/nsMediaFeatures.cpp
 index 5e39014539..fac13c27a7 100644
 --- a/layout/style/nsMediaFeatures.cpp
 +++ b/layout/style/nsMediaFeatures.cpp
-@@ -22,6 +22,8 @@
+@@ -22,6 +22,7 @@
  #include "nsContentUtils.h"
  #include "nsDeviceContext.h"
  #include "nsGlobalWindowOuter.h"
-+#include "nsGlobalWindowInner.h"
-+#include "mozilla/dom/ScreenDimensionManager.h"
++#include "MaskConfig.hpp"
  #include "nsIBaseWindow.h"
  #include "nsIDocShell.h"
  #include "nsIPrintSettings.h"
-@@ -62,6 +64,18 @@ static nsSize GetDeviceSize(const Document& aDocument) {
-     return GetSize(aDocument);
-   }
+@@ -58,6 +59,17 @@ static nsSize GetSize(const Document& aDocument) {
  
-+  // Camoufox: per-context screen dimensions for CSS device-width/height queries
-+  if (nsPIDOMWindowInner* inner = aDocument.GetInnerWindow()) {
-+    nsGlobalWindowInner* win = nsGlobalWindowInner::Cast(inner);
-+    if (win) {
-+      uint32_t ucid = mozilla::dom::ScreenDimensionManager::GetUserContextIdFromWindow(win);
-+      int32_t w = 0, h = 0;
-+      if (mozilla::dom::ScreenDimensionManager::GetDimensions(ucid, &w, &h)) {
-+        return CSSPixel::ToAppUnits(CSSIntSize(w, h));
-+      }
-+    }
+ // A helper for three features below.
+ static nsSize GetDeviceSize(const Document& aDocument) {
++  // Camoufox: report the spoofed screen size for CSS device-width/height so
++  // they agree with screen.width/height (nsScreen::GetRect). This must run
++  // before the RFP early-return below, since Camoufox runs with
++  // ResistFingerprinting enabled and RFPTarget::CSSDeviceSize would otherwise
++  // return the real window size -- an internal-inconsistency lie signal.
++  if (auto width = MaskConfig::GetInt32("screen.width"),
++      height = MaskConfig::GetInt32("screen.height");
++      width && height) {
++    return CSSPixel::ToAppUnits(CSSIntSize(width.value(), height.value()));
 +  }
 +
-   // Media queries in documents in an RDM pane should use the simulated
-   // device size.
-   Maybe<CSSIntSize> deviceSize =
+   if (aDocument.ShouldResistFingerprinting(RFPTarget::CSSDeviceSize)) {
+     return GetSize(aDocument);
+   }

--- a/patches/sessionstore-popup-close-crash.patch
+++ b/patches/sessionstore-popup-close-crash.patch
@@ -1,0 +1,25 @@
+diff --git a/browser/components/sessionstore/SessionStore.sys.mjs b/browser/components/sessionstore/SessionStore.sys.mjs
+index 183543c5f2..a2a236c7c8 100644
+--- a/browser/components/sessionstore/SessionStore.sys.mjs
++++ b/browser/components/sessionstore/SessionStore.sys.mjs
+@@ -4884,8 +4884,19 @@ var SessionStoreInternal = {
+   },
+
+   maybeDontRestoreTabs(aWindow) {
++    // Camoufox: a window.open() popup created with window features opens as a
++    // separate chrome window that SessionStore may never have registered (the
++    // popup-window path can skip onLoad tracking, and our session-restore is
++    // disabled). globalOverlay.js calls this unconditionally on window close, so
++    // an untracked window left this._windows[aWindow.__SSi] undefined and the
++    // bare property set threw, crashing Browser.removeBrowserContext and killing
++    // the juggler channel. No-op for untracked windows, matching onClose's guard.
++    const winData = aWindow.__SSi && this._windows[aWindow.__SSi];
++    if (!winData) {
++      return;
++    }
+     // Don't restore the tabs if we restore the session at startup
+-    this._windows[aWindow.__SSi]._maybeDontRestoreTabs = true;
++    winData._maybeDontRestoreTabs = true;
+   },
+
+   isLastRestorableWindow() {

--- a/patches/webrtc-ip-spoofing.patch
+++ b/patches/webrtc-ip-spoofing.patch
@@ -355,21 +355,37 @@ index 063843934e..11736cc985 100644
  
    void ForgetSharedWorker(mozilla::dom::SharedWorker* aSharedWorker);
 diff --git a/dom/media/webrtc/jsapi/PeerConnectionImpl.cpp b/dom/media/webrtc/jsapi/PeerConnectionImpl.cpp
-index e9afe2cfb2..57a8e1cad8 100644
+index 91f927902f..b1f3c6980d 100644
 --- a/dom/media/webrtc/jsapi/PeerConnectionImpl.cpp
 +++ b/dom/media/webrtc/jsapi/PeerConnectionImpl.cpp
-@@ -98,6 +98,10 @@
+@@ -99,6 +99,11 @@
  #include "mozilla/glean/DomMediaWebrtcMetrics.h"
  #include "mozilla/net/DataChannelProtocol.h"
  #include "mozilla/net/WebrtcProxyConfig.h"
 +#include "MaskConfig.hpp"
++#include "mozilla/RandomNum.h"
 +#include "mozilla/RustRegex.h"
 +#include "WebRTCIPManager.h"
 +#include "nsDocShell.h"
  #include "nsContentUtils.h"
  #include "nsDOMJSUtils.h"
  #include "nsGlobalWindowInner.h"
-@@ -1585,7 +1589,15 @@ PeerConnectionImpl::SetLocalDescription(int32_t aAction, const char* aSDP) {
+@@ -228,6 +233,14 @@ class DataChannel;
+ 
+ namespace mozilla {
+ 
++// Camoufox: ICE candidate priorities for the fabricated host/srflx candidates,
++// measured from real Firefox (constant across sessions). Defined here at the
++// top of the namespace because GetStats() (above the fabrication code) also
++// references kSrflxPriority. host UDP / host TCP / srflx.
++static constexpr uint32_t kHostUdpPriority = 2122252543u;
++static constexpr uint32_t kHostTcpPriority = 2105524479u;
++static constexpr uint32_t kSrflxPriority = 1686052863u;
++
+ void PeerConnectionAutoTimer::RegisterConnection() { mRefCnt++; }
+ 
+ void PeerConnectionAutoTimer::UnregisterConnection(bool aContainedAV) {
+@@ -1592,7 +1605,15 @@ PeerConnectionImpl::SetLocalDescription(int32_t aAction, const char* aSDP) {
      }
    };
  
@@ -386,54 +402,85 @@ index e9afe2cfb2..57a8e1cad8 100644
  
    SyncToJsep();
  
-@@ -1751,11 +1763,44 @@ already_AddRefed<dom::Promise> PeerConnectionImpl::GetStats(
+@@ -1751,11 +1772,75 @@ already_AddRefed<dom::Promise> PeerConnectionImpl::GetStats(
      MOZ_CRASH("Failed to create a promise!");
    }
  
-+  // Camoufox: Capture userContextId for stats sanitization
-+  uint32_t statsUserContextId = 0;
-+  if (mWindow) {
-+    if (BrowsingContext* bc = mWindow->GetBrowsingContext()) {
-+      statsUserContextId = bc->OriginAttributesRef().mUserContextId;
-+    }
-+  }
++  // Camoufox: stats sanitization reads the spoof IP from MaskConfig.
 +  bool shouldSanitizeStats = ShouldSpoofCandidateIP();
++  // The port of the fabricated srflx (if any), so the synthetic getStats
++  // entry below matches the candidate/SDP exactly. 0 = nothing fabricated.
++  uint16_t fabricatedSrflxPort = mFabricatedSrflxPort;
 +
    GetStats(aSelector, false)
        ->Then(
            GetMainThreadSerialEventTarget(), __func__,
 -          [promise,
 -           window = mWindow](UniquePtr<dom::RTCStatsReportInternal>&& aReport) {
-+          [promise, window = mWindow, statsUserContextId, shouldSanitizeStats](
++          [promise, window = mWindow, shouldSanitizeStats,
++           fabricatedSrflxPort](
 +              UniquePtr<dom::RTCStatsReportInternal>&& aReport) {
 +            // Camoufox: Sanitize IP addresses in stats before exposing to JS
 +            if (shouldSanitizeStats && aReport) {
-+              nsString ipv4, ipv6;
-+              WebRTCIPManager::GetIPv4(statsUserContextId, ipv4);
-+              WebRTCIPManager::GetIPv6(statsUserContextId, ipv6);
-+              NS_ConvertUTF16toUTF8 ipv4Utf8(ipv4);
-+              NS_ConvertUTF16toUTF8 ipv6Utf8(ipv6);
++              auto ipv4Opt = MaskConfig::GetString("webrtc:ipv4");
++              auto ipv6Opt = MaskConfig::GetString("webrtc:ipv6");
++              bool haveSrflx = false;
 +              for (auto& candStat : aReport->mIceCandidateStats) {
-+                if (candStat.mAddress.WasPassed() &&
-+                    !candStat.mAddress.Value().IsEmpty()) {
++                if (candStat.mCandidateType.WasPassed() &&
++                    candStat.mCandidateType.Value() ==
++                        dom::RTCIceCandidateType::Srflx) {
++                  haveSrflx = true;
++                }
++                if (candStat.mAddress.WasPassed() && !candStat.mAddress.Value().IsEmpty()) {
 +                  nsAutoCString addr;
 +                  addr.Assign(NS_ConvertUTF16toUTF8(candStat.mAddress.Value()));
-+                  // Check for colons AND no periods to avoid IPv4:port false
-+                  // positives
-+                  bool isIPv6 = addr.FindChar(':') != kNotFound &&
-+                                addr.FindChar('.') == kNotFound;
-+                  if (isIPv6 && !ipv6.IsEmpty()) {
-+                    candStat.mAddress.Value() = NS_ConvertUTF8toUTF16(ipv6Utf8);
-+                  } else if (!isIPv6 && !ipv4.IsEmpty()) {
-+                    candStat.mAddress.Value() = NS_ConvertUTF8toUTF16(ipv4Utf8);
++                  // Check for colons AND no periods to avoid IPv4:port false positives
++                  bool isIPv6 = addr.FindChar(':') != kNotFound && addr.FindChar('.') == kNotFound;
++                  if (isIPv6 && ipv6Opt) {
++                    candStat.mAddress.Value() = NS_ConvertUTF8toUTF16(ipv6Opt.value().c_str());
++                  } else if (!isIPv6 && ipv4Opt) {
++                    candStat.mAddress.Value() = NS_ConvertUTF8toUTF16(ipv4Opt.value().c_str());
 +                  }
++                }
++              }
++              // Camoufox: if we fabricated a srflx into the candidate stream /
++              // SDP (TCP-proxy case) but getStats() carries no srflx local
++              // candidate, add a matching one so the three surfaces agree.
++              // A srflx in the SDP with no local-candidate stat is itself a
++              // detectable inconsistency. Pair / RTT stats are intentionally
++              // NOT fabricated: they are legitimately absent with no remote
++              // peer, so leaving them empty matches a real browser.
++              std::string spoofIp = ipv4Opt ? ipv4Opt.value()
++                                            : (ipv6Opt ? ipv6Opt.value()
++                                                       : std::string());
++              if (!haveSrflx && !spoofIp.empty() && fabricatedSrflxPort != 0) {
++                dom::RTCIceCandidateStats cand;
++                cand.mType.Construct(dom::RTCStatsType::Local_candidate);
++                cand.mTimestamp.Construct(aReport->mTimestamp);
++                cand.mCandidateType.Construct(dom::RTCIceCandidateType::Srflx);
++                cand.mPriority.Construct(kSrflxPriority);
++                cand.mAddress.Construct(NS_ConvertUTF8toUTF16(spoofIp.c_str()));
++                cand.mPort.Construct(fabricatedSrflxPort);
++                cand.mProtocol.Construct(NS_ConvertASCIItoUTF16("udp"));
++                cand.mProxied.Construct(NS_ConvertASCIItoUTF16("proxied"));
++                cand.mId.Construct(NS_ConvertASCIItoUTF16("camou-srflx"));
++                // Associate with the same transport as the real candidates.
++                for (const auto& existing : aReport->mIceCandidateStats) {
++                  if (existing.mTransportId.WasPassed()) {
++                    cand.mTransportId.Construct(existing.mTransportId.Value());
++                    break;
++                  }
++                }
++                if (!aReport->mIceCandidateStats.AppendElement(cand,
++                                                               fallible)) {
++                  mozalloc_handle_oom(0);
 +                }
 +              }
 +            }
              RefPtr<RTCStatsReport> report(new RTCStatsReport(window));
              report->Incorporate(*aReport);
              promise->MaybeResolve(std::move(report));
-@@ -3274,12 +3319,22 @@ const std::string& PeerConnectionImpl::GetName() {
+@@ -3260,12 +3345,22 @@ const std::string& PeerConnectionImpl::GetName() {
    return mName;
  }
  
@@ -457,14 +504,18 @@ index e9afe2cfb2..57a8e1cad8 100644
    if (mForceIceTcp && std::string::npos != candidate.find(" UDP ")) {
      CSFLogWarn(LOGTAG, "Blocking local UDP candidate: %s", candidate.c_str());
      STAMP_TIMECARD(mTimeCard, "UDP Ice Candidate blocked");
-@@ -3342,10 +3397,197 @@ void PeerConnectionImpl::SendLocalIceCandidateToContent(
+@@ -3328,10 +3423,393 @@ void PeerConnectionImpl::SendLocalIceCandidateToContent(
      uint16_t level, const std::string& mid, const std::string& candidate,
      const std::string& ufrag) {
    STAMP_TIMECARD(mTimeCard, "Send Ice Candidate to content");
--  JSErrorResult rv;
--  mPCObserver->OnIceCandidate(level, ObString(mid.c_str()),
--                              ObString(candidate.c_str()),
--                              ObString(ufrag.c_str()), rv);
++
++  // Camoufox: remember if a real public candidate ever reached content, so we
++  // only fabricate one at gathering-complete when ICE produced none.
++  if (candidate.find(" typ srflx ") != std::string::npos ||
++      candidate.find(" typ prflx ") != std::string::npos ||
++      candidate.find(" typ relay ") != std::string::npos) {
++    mSurfacedPublicCandidate = true;
++  }
 +
 +  // Check if IP spoofing is enabled
 +  if (ShouldSpoofCandidateIP()) {
@@ -482,18 +533,8 @@ index e9afe2cfb2..57a8e1cad8 100644
 +}
 +
 +bool PeerConnectionImpl::ShouldSpoofCandidateIP() const {
-+  if (!mWindow) {
-+    return false;
-+  }
-+
-+  uint32_t userContextId = 0;
-+  if (BrowsingContext* bc = mWindow->GetBrowsingContext()) {
-+    userContextId = bc->OriginAttributesRef().mUserContextId;
-+  }
-+
-+  nsString ipv4, ipv6;
-+  return WebRTCIPManager::GetIPv4(userContextId, ipv4) ||
-+         WebRTCIPManager::GetIPv6(userContextId, ipv6);
++  return MaskConfig::GetString("webrtc:ipv4").has_value() ||
++         MaskConfig::GetString("webrtc:ipv6").has_value();
 +}
 +
 +// *****
@@ -538,18 +579,16 @@ index e9afe2cfb2..57a8e1cad8 100644
 +  // Use colons AND no periods to avoid IPv4:port false positives
 +  bool isIPv6 = (ip.find(':') != std::string::npos) && (ip.find('.') == std::string::npos);
 +
-+  // Get IP addresses from WebRTCIPManager for this user context
-+  nsString ipv4Value, ipv6Value;
-+  bool hasIPv4 = WebRTCIPManager::GetIPv4(userContextId, ipv4Value);
-+  bool hasIPv6 = WebRTCIPManager::GetIPv6(userContextId, ipv6Value);
-+  
++  auto ipv4Value = MaskConfig::GetString("webrtc:ipv4");
++  auto ipv6Value = MaskConfig::GetString("webrtc:ipv6");
++
 +  if (isIPv6) {
-+    if (hasIPv6) {
-+      return NS_ConvertUTF16toUTF8(ipv6Value).get();
++    if (ipv6Value) {
++      return ipv6Value.value();
 +    }
 +  } else {
-+    if (hasIPv4) {
-+      return NS_ConvertUTF16toUTF8(ipv4Value).get();
++    if (ipv4Value) {
++      return ipv4Value.value();
 +    }
 +  }
 +  // return original ip if no mask is available
@@ -654,12 +693,247 @@ index e9afe2cfb2..57a8e1cad8 100644
 +  if (processedSdp != originalSdp) {
 +    sdp = processedSdp;
 +  }
-+  
++
 +  return NS_OK;
++}
++
++// *****
++// Synthetic srflx fabrication (TCP-proxy case)
++// *****
++//
++// Behind a TCP/HTTP proxy, STUN (UDP) cannot traverse, so no server-reflexive
++// candidate ever forms and the rewrite paths above have nothing to operate on
++// -> WebRTC reports n/a, which anti-bot systems flag. We fabricate a synthetic
++// srflx carrying the spoof IP (the proxy exit IP, already in config) so the
++// page sees a plausible public candidate. The port/priority are derived as a
++// pure function of the spoof IP so the live-stream, SDP, and getStats() copies
++// all agree without threading state through the stats continuation.
++
++// A fresh random ephemeral port per PeerConnection. Real Firefox binds a new
++// UDP socket per PeerConnection and REUSES that port for the host candidate and
++// its srflx; we mirror that (one port, shared, random per PC) -- never derived
++// from the IP. The only observable pattern is the RANGE: it must be the OS
++// ephemeral range, which is OS-specific. Linux uses 32768-60999 (the kernel
++// default ip_local_port_range); Windows/macOS use 49152-65535. Pick the range
++// matching the SPOOFED OS (navigator.platform) so a Linux profile never emits a
++// >60999 port that real Linux Firefox couldn't, and vice-versa.
++static uint16_t RandomEphemeralPort() {
++  uint16_t lo = 32768, hi = 60999;  // Linux default
++  auto platform = MaskConfig::GetString("navigator.platform");
++  if (platform) {
++    const std::string& p = platform.value();
++    // "Win32"/"Win64" -> Windows, "MacIntel"/"Mac" -> macOS: both 49152-65535.
++    if (p.find("Win") != std::string::npos ||
++        p.find("Mac") != std::string::npos) {
++      lo = 49152;
++      hi = 65535;
++    }
++  }
++  uint32_t span = static_cast<uint32_t>(hi - lo) + 1u;
++  return static_cast<uint16_t>(lo + (mozilla::RandomUint64OrDie() % span));
++}
++
++// A realistic STUN round-trip delay (ms) before the srflx surfaces. Real
++// Firefox emits the srflx ~30-90ms after the host candidate; a zero-delay
++// srflx (host and srflx arriving together) is an unnatural timing signature.
++static uint32_t RandomSrflxDelayMs() {
++  return static_cast<uint32_t>(30u + (mozilla::RandomUint64OrDie() % 60u));
++}
++
++// Extract the value of the first "<prefix><value>" line in an SDP (prefix like
++// "a=mid:" or "a=ice-ufrag:"). Returns empty string if not found.
++static std::string FirstSdpLineValue(const std::string& sdp,
++                                     const std::string& prefix) {
++  std::istringstream iss(sdp);
++  std::string line;
++  while (std::getline(iss, line)) {
++    while (!line.empty() && (line.back() == '\r' || line.back() == '\n')) {
++      line.pop_back();
++    }
++    if (line.compare(0, prefix.size(), prefix) == 0) {
++      return line.substr(prefix.size());
++    }
++  }
++  return std::string();
++}
++
++void PeerConnectionImpl::MaybeFabricateSrflxCandidate() {
++  if (!ShouldSpoofCandidateIP() || mSurfacedPublicCandidate) {
++    return;
++  }
++
++  auto ipv4Opt = MaskConfig::GetString("webrtc:ipv4");
++  auto ipv6Opt = MaskConfig::GetString("webrtc:ipv6");
++  std::string spoofIp = ipv4Opt ? ipv4Opt.value()
++                                : (ipv6Opt ? ipv6Opt.value() : std::string());
++  if (spoofIp.empty()) {
++    return;
++  }
++
++  // Attach to the first media section of the local description. Prefer the
++  // pending description (offer just set); fall back to current.
++  const std::string& sdp = !mPendingLocalDescription.empty()
++                               ? mPendingLocalDescription
++                               : mCurrentLocalDescription;
++  if (sdp.empty()) {
++    return;
++  }
++  std::string mid = FirstSdpLineValue(sdp, "a=mid:");
++  std::string ufrag = FirstSdpLineValue(sdp, "a=ice-ufrag:");
++  if (mid.empty() || ufrag.empty()) {
++    return;
++  }
++
++  // One random ephemeral port, shared by the UDP host candidate and the srflx,
++  // exactly as real Firefox reuses its local RTP port across both. Remember it
++  // so the getStats() synthetic srflx reports the same port.
++  uint16_t port = RandomEphemeralPort();
++  mFabricatedSrflxPort = port;
++
++  // mDNS .local hostname for the host candidates, like real Firefox
++  // (obfuscate_host_addresses). PCUuidGenerator yields "{uuid}"; strip braces.
++  // Both host candidates (UDP + TCP) share the same hostname, as real FF does.
++  std::string mdnsHost;
++  if (mUuidGen) {
++    std::string uuid;
++    if (mUuidGen->Generate(&uuid)) {
++      if (!uuid.empty() && uuid.front() == '{') uuid.erase(0, 1);
++      if (!uuid.empty() && uuid.back() == '}') uuid.pop_back();
++      mdnsHost = uuid + ".local";
++    }
++  }
++  if (mdnsHost.empty()) {
++    return;
++  }
++
++  // Helper: append an a=candidate line into both local-description strings,
++  // right after the first m-section's a=mid: line. The SDP attribute form is
++  // "a=candidate:<foundation>..." (no leading "candidate:"). Captures `this` and
++  // `mid` BY VALUE so it stays valid when copied into the delayed srflx runnable
++  // below (which keeps the PC alive via a strong RefPtr).
++  auto injectIntoSdp = [this, mid](const std::string& candStr) {
++    std::string sdpCand = candStr;
++    const std::string kCandPrefix = "candidate:";
++    if (sdpCand.compare(0, kCandPrefix.size(), kCandPrefix) == 0) {
++      sdpCand.erase(0, kCandPrefix.size());
++    }
++    std::string candLine = "a=candidate:" + sdpCand + "\r\n";
++    auto into = [&](std::string& target) {
++      if (target.empty()) return;
++      std::string midLine = "a=mid:" + mid;
++      size_t pos = target.find(midLine);
++      if (pos == std::string::npos) {
++        target += candLine;
++        return;
++      }
++      size_t eol = target.find('\n', pos);
++      if (eol == std::string::npos) {
++        target += "\r\n" + candLine;
++      } else {
++        target.insert(eol + 1, candLine);
++      }
++    };
++    into(mPendingLocalDescription);
++    into(mCurrentLocalDescription);
++  };
++
++  // Mark surfaced now so re-entrant ICE-state changes during the delay below
++  // don't fabricate a second set.
++  mSurfacedPublicCandidate = true;
++
+   JSErrorResult rv;
+-  mPCObserver->OnIceCandidate(level, ObString(mid.c_str()),
+-                              ObString(candidate.c_str()),
++
++  // STEP 1: the two host candidates first (UDP foundation 0, TCP foundation 2),
++  // sharing one mDNS hostname -- the exact pair real Firefox emits. CreepJS
++  // latches the first (UDP host) as "host connection" and its foundation 0 as
++  // "type & base ip". Neither carries a real IP (.local / port 9), so an
++  // IP-from-SDP probe still sees 0.0.0.0 and keeps waiting, just like a real
++  // browser whose srflx round-trip is still in flight.
++  std::ostringstream hostUdp;
++  hostUdp << "candidate:0 1 UDP " << kHostUdpPriority << " " << mdnsHost << " "
++          << port << " typ host";
++  std::string hostUdpCand = hostUdp.str();
++  injectIntoSdp(hostUdpCand);
++  mPCObserver->OnIceCandidate(0, ObString(mid.c_str()),
++                              ObString(hostUdpCand.c_str()),
++                              ObString(ufrag.c_str()), rv);
++
++  std::ostringstream hostTcp;
++  hostTcp << "candidate:2 1 TCP " << kHostTcpPriority << " " << mdnsHost
++          << " 9 typ host tcptype active";
++  std::string hostTcpCand = hostTcp.str();
++  injectIntoSdp(hostTcpCand);
++  mPCObserver->OnIceCandidate(0, ObString(mid.c_str()),
++                              ObString(hostTcpCand.c_str()),
+                               ObString(ufrag.c_str()), rv);
++
++  // STEP 2: the srflx (foundation 1, spoof/proxy IP, SAME port as the UDP host),
++  // delayed by a realistic STUN round-trip so the timing matches a real gather.
++  // The SDP line is added just before the event fires, so a fingerprinter that
++  // reads pc.localDescription.sdp inside the candidate handler (CreepJS's
++  // getIPAddress) sees the public IP on this event -> "stun connection" + "ip"
++  // populate. A strong ref keeps the PC alive across the delay; bail if closed.
++  std::ostringstream srflx;
++  srflx << "candidate:1 1 UDP " << kSrflxPriority << " " << spoofIp << " "
++        << port << " typ srflx raddr 0.0.0.0 rport 0";
++  std::string srflxCand = srflx.str();
++
++  RefPtr<PeerConnectionImpl> self(this);
++  std::string midCopy = mid;
++  std::string ufragCopy = ufrag;
++  GetMainThreadSerialEventTarget()->DelayedDispatch(
++      NS_NewRunnableFunction(
++          "PeerConnectionImpl::EmitFabricatedSrflx",
++          [self, srflxCand, midCopy, ufragCopy, injectIntoSdp]() {
++            if (self->IsClosed() || !self->mPCObserver) {
++              return;
++            }
++            injectIntoSdp(srflxCand);
++            JSErrorResult rv2;
++            self->mPCObserver->OnIceCandidate(
++                0, ObString(midCopy.c_str()), ObString(srflxCand.c_str()),
++                ObString(ufragCopy.c_str()), rv2);
++          }),
++      RandomSrflxDelayMs());
  }
  
  void PeerConnectionImpl::IceConnectionStateChange(
-@@ -3710,11 +3952,27 @@ void PeerConnectionImpl::UpdateDefaultCandidate(
+@@ -3420,6 +3898,19 @@ void PeerConnectionImpl::IceConnectionStateChange(
+   // If connectionIceConnectionStateChanged is true, fire an event named
+   // iceconnectionstatechange at connection.
+   if (connectionIceConnectionStateChanged) {
++    // Camoufox: behind a TCP proxy, ICE fails almost immediately and gathering
++    // never reaches "complete" (no null-candidate event fires), so the
++    // gathering-complete trigger never runs. The ICE connection state DOES
++    // change (-> Failed within ~20ms), and by now SetLocalDescription has
++    // populated the local SDP. Fabricate the synthetic srflx here too, on any
++    // terminal/active ICE state, if none surfaced. Idempotent via
++    // mSurfacedPublicCandidate.
++    if (mIceConnectionState == RTCIceConnectionState::Failed ||
++        mIceConnectionState == RTCIceConnectionState::Disconnected ||
++        mIceConnectionState == RTCIceConnectionState::Connected ||
++        mIceConnectionState == RTCIceConnectionState::Completed) {
++      MaybeFabricateSrflxCandidate();
++    }
+     pcObserver->OnStateChange(PCObserverStateType::IceConnectionState, rv);
+   }
+ 
+@@ -3605,6 +4096,12 @@ void PeerConnectionImpl::IceGatheringStateChange(
+   // If connectionIceGatheringStateChanged is true, fire an event named
+   // icegatheringstatechange at connection.
+   if (gatheringStateChanged) {
++    // Camoufox: gathering just finished. If spoofing is on but ICE produced no
++    // public candidate (TCP-proxy case), fabricate a synthetic srflx now, so it
++    // reaches the page before the null-candidate "done" event fired below.
++    if (mIceGatheringState == RTCIceGatheringState::Complete) {
++      MaybeFabricateSrflxCandidate();
++    }
+     // NOTE: If we're in the "complete" case, our JS code will fire a null
+     // icecandidate event after firing the icegatheringstatechange event.
+     // Fire an event named icecandidate using the RTCPeerConnectionIceEvent
+@@ -3696,11 +4193,27 @@ void PeerConnectionImpl::UpdateDefaultCandidate(
      const std::string& defaultRtcpAddr, uint16_t defaultRtcpPort,
      const std::string& transportId) {
    CSFLogDebug(LOGTAG, "%s", __FUNCTION__);
@@ -689,7 +963,7 @@ index e9afe2cfb2..57a8e1cad8 100644
          transportId);
    }
  }
-@@ -4485,8 +4743,10 @@ bool PeerConnectionImpl::GetPrefDefaultAddressOnly() const {
+@@ -4471,8 +4984,10 @@ bool PeerConnectionImpl::GetPrefDefaultAddressOnly() const {
  
    uint64_t winId = mWindow->WindowID();
  
@@ -703,10 +977,10 @@ index e9afe2cfb2..57a8e1cad8 100644
        !MediaManager::Get()->IsActivelyCapturingOrHasAPermission(winId);
    return default_address_only;
 diff --git a/dom/media/webrtc/jsapi/PeerConnectionImpl.h b/dom/media/webrtc/jsapi/PeerConnectionImpl.h
-index 084a437313..b0b8f6097d 100644
+index b2b657a046..8d98809d17 100644
 --- a/dom/media/webrtc/jsapi/PeerConnectionImpl.h
 +++ b/dom/media/webrtc/jsapi/PeerConnectionImpl.h
-@@ -620,8 +620,12 @@ class PeerConnectionImpl final
+@@ -619,8 +619,17 @@ class PeerConnectionImpl final
    RefPtr<MediaPipeline> GetMediaPipelineForTrack(
        dom::MediaStreamTrack& aRecvTrack);
  
@@ -717,9 +991,29 @@ index 084a437313..b0b8f6097d 100644
 +  bool ShouldSpoofCandidateIP() const;
 +  nsresult SanitizeSDPForIPLeak(std::string& sdp);
 +  std::string SpoofCandidateIP(const std::string& candidate);
++  // Camoufox: when spoofing is on and ICE surfaced no public candidate (TCP
++  // proxy: STUN is UDP, can't traverse, so no srflx forms), fabricate a
++  // synthetic srflx carrying the spoof IP into the live candidate stream and
++  // the local SDP so WebRTC reports the proxy IP instead of n/a.
++  void MaybeFabricateSrflxCandidate();
    void SendLocalIceCandidateToContent(uint16_t level, const std::string& mid,
                                        const std::string& candidate,
                                        const std::string& ufrag);
+@@ -728,7 +737,14 @@ class PeerConnectionImpl final
+   unsigned int mDataChannelsClosed = 0;
+
+   bool mForceIceTcp;
++  // Camoufox: set true once a public (srflx/prflx/relay) candidate has been
++  // surfaced to content, so MaybeFabricateSrflxCandidate() only fabricates when
++  // ICE produced none (the TCP-proxy case where STUN can't form a srflx).
++  bool mSurfacedPublicCandidate = false;
++  // Camoufox: the port of the fabricated srflx, so the getStats() synthetic
++  // entry reports the SAME port as the candidate string / SDP line. 0 = none.
++  uint16_t mFabricatedSrflxPort = 0;
+   Maybe<dom::RTCRtcpMuxPolicy> mRtcpMuxPolicy;
+   RefPtr<MediaTransportHandler> mTransportHandler;
+ 
+   // The JSEP negotiation session.
 diff --git a/dom/media/webrtc/jsapi/moz.build b/dom/media/webrtc/jsapi/moz.build
 index d32e08c2b0..40a750196a 100644
 --- a/dom/media/webrtc/jsapi/moz.build

--- a/scripts/copy-additions.sh
+++ b/scripts/copy-additions.sh
@@ -23,10 +23,18 @@ run() {
     fi
 }
 
-# Copy the search-config.json file
+# Copy the search-config.json file.
+# FF150 removed the bundled RemoteSettings dumps tree (services/settings/dumps/
+# no longer ships in the source tarball — search config is fetched at runtime),
+# so the destination dir must be created first. Shipping the empty stub keeps
+# Camoufox's "no bundled search engines" intent and is harmless if unread.
+run 'mkdir -p services/settings/dumps/main'
 run 'cp -v ../assets/search-config.json services/settings/dumps/main/search-config.json'
 
 # vs_pack.py issue... should be temporary
+# FF150 no longer ships build/vs/ in the source tree, so create it first
+# (this helper is only consumed by the Windows MSVC packaging path).
+run 'mkdir -p build/vs'
 run 'cp -v ../patches/librewolf/pack_vs.py build/vs/'
 
 # Apply most recent `settings` repository files


### PR DESCRIPTION
## Overview

This consolidates my previously-separate stealth / juggler / build PRs (**#637–#647**) into a single changeset, **rebased onto the current Firefox 152 base** and validated together via a full local build. I'm closing the individual PRs in favor of this one so they can be reviewed and merged as a coherent, already-integration-tested set.

All changes are confined to `patches/`, `additions/`, and one `scripts/copy-additions.sh` build fix — no changes to the test suite or repo tooling.

## Changes

**WebRTC**
- `fix(webrtc): stop real-IP leak under a proxy; fabricate srflx when blocked` — sanitizes candidate IPs in the SDP, `getStats()`, and default-candidate paths from `MaskConfig`; when ICE produces no public candidate (TCP-proxy case) a synthetic srflx candidate is fabricated so the SDP, `getStats()`, and candidate stream stay consistent (a srflx in the SDP with no matching local-candidate stat is itself a tell). Re-anchored for FF152, which removed the `if (!IsClosed())` wrapper in `GetStats` and added `mRtcpMuxPolicy`.

**Proxy**
- `fix(proxy): re-enable launch-arg proxy by disabling https_first` — `dom.security.https_first` was silently overriding the launch-arg proxy.

**Screen / device dimensions**
- `fix(stealth): make MaskConfig the single source for screen/device dims` — CSS media-feature `device-width`/`device-height` now resolve from the same `MaskConfig` source as `screen.width/height`, so `matchMedia(device-width)` agrees with `screen.width` instead of leaking the real window size.

**Fonts**
- `fix(stealth): spoof CSS2 system-font keyword resolution` (`font-system-fonts-css2.patch`) — resolves CSS2 system-font keywords (`menu`, `caption`, etc.) consistently with the spoofed platform.

**Juggler**
- `fix(juggler): filepicker reliability + skip coalescing for synthetic mouse moves` — synthetic (juggler) mouse events bypass the mouse-move coalescing path so input dispatch can't stall for seconds under heavy parallel load; filepicker interception hardened. Updated for FF152's `RecvRealMouseMoveEvent` signature (`aEvent` → `aMouseEvent`, new `MOZ_ASSERT`s).
- `fix(juggler): emit a single input event for insertText on form fields`.
- `fix(juggler): reload about:blank via browsingContext.reload`.
- `fix(juggler): adapt to FF152 API drift — screenshots, popups, touch, popup-window close` (second commit) — four FF152 platform changes broke driven-browser paths that only surface at runtime:
  - **`Page.screenshot` failed on every call** (`can't access property "document", win is undefined`): FF152 renamed `Node.ownerGlobal` → `documentGlobal` and removed the accessor from `Window` entirely. Fixed the screenshot canvas path (`topChromeWindow` needs no accessor — it *is* the chrome window) plus the other stale call sites (`bringToFront`, both screencast `docShell` lookups, `_linkClicked`).
  - **`page.on('popup')` never fired**: FF152 creates a `window.open()` popup's content-process WindowGlobal actor *before* `TabOpen` registers the PageTarget; the old self-binding actor bailed with no retry, leaving the popup channel permanently unbound. `TargetRegistry` now tracks actors and binds actor↔target from whichever side appears first (mirrors upstream Playwright).
  - **`page.tap()` hung**: FF152 removed `windowUtils.sendTouchEvent` (parallel-array API); touch synthesis now uses `Window.synthesizeTouchEvent`.
  - **Closing a window-features popup crashed `Browser.removeBrowserContext`**: `globalOverlay.js` `closeWindow()` calls `SessionStore.maybeDontRestoreTabs()` unconditionally, which threw on juggler popup windows SessionStore never tracked. New `patches/sessionstore-popup-close-crash.patch` makes it a no-op for untracked windows (matching `onClose`'s guard).

**Locale**
- `fix(locale): propagate launch-arg locale to BrowsingContext`.

**Build**
- `fix(build): create v150-removed dirs before copy-additions` — FF150+ dropped some source dirs `copy-additions.sh` writes into; `mkdir -p` them first so additions land (idempotent, harmless on older bases).

**Fingerprint / voices**
- `fix(stealth): correct BrowserForge headless / impossible-geometry tells` and `fix(stealth): make speech-voice spoofing work, and stop leaking host voices`.

## Validation

Built locally for **Linux x86_64 on Firefox 152.0.4** and tested end-to-end:

- **Patches apply cleanly** — all patches apply to the FF152 source with **zero rejects**; juggler ends up in `browser/omni.ja`.
- **Playwright functionality** — driven via Playwright (build-tester harness) across 8 fingerprint profiles: **1024/1048 checks pass, grade [A]**, with **no WebRTC failures** in any profile (validates the getStats/srflx rebase). Global single-identity profiles: macOS 117/118, Linux 116/117. Hundreds of automated interactions (navigation, clicks, form input) ran without juggler stalls.
- **Fingerprint consistency (sundial / CreepJS)** — **~95% (727–728/763)**; WebRTC, global screen, navigator, WebGL, locale and timezone all report consistent.
- **Upstream Playwright suite (added with the FF152 API-drift commit)** — the full **microsoft/playwright-python v1.60.0** `tests/async/` suite run against the built binary: **1406 passed / 0 failed** (48 skipped; the only deselections are environment-dependent `launch_server` tests that require Playwright's bundled Firefox, which doesn't ship for this host OS). This covers screenshots, popups, tap/touch, input, navigation, frames, and video end-to-end.

A prebuilt Linux binary of this exact changeset (including the FF152 API-drift fixes) is available here: **https://github.com/JWriter20/camoufox/releases/tag/v152.0.4-20260712** (macOS/Windows to follow).

## Known / remaining issues

These are **pre-existing or base-level**, not introduced by this changeset:

1. **Cross-OS font consistency leak** — subtle font markers can still disagree with the claimed OS. Present in upstream as well; tracked as a separate follow-up.
2. **`speechSynthesis` voice-list instability on FF152** — voices are correctly spoofed (no host-voice leak), but repeated `getVoices()` calls return a growing list. The voice patch is unchanged from the v150 line, so FF152 changed `speechSynthesis` internals under it; needs a small follow-up specific to FF152.
3. **Per-context screen dimensions** — this branch intentionally uses a single global `MaskConfig` screen (see the screen fix above), so distinct per-context screen sizes are not applied; global/single-identity screen spoofing is correct.
4. `Document.caretRangeFromPoint` is now present because FF152 legitimately added it (base characteristic, not a leak).

