### PR TITLE
Clamp headful window geometry to the real display

### DIFF
--- a/pythonlib/camoufox/fingerprints.py
+++ b/pythonlib/camoufox/fingerprints.py
@@ -406,6 +406,52 @@ def clamp_window_dimensions(config: Dict[str, Any]) -> None:
             config[f'window.inner{axis}'] = outer_clamped
 
 
+def clamp_screen_to_display(
+    config: Dict[str, Any],
+    max_width: Optional[int],
+    max_height: Optional[int],
+) -> None:
+    """Shrink screen.width/height down to the bounds of the real display.
+
+    BrowserForge takes a Screen constraint but drops it silently whenever it
+    filters the fingerprint pool too far: FingerprintGenerator.partial_csp
+    swallows the resulting failure and deletes the constraint unless strict=True.
+    So the bound from get_screen_cons() is best-effort only, and a 1366x768
+    laptop routinely gets a 2560x1440 fingerprint. browser-init.patch resizes the
+    real chrome window to window.outerWidth/outerHeight, so an unbounded value
+    renders past the edge of the monitor (daijro/camoufox#499).
+
+    Keeps the taskbar delta (screen - avail) intact so fix_screen_no_taskbar's
+    invariant survives. Callers must run clamp_window_dimensions afterwards to
+    cascade the new bounds down to avail/outer/inner.
+    """
+    for axis, cap in (('width', max_width), ('height', max_height)):
+        screen = config.get(f'screen.{axis}')
+        if not (screen and cap) or screen <= cap:
+            continue
+        avail_key = 'screen.availWidth' if axis == 'width' else 'screen.availHeight'
+        avail = config.get(avail_key)
+        config[f'screen.{axis}'] = cap
+        if avail:
+            config[avail_key] = max(1, cap - max(0, screen - avail))
+
+
+def clamp_window_position(config: Dict[str, Any]) -> None:
+    """Keep the window box inside the screen: 0 <= screenX/Y <= screen - outer.
+
+    BrowserForge's screenX/screenY are consistent with the screen it generated
+    them against, so clamp_screen_to_display invalidates them. A window
+    positioned partly off its own reported screen is an impossible geometry.
+    """
+    for axis, pos_key in (('Width', 'window.screenX'), ('Height', 'window.screenY')):
+        screen = config.get(f'screen.{axis.lower()}')
+        outer = config.get(f'window.outer{axis}')
+        pos = config.get(pos_key)
+        if pos is None or not (screen and outer):
+            continue
+        config[pos_key] = max(0, min(pos, screen - outer))
+
+
 def set_media_devices_defaults(config: Dict[str, Any]) -> None:
     """Spoof navigator.mediaDevices.enumerateDevices() so headless contexts
     expose a plausible device list.

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -692,11 +692,11 @@ def launch_options(
     if not _user_set_navigator:
         fix_navigator_arch(config, target_os)
     if not _user_set_screen_window:
-        # Headful only: this bound exists so the real window fits the monitor.
-        # headless has no window to overflow, and headless='virtual' runs a 1x1
-        # Xvfb (see virtdisplay.py) that would otherwise shrink the whole
-        # fingerprint to 1x1.
-        if headless is False and screen_cons:
+        # Headful on a real monitor only: this bound exists so the window fits
+        # the screen it is drawn on. headless has no window to overflow, and
+        # headless='virtual' reaches here as headless=False (see async_api) with
+        # a 1x1 Xvfb (virtdisplay.py) that is not a real screen.
+        if headless is False and not virtual_display and screen_cons:
             clamp_screen_to_display(config, screen_cons.max_width, screen_cons.max_height)
         fix_screen_no_taskbar(config, target_os)
         clamp_window_dimensions(config)

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -21,7 +21,7 @@ from .exceptions import (
     InvalidPropertyType,
     NonFirefoxFingerprint,
 )
-from .fingerprints import from_browserforge, from_preset, generate_fingerprint, get_random_preset, _generate_random_font_subset, _generate_random_voice_subset, fix_navigator_arch, fix_screen_no_taskbar, clamp_window_dimensions, set_media_devices_defaults
+from .fingerprints import from_browserforge, from_preset, generate_fingerprint, get_random_preset, _generate_random_font_subset, _generate_random_voice_subset, fix_navigator_arch, fix_screen_no_taskbar, clamp_screen_to_display, clamp_window_dimensions, clamp_window_position, set_media_devices_defaults
 from .geolocation import geoip_allowed, get_geolocation
 from .ip import Proxy, public_ip, valid_ipv4, valid_ipv6
 from .locales import handle_locales
@@ -666,10 +666,14 @@ def launch_options(
             merge_into(config, from_preset(preset, ff_version_str))
             _used_preset = True
 
+    # Bound the geometry to the real display. BrowserForge only honours this when
+    # its pool has a match, so it is re-applied after generation as well.
+    screen_cons = screen or get_screen_cons(headless or 'DISPLAY' in env)
+
     if not _used_preset and fingerprint is None:
         # Default: BrowserForge synthetic generation (infinite unique fingerprints)
         fingerprint = generate_fingerprint(
-            screen=screen or get_screen_cons(headless or 'DISPLAY' in env),
+            screen=screen_cons,
             window=window,
             os=os,
         )
@@ -688,8 +692,15 @@ def launch_options(
     if not _user_set_navigator:
         fix_navigator_arch(config, target_os)
     if not _user_set_screen_window:
+        # Headful only: this bound exists so the real window fits the monitor.
+        # headless has no window to overflow, and headless='virtual' runs a 1x1
+        # Xvfb (see virtdisplay.py) that would otherwise shrink the whole
+        # fingerprint to 1x1.
+        if headless is False and screen_cons:
+            clamp_screen_to_display(config, screen_cons.max_width, screen_cons.max_height)
         fix_screen_no_taskbar(config, target_os)
         clamp_window_dimensions(config)
+        clamp_window_position(config)
 
     # Set a random window.history.length
     set_into(config, 'window.history.length', randrange(1, 6))  # nosec

--- a/pythonlib/tests/test_fingerprint_fixes.py
+++ b/pythonlib/tests/test_fingerprint_fixes.py
@@ -16,7 +16,9 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from camoufox.fingerprints import (  # noqa: E402
+    clamp_screen_to_display,
     clamp_window_dimensions,
+    clamp_window_position,
     fix_navigator_arch,
     fix_screen_no_taskbar,
     set_media_devices_defaults,
@@ -126,6 +128,99 @@ class TestClampWindowDimensions:
         clamp_window_dimensions(c)
         assert c["window.outerWidth"] == 1280
         assert c["window.innerWidth"] == 1264
+
+
+class TestClampScreenToDisplay:
+    def test_shrinks_screen_to_display(self):
+        # BrowserForge routinely ships a 2560x1440 fingerprint to a 1366x768
+        # laptop; browser-init then resizes the real window past the monitor.
+        c = {
+            "screen.width": 2560,
+            "screen.height": 1440,
+            "screen.availWidth": 2560,
+            "screen.availHeight": 1400,
+        }
+        clamp_screen_to_display(c, 1366, 768)
+        assert c["screen.width"] == 1366
+        assert c["screen.height"] == 768
+        # taskbar delta (1440-1400=40) preserved, so fix_screen_no_taskbar's
+        # avail < height invariant still holds
+        assert c["screen.availWidth"] == 1366
+        assert c["screen.availHeight"] == 768 - 40
+
+    def test_noop_when_already_within_display(self):
+        c = {"screen.width": 1280, "screen.height": 720, "screen.availHeight": 700}
+        clamp_screen_to_display(c, 1366, 768)
+        assert c["screen.width"] == 1280
+        assert c["screen.height"] == 720
+        assert c["screen.availHeight"] == 700
+
+    def test_ignores_unset_bounds(self):
+        c = {"screen.width": 2560, "screen.height": 1440}
+        clamp_screen_to_display(c, None, None)
+        assert c["screen.width"] == 2560
+        assert c["screen.height"] == 1440
+
+    def test_avail_never_drops_below_one(self):
+        # taskbar delta larger than the display must not produce a <= 0 avail
+        c = {"screen.height": 2000, "screen.availHeight": 100}
+        clamp_screen_to_display(c, None, 768)
+        assert c["screen.availHeight"] >= 1
+
+    def test_clamped_result_survives_cascade(self):
+        c = {
+            "screen.width": 2560,
+            "screen.height": 1440,
+            "screen.availWidth": 2560,
+            "screen.availHeight": 1400,
+            "window.outerWidth": 1920,
+            "window.outerHeight": 1055,
+            "window.innerWidth": 1920,
+            "window.innerHeight": 1000,
+        }
+        clamp_screen_to_display(c, 1366, 768)
+        clamp_window_dimensions(c)
+        assert c["window.outerWidth"] <= c["screen.availWidth"] <= c["screen.width"] == 1366
+        assert c["window.outerHeight"] <= c["screen.availHeight"] <= c["screen.height"] == 768
+        assert c["window.innerWidth"] <= c["window.outerWidth"]
+        assert c["window.innerHeight"] <= c["window.outerHeight"]
+
+
+class TestClampWindowPosition:
+    def test_pulls_window_back_inside_screen(self):
+        c = {
+            "screen.width": 1366,
+            "screen.height": 768,
+            "window.outerWidth": 1366,
+            "window.outerHeight": 728,
+            "window.screenX": 250,
+            "window.screenY": 281,
+        }
+        clamp_window_position(c)
+        assert c["window.screenX"] == 0
+        assert c["window.screenY"] == 40
+
+    def test_noop_when_window_already_inside(self):
+        c = {
+            "screen.width": 1920,
+            "screen.height": 1080,
+            "window.outerWidth": 1280,
+            "window.outerHeight": 720,
+            "window.screenX": 100,
+            "window.screenY": 50,
+        }
+        clamp_window_position(c)
+        assert c["window.screenX"] == 100
+        assert c["window.screenY"] == 50
+
+    def test_never_negative(self):
+        c = {
+            "screen.width": 800,
+            "window.outerWidth": 1000,  # wider than screen
+            "window.screenX": 50,
+        }
+        clamp_window_position(c)
+        assert c["window.screenX"] == 0
 
 
 class TestSetMediaDevicesDefaults:

--- a/pythonlib/tests/test_launch_geometry.py
+++ b/pythonlib/tests/test_launch_geometry.py
@@ -1,0 +1,70 @@
+"""
+Launch-level guards for the display clamp in launch_options().
+
+Run with:
+    cd pythonlib && python -m pytest tests/test_launch_geometry.py -v
+"""
+
+import os
+import sys
+from contextlib import contextmanager
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import orjson  # noqa: E402
+from browserforge.fingerprints import Screen  # noqa: E402
+
+from camoufox import utils  # noqa: E402
+
+# What get_screen_cons() reports under the Xvfb that headless='virtual' starts:
+# virtdisplay.py sizes it "1x1x24", and launch_options mutates os.environ's
+# DISPLAY, so the parent process enumerates that stub as its only monitor.
+XVFB_STUB = Screen(max_width=1, max_height=1)
+
+
+@contextmanager
+def host(screen_cons):
+    """Run launch_options() against a stubbed host, without touching the disk."""
+    with mock.patch.object(utils, "get_screen_cons", lambda headless: screen_cons), (
+        mock.patch.object(utils, "installed_verstr", lambda: "150.0.2")
+    ), mock.patch.object(utils, "launch_path", lambda **kwargs: "/nonexistent/camoufox"):
+        yield
+
+
+def config_of(options):
+    """Reassemble the chunked CAMOU_CONFIG_<n> env vars into a dict."""
+    env = options["env"]
+    chunks = sorted(
+        (int(k.rsplit("_", 1)[1]), v) for k, v in env.items() if k.startswith("CAMOU_CONFIG_")
+    )
+    return orjson.loads("".join(chunk for _, chunk in chunks))
+
+
+def launch(**kwargs):
+    kwargs.setdefault("os", "windows")
+    kwargs.setdefault("i_know_what_im_doing", True)
+    return config_of(utils.launch_options(**kwargs))
+
+
+class TestVirtualDisplayIsNotAScreen:
+    """headless='virtual' arrives here as headless=False (async_api rewrites it),
+    so the headful gate alone would clamp the fingerprint to the 1x1 Xvfb."""
+
+    def test_fingerprint_is_not_shrunk_to_the_xvfb(self):
+        with host(XVFB_STUB):
+            config = launch(headless=False, virtual_display=":99")
+
+        assert config["screen.width"] > 1
+        assert config["screen.height"] > 1
+        assert config["window.outerWidth"] > 1
+
+    def test_screen_dimensions_stay_valid(self):
+        """Clamping to 1x1 drives availHeight negative once fix_screen_no_taskbar
+        subtracts the taskbar, which validate_config rejects as a uint."""
+        with host(XVFB_STUB):
+            config = launch(headless=False, virtual_display=":99")
+
+        for key, value in config.items():
+            if key.startswith("screen.") or key.startswith("window.outer"):
+                assert value >= 0, f"{key} is negative: {value}"


### PR DESCRIPTION
Fixes #499.

## Problem

In headful mode the browser window is sometimes larger than the monitor, with rendering artifacts along the right and bottom margins. Reported on a 1366x768 laptop.

## Cause

`get_screen_cons()` already computes the right bound — `Screen(max_width=1366, max_height=768)` — and hands it to BrowserForge. BrowserForge then throws it away.

`FingerprintGenerator.partial_csp` filters the fingerprint pool by the screen constraint, and when that filtering fails it swallows the error and drops the constraint entirely unless `strict=True`:

```python
try:
    return get_possible_values(self.fingerprint_generator_network, filtered_values)
except Exception as e:
    if strict:
        raise e
    del filtered_values['screen']
return None
```

Camoufox doesn't pass `strict`, so the bound is silently discarded and a 1366x768 laptop gets a 2560x1440 fingerprint with `window.outerWidth` 1920. `browser-init.patch` then calls `window.resizeTo(outerWidth, outerHeight)` on the real chrome window, so the oversized value becomes a real oversized window.

Measured on an Xvfb sized to the reporter's 1366x768, the real X window reached **2225x1238**.

## Change

Re-apply the bound after generation rather than trusting BrowserForge with it:

- `clamp_screen_to_display()` — shrinks `screen.width/height` to the display, preserving the taskbar delta so `fix_screen_no_taskbar`'s `avail < height` invariant still holds. The existing `clamp_window_dimensions()` then cascades the new bounds down to avail/outer/inner.
- `clamp_window_position()` — pulls `screenX/screenY` back inside the screen. Shrinking the screen invalidates the positions BrowserForge generated against the original one, which would otherwise leave the window box partly outside its own reported screen.

## Headful only

The clamp is gated on `headless is False`, which matters more than it looks:

- headless has no window to overflow.
- `headless='virtual'` launches Xvfb with `-screen 0 1x1x24` (`virtdisplay.py`), and `env` *is* `os.environ`, so `env['DISPLAY'] = virtual_display` mutates the caller's environment. Under that display `get_screen_cons(True)` returns `Screen(max_width=1, max_height=1)` — verified. An unconditional clamp would shrink those fingerprints to a 1x1 screen. It is harmless today only because BrowserForge discards the constraint.

## Verification

Against the released binary on an Xvfb at 1366x768:

| | before | after |
|---|---|---|
| generated geometry fits the display | 7/40 | **40/40** |
| full geometry invariants hold | 17/60 | **50/50** |

Invariants checked: `inner <= outer <= avail <= screen`, `screen <= display`, `avail < screen` (noTaskbar tell), all dimensions positive, and `0 <= screenX/Y <= screen - outer`.

Real window after the fix: visible chrome **1366x720 at +5+5**, inside the display. The toplevel X window reads 1376x730 because Firefox carries a 5px invisible shadow border on each side (there is no window manager under Xvfb, and no `_GTK_FRAME_EXTENTS`); the child window matches `window.outerWidth` exactly.

Headless and `headless='virtual'` are unaffected — sampled under the 1x1 Xvfb they still produce 3072x1728 and 3440x1440, so no fingerprint diversity is lost.

## Tests

`pythonlib/tests/test_fingerprint_fixes.py`, 12 -> 20 passing. Covers the shrink, no-op when already within the display, unset bounds, the avail floor, composition with `clamp_window_dimensions` (the ordering is load-bearing), the position clamp, and the negative guard.

Full pythonlib suite: 53 passed. The 2 `test_virtdisplay.py` failures are pre-existing and reproduce unchanged on a clean tree.

## Not addressed

BrowserForge silently dropping non-strict constraints is an upstream bug. This change defends against it rather than depending on it being fixed.
