### PR TITLE
Add disableInstantAnimations opt-out flag

### DIFF
--- a/patches/no-css-animations.patch
+++ b/patches/no-css-animations.patch
@@ -2,30 +2,39 @@ diff --git a/dom/animation/AnimationEffect.cpp b/dom/animation/AnimationEffect.c
 index 6ef8c30d49..07cad770c9 100644
 --- a/dom/animation/AnimationEffect.cpp
 +++ b/dom/animation/AnimationEffect.cpp
-@@ -108,10 +108,18 @@ ComputedTiming AnimationEffect::GetComputedTimingAt(
+@@ -13,6 +13,7 @@
+ #include "mozilla/dom/MutationObservers.h"
+ #include "mozilla/dom/ScrollTimeline.h"  // For PROGRESS_TIMELINE_DURATION_MILLISEC
+ #include "nsDOMMutationObserver.h"
++#include "MaskConfig.hpp"
+
+ namespace mozilla::dom {
+
+@@ -108,10 +109,19 @@ ComputedTiming AnimationEffect::GetComputedTimingAt(
    // Always return the same object to benefit from return-value optimization.
    ComputedTiming result;
- 
+
 +  result.mActiveDuration = aTiming.ActiveDuration();
    if (aTiming.Duration()) {
      MOZ_ASSERT(aTiming.Duration().ref() >= zeroDuration,
                 "Iteration duration should be positive");
 -    result.mDuration = aTiming.Duration().ref();
-+    if (result.mActiveDuration != StickyTimeDuration::Forever()) {
-+      // On css animations with finite duration, set the duration & active duration to 0
++    // Camoufox: finite CSS animations complete instantly so Playwright doesn't
++    // wait on them. `disableInstantAnimations` restores normal animation timing.
++    if (MaskConfig::GetBool("disableInstantAnimations") ||
++        result.mActiveDuration == StickyTimeDuration::Forever()) {
++      result.mDuration = aTiming.Duration().ref();
++    } else {
 +      result.mDuration = zeroDuration;
 +      result.mActiveDuration = zeroDuration;
-+    } else {
-+      // On infinite-running animations, use the default duration
-+      result.mDuration = aTiming.Duration().ref();
 +    }
    }
- 
+
    MOZ_ASSERT(aTiming.Iterations() >= 0.0 && !std::isnan(aTiming.Iterations()),
-@@ -124,7 +132,6 @@ ComputedTiming AnimationEffect::GetComputedTimingAt(
+@@ -124,7 +134,6 @@ ComputedTiming AnimationEffect::GetComputedTimingAt(
               "ValidateIterationStart");
    result.mIterationStart = aTiming.IterationStart();
- 
+
 -  result.mActiveDuration = aTiming.ActiveDuration();
    result.mEndTime = aTiming.EndTime();
    result.mFill = aTiming.Fill() == dom::FillMode::Auto ? dom::FillMode::None

--- a/settings/properties.json
+++ b/settings/properties.json
@@ -101,6 +101,7 @@
   { "property": "forceScopeAccess", "type": "bool" },
 
   { "property": "disableTheming", "type": "bool" },
+  { "property": "disableInstantAnimations", "type": "bool" },
   { "property": "memorysaver", "type": "bool" },
   { "property": "addons", "type": "array" },
   { "property": "certificatePaths", "type": "array" },


### PR DESCRIPTION
## Issue

Fixes #664 — Microsoft's "Press and Hold" CAPTCHA does not render the checkmark when the button reaches its filled state.

## Root cause

`patches/no-css-animations.patch` (feat: Instant CSS animations, d32f76f) unconditionally collapses every finite CSS animation to zero duration so Playwright doesn't wait on them. Elements that are only revealed *during* an animation's active phase (like the Press-and-Hold checkmark) are therefore never painted — the animation is over before it starts.

The feature is a Playwright-wait convenience, not a fingerprinting defense, so making it opt-out is safe.

## Fix

Introduce a `disableInstantAnimations` config flag, following the existing `disableTheming` pattern:

- **`patches/no-css-animations.patch`** — the finite-animation collapse now runs only when `disableInstantAnimations` is unset. Infinite animations are unaffected, as before.
- **`settings/properties.json`** — registers the `bool` property so it validates through the Python layer.

Default behavior is unchanged (instant animations stay on), so there is no regression. Users hitting animation-dependent UI opt out:

```python
Camoufox(config={"disableInstantAnimations": True})
```

## Behavior

| `disableInstantAnimations` | Finite animation | Infinite animation |
|---|---|---|
| unset (default) | instant (0 duration) | normal |
| `True` | normal | normal |

## Testing

Patch validated by applying against `dom/animation/AnimationEffect.cpp` and confirming the resulting C++ and control flow. A full browser build was not run locally; please run `build-tester` / `make tests` in CI.