### PR TITLE
Fix getResponseBody on ORB-decompressed responses

### DIFF
--- a/additions/juggler/NetworkObserver.js
+++ b/additions/juggler/NetworkObserver.js
@@ -855,7 +855,10 @@ class ResponseStorage {
     }
     let encodings = [];
     // Note: fulfilled request comes with decoded body right away.
-    if ((request.httpChannel instanceof Ci.nsIEncodedChannel) && request.httpChannel.contentEncodings && !request.httpChannel.applyConversion && !request._fulfilled) {
+    // Note: ORB's compressed-media sniffing (browser.opaqueResponseBlocking) decodes
+    // the body in the parent process without clearing applyConversion, so
+    // hasContentDecompressed is the only signal that we already have plain bytes.
+    if ((request.httpChannel instanceof Ci.nsIEncodedChannel) && request.httpChannel.contentEncodings && !request.httpChannel.applyConversion && !request.httpChannel.hasContentDecompressed && !request._fulfilled) {
       const encodingHeader = request.httpChannel.getResponseHeader("Content-Encoding");
       encodings = encodingHeader.split(/\s*\t*,\s*\t*/);
     }

--- a/tests/async/test_network.py
+++ b/tests/async/test_network.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import gzip
 import json
 from asyncio import Future
 from pathlib import Path
@@ -539,6 +540,43 @@ async def test_response_body_should_work_with_compression(
         "rb",
     ) as fd:
         assert fd.read() == await response.body()
+
+
+async def test_response_text_should_work_with_compressed_cross_origin_jsonp(
+    page: Page, server: Server
+) -> None:
+    # Opaque Response Blocking decompresses a compressed cross-origin no-CORS response
+    # in the parent process in order to sniff it, unless its Content-Type is
+    # opaque-safelisted. Juggler observes the channel in the parent, so for those
+    # responses it already holds plain bytes and must not decompress them again.
+    # The Content-Type has to be a non-safelisted one (as JSONP endpoints typically
+    # serve) to exercise this: application/javascript is safelisted and skips ORB.
+    # See issue #648.
+    body = 'jsonpCallback({"foo": "bar"});\n'
+
+    def handle_jsonp(request: TestServerRequest) -> None:
+        request.setHeader("Content-Type", "application/json")
+        request.setHeader("Content-Encoding", "gzip")
+        request.write(gzip.compress(body.encode()))
+        request.finish()
+
+    server.set_route("/jsonp", handle_jsonp)
+    await page.goto(server.EMPTY_PAGE)
+
+    # EMPTY_PAGE is served from localhost, CROSS_PROCESS_PREFIX from 127.0.0.1, so the
+    # script tag below is a cross-origin no-CORS subresource.
+    url = server.CROSS_PROCESS_PREFIX + "/jsonp"
+    async with page.expect_response(url) as response_info:
+        # Not add_script_tag(): a non-safelisted Content-Type never executes, so its
+        # load event would never fire.
+        await page.evaluate(
+            "u => { const s = document.createElement('script');"
+            "s.src = u; document.head.appendChild(s); }",
+            url,
+        )
+    response = await response_info.value
+    assert response.headers["content-encoding"] == "gzip"
+    assert await response.text() == body
 
 
 async def test_response_status_text_should_work(page: Page, server: Server) -> None:


### PR DESCRIPTION
Fixes #648.

## Problem

`Network.getResponseBody` fails on compressed cross-origin responses with:

```
Protocol error (Network.getResponseBody): Component returned failure code:
0x804b001b (NS_ERROR_INVALID_CONTENT_ENCODING) [nsIStreamListener.onDataAvailable]
```

## Cause

Opaque Response Blocking (`browser.opaqueResponseBlocking`, enabled by default) decompresses a compressed cross-origin no-CORS response **in the parent process** in order to sniff it, unless its `Content-Type` is opaque-safelisted. It sets `hasContentDecompressed = true` but leaves `applyConversion` false.

Juggler observes the channel in the parent, so for those responses it already holds plain bytes — but `ResponseStorage.addResponseBody` infers "still compressed" from `applyConversion` alone, tags the body with its `Content-Encoding`, and `getBase64EncodedResponse` decompresses it a second time. gzip's `check_header` finds no magic bytes and throws.

The report's "large" is really a proxy for "compressed" — servers only compress above a size threshold, which is also why `Accept-Encoding: identity` worked around it.

Mozilla hit the identical bug in their own DevTools network observer — [bug 1852870](https://bugzilla.mozilla.org/show_bug.cgi?id=1852870), Firefox 120 — reported with the same error string. This change applies the same guard they did, matching the in-tree check in `NetworkResponseListener.sys.mjs`.

## Change

One additional condition in `ResponseStorage.addResponseBody`:

```js
!request.httpChannel.hasContentDecompressed
```

## Verification

Tested against the released `135.0.1-beta.24` binary (the version in the report) and the same binary with the guard applied to `chrome/juggler/content/NetworkObserver.js` inside `omni.ja`.

Matrix of 4 Content-Types × 6 Content-Encodings, each loaded as a cross-origin no-CORS script:

| | stock | patched |
|---|---|---|
| passing | 9/24 | **24/24** |

Every compressed non-safelisted combination failed before (`gzip`, `x-gzip`, `deflate`, `br`, `zstd`) — broader than the issue suggested. The `application/javascript` row passes both before and after: ORB safelists it, so Juggler still decompresses that one itself. That confirms the guard doesn't over-correct and disable legitimate decompression.

No regressions:

- `test_network.py` — 48 passed, 3 failed; the same 3 fail on the stock binary (service workers, local SSL setup)
- request-interception suites — 20/20
- fetch suites — same 7 pre-existing failures on stock and patched

## Test

`tests/async/test_network.py::test_response_text_should_work_with_compressed_cross_origin_jsonp` fails on stock with the exact reported error and passes with the fix.

It deliberately serves `application/json` rather than `application/javascript`: the latter is opaque-safelisted, skips ORB entirely, and would pass even without the fix. The existing gzip tests only cover `page.goto` navigations, which ORB never inspects — which is why this went unnoticed.

## Out of scope

- `Content-Encoding: x-deflate` also errors, identically on stock and patched. Pre-existing, unrelated, and not emitted by real servers.
- `convertString` round-trips bodies through `Array.from` + chunked `String.fromCharCode.apply`, which is inefficient for large bodies. Unchanged upstream Playwright code; separate concern.
