### PR TITLE
Fix uninitialized DateTimeInfo cache in worker timezone override

### DIFF
--- a/patches/timezone-spoofing.patch
+++ b/patches/timezone-spoofing.patch
@@ -314,20 +314,28 @@ index 96ed101921..aa78f0fe26 100644
  
  static bool ComputeLocalTime(time_t local, struct tm* ptm) {
    // Neither localtime_s nor localtime_r are required to act as if tzset has
-@@ -256,6 +257,12 @@ js::DateTimeInfo::DateTimeInfo() {
+@@ -256,6 +257,20 @@ js::DateTimeInfo::DateTimeInfo() {
  
  js::DateTimeInfo::~DateTimeInfo() = default;
  
 +js::DateTimeInfo::DateTimeInfo(const char* timezone) : DateTimeInfo() {
 +#if JS_HAS_INTL_API
 +  timeZoneOverride_ = timezone ? std::string(timezone) : std::string();
++
++  // Override instances bypass updateTimeZone()/resetState() (
++  // getOffsetMilliseconds calls them directly when a per-realm dtInfo is
++  // present), so seed the cache state as the upstream per-realm ctor did.
++  // Without this the RangeCache members are read uninitialized and
++  // getTimezoneOffset() intermittently returns 0 or garbage. (issue #657)
++  utcToLocalStandardOffsetSeconds_ = SecondsPerDay;
++  resetState();
 +#endif
 +}
 +
  int64_t js::DateTimeInfo::toClampedSeconds(int64_t milliseconds) {
    int64_t seconds = milliseconds / msPerSecond;
    int64_t millis = milliseconds % msPerSecond;
-@@ -586,6 +593,18 @@ JS_PUBLIC_API bool JS::SetTimeZoneOverride(const char* timeZoneId) {
+@@ -586,6 +601,18 @@ JS_PUBLIC_API bool JS::SetTimeZoneOverride(const char* timeZoneId) {
    return true;
  }
  


### PR DESCRIPTION
## Issue

Fixes #657 — inside a freshly-spawned Web Worker, `Date.prototype.getTimezoneOffset()` intermittently (~12%) returns `0` or a garbage non-integer (e.g. `-0.0000166`, `31543.17`), while the main thread and the worker's own `Intl.DateTimeFormat().resolvedOptions().timeZone` stay correct.

## Root cause

`timezone-spoofing.patch` re-adds per-realm timezone overrides on top of the Playwright base, including a constructor:

```cpp
js::DateTimeInfo::DateTimeInfo(const char* timezone) : DateTimeInfo() {
  timeZoneOverride_ = timezone ? std::string(timezone) : std::string();
}
```

Override `DateTimeInfo` instances are used via the fast paths in `DateTimeInfo::getOffsetMilliseconds` / `getDSTOffsetMilliseconds`, which call `internalGet…OffsetMilliseconds` **directly** when a per-realm `dtInfo` is present — bypassing `acquireLockWithValidTimeZone()`, the only path that runs `updateTimeZone()` → `resetState()`. Delegating to the default ctor only sets `timeZoneStatus_ = NeedsUpdate`; it never resets the `RangeCache` members (`dstRange_`, `localRange_`, `utcRange_`) or seeds `utcToLocalStandardOffsetSeconds_`.

So those caches are read uninitialized. In `getOrComputeValue`, if the garbage `startSeconds/endSeconds` happen to bracket the queried time, it returns the garbage `offsetMilliseconds` directly (skipping the correct ICU computation). The `sanityCheck()` `MOZ_ASSERT`s that would catch this are compiled out in the release build. This is why it is intermittent (~12%, uninitialized-memory dependent) and why `Intl` is unaffected — `Intl` reads `timeZoneOverride_` directly.

The upstream per-realm constructor that was removed by the Playwright refactor did exactly this initialization:

```cpp
DateTimeInfo(RefPtr<TimeZoneString> tz)
    : utcToLocalStandardOffsetSeconds_(SecondsPerDay), timeZoneOverride_(tz) {
  resetState();   // updateTimeZone() is never called for override instances
}
```

## Fix

Restore that initialization in the re-added constructor — seed the offset sentinel and call `resetState()`:

```cpp
utcToLocalStandardOffsetSeconds_ = SecondsPerDay;
resetState();
```

Now every override instance starts with valid, empty range caches, so the first `getTimezoneOffset()` is a cache miss that computes the correct offset via ICU, consistent with `Intl` and the main thread.

## Testing

Verified the patch applies cleanly on top of the Playwright-patched `js/src/vm/DateTime.cpp` (3 hunks, no rejects) and produces the intended constructor. A full browser build was not run locally; the repro in #657 (`getTimezoneOffset()` across many fresh workers) should be exercised in CI.