### PR TITLE
Fix undefined ownerWindow in activateAndRun on FF152

### DIFF
--- a/additions/juggler/TargetRegistry.js
+++ b/additions/juggler/TargetRegistry.js
@@ -441,7 +441,8 @@ export class PageTarget {
   }
 
   async activateAndRun(callback = () => {}, { muteNotificationsPopup = false } = {}) {
-    const ownerWindow = this._tab.linkedBrowser.ownerGlobal;
+    const linkedBrowser = this._tab.linkedBrowser;
+    const ownerWindow = linkedBrowser.ownerGlobal || linkedBrowser.ownerDocument.defaultView;
     const tabBrowser = ownerWindow.gBrowser;
     // Serialize all tab-switching commands per tabbed browser
     // to disallow concurrent tab switching.


### PR DESCRIPTION
## Issue

Fixes #660 — on `v152.x` builds, `page.mouse.click` (and other input) fails with:

```
Mouse.click: Protocol error (Page.dispatchMouseEvent): can't access property "gBrowser", ownerWindow is undefined
```

## Root cause

`PageTarget.activateAndRun` in `additions/juggler/TargetRegistry.js` does:

```js
const ownerWindow = this._tab.linkedBrowser.ownerGlobal;
const tabBrowser = ownerWindow.gBrowser;
```

On Firefox 152, `<browser>.ownerGlobal` can return `undefined`, so dereferencing `ownerWindow.gBrowser` throws. `activateAndRun` backs several protocol handlers (`PageHandler.js` mouse/keyboard/etc.), so the failure is not limited to `Mouse.click`.

## Fix

Fall back to the browser element's `ownerDocument.defaultView` (the chrome window), mirroring the `ownerGlobal || defaultView` fallbacks already present for FF152 in `content/PageAgent.js` and `content/FrameTree.js`:

```js
const linkedBrowser = this._tab.linkedBrowser;
const ownerWindow = linkedBrowser.ownerGlobal || linkedBrowser.ownerDocument.defaultView;
```

`linkedBrowser` is a `<browser>` XUL element, so `ownerDocument.defaultView` resolves to the chrome window that owns `gBrowser`.

## Testing

A full browser build was not run locally (requires fetching + building the FF152 tree). The change is a one-line null-fallback matching an established pattern; please exercise `build-tester` / mouse input in CI.