### PR TITLE
Fix page.route changing request headers on the wire

### DIFF
--- a/additions/juggler/NetworkObserver.js
+++ b/additions/juggler/NetworkObserver.js
@@ -239,10 +239,13 @@ class NetworkRequest {
     this._overriddenHeadersForRedirect = headers;
     this._expectingResumedRequest = undefined;
 
-    if (headers)
+    const extraHTTPHeaders = this._pageNetwork ? this._pageNetwork.combinedExtraHTTPHeaders() : [];
+    if (headers) {
       overrideRequestHeaders(this.httpChannel, headers);
-    else if (this._pageNetwork)
-      appendExtraHTTPHeaders(this.httpChannel, this._pageNetwork.combinedExtraHTTPHeaders());
+    } else {
+      appendExtraHTTPHeaders(this.httpChannel, extraHTTPHeaders);
+      restoreInterceptedHeaderOrder(this.httpChannel, extraHTTPHeaders);
+    }
     if (method)
       this.httpChannel.requestMethod = method;
     if (postData !== undefined)
@@ -808,6 +811,63 @@ function clearRequestHeaders(httpChannel) {
 function overrideRequestHeaders(httpChannel, headers) {
   clearRequestHeaders(httpChannel);
   appendExtraHTTPHeaders(httpChannel, headers);
+}
+
+// Headers necko adds in HttpBaseChannel::Init, before anything else touches the channel.
+const DEFAULT_REQUEST_HEADERS = ['host', 'user-agent', 'accept', 'accept-language', 'accept-encoding'];
+// Headers necko adds in nsHttpChannel::OnBeforeConnect, which runs after the cookie header is set
+// and after http-on-modify-request, where we add the extra headers.
+const ON_BEFORE_CONNECT_HEADERS = ['upgrade-insecure-requests', 'sec-fetch-dest', 'sec-fetch-mode', 'sec-fetch-site', 'sec-fetch-user'];
+
+// Resuming an intercepted request makes necko tear down the channel and build a fresh one
+// (InterceptedHttpChannel::ResetInterception). The header copy that follows deliberately drops
+// "connection" and "cookie" - the replacement channel is expected to regenerate them - so both
+// end up appended after every header that was copied over, rather than in the slot they occupy
+// on a channel that was never intercepted:
+//
+//   never intercepted: ... accept-encoding, connection, referer, cookie, sec-fetch-*
+//   after a resume:    ... accept-encoding, referer, sec-fetch-*, connection, cookie
+//
+// Request header order is part of a browser's fingerprint, so the second layout tells a server the
+// request came from an automated browser. Put the two headers back in the order necko fills them
+// in: the defaults, "connection", whatever the channel was set up with, "cookie", and finally
+// everything added from http-on-modify-request onwards. Order on the wire follows
+// nsHttpHeaderArray, and setting a header that is already present updates it in place, so moving
+// one means deleting it and adding it back.
+function restoreInterceptedHeaderOrder(httpChannel, extraHTTPHeaders) {
+  const headers = requestHeaders(httpChannel);
+  const nameOf = header => header.name.toLowerCase();
+
+  const displaced = [];
+  for (const name of ['connection', 'cookie']) {
+    const index = headers.findIndex(header => nameOf(header) === name);
+    if (index !== -1)
+      displaced.push(headers.splice(index, 1)[0]);
+  }
+  if (!displaced.length)
+    return;
+
+  const lateHeaders = new Set([
+    ...ON_BEFORE_CONNECT_HEADERS,
+    ...extraHTTPHeaders.map(header => header.name.toLowerCase()),
+  ]);
+  const firstIndex = predicate => {
+    const index = headers.findIndex(predicate);
+    return index === -1 ? headers.length : index;
+  };
+
+  for (const header of displaced) {
+    const boundary = nameOf(header) === 'connection' ?
+        firstIndex(h => !DEFAULT_REQUEST_HEADERS.includes(nameOf(h))) :
+        firstIndex(h => lateHeaders.has(nameOf(h)));
+    headers.splice(boundary, 0, header);
+  }
+
+  // The host header cannot be removed, and it sorts first either way.
+  const movable = headers.filter(header => nameOf(header) !== 'host');
+  for (const header of movable)
+    httpChannel.setRequestHeader(header.name, '', false /* merge */);
+  appendExtraHTTPHeaders(httpChannel, movable);
 }
 
 const redirectStatus = [301, 302, 303, 307, 308];

--- a/additions/juggler/TargetRegistry.js
+++ b/additions/juggler/TargetRegistry.js
@@ -588,8 +588,13 @@ export class PageTarget {
 
   updateCacheDisabled(browsingContext = this._linkedBrowser.browsingContext) {
     const enableFlags = Ci.nsIRequest.LOAD_NORMAL;
-    const disableFlags = Ci.nsIRequest.LOAD_BYPASS_CACHE |
-                  Ci.nsIRequest.INHIBIT_CACHING;
+    // Camoufox: upstream also sets LOAD_BYPASS_CACHE here, which makes necko put
+    // "Pragma: no-cache" and "Cache-Control: no-cache" on every request. Firefox only
+    // does that for a forced reload, and Playwright turns this on for every page.route()
+    // call, so it marks all our traffic as automated. INHIBIT_CACHING alone stops
+    // responses from ever being stored, which starves the cache just as effectively
+    // without announcing it to the server.
+    const disableFlags = Ci.nsIRequest.INHIBIT_CACHING;
 
     browsingContext.defaultLoadFlags = (this._browserContext.disableCache || this.disableCache) ? disableFlags : enableFlags;
   }

--- a/tests/async/test_route_request_fingerprint.py
+++ b/tests/async/test_route_request_fingerprint.py
@@ -1,0 +1,83 @@
+# Camoufox-specific: page.route() must not change what a request looks like on the wire.
+#
+# Enabling request interception used to alter every request the page made, which let anti-bot
+# services tell an intercepted page apart from a normal one (daijro/camoufox#428, #271):
+#
+#   - Playwright pairs every setRequestInterception() with setCacheDisabled(true), and the load
+#     flags behind that made necko attach "Pragma: no-cache" / "Cache-Control: no-cache", which
+#     Firefox otherwise only sends for a forced reload.
+#   - Resuming an intercepted request rebuilds the channel, and the header copy that follows
+#     leaves "connection" and "cookie" appended after the sec-fetch-* headers instead of in
+#     front of them.
+#
+# These tests compare a routed page against an unrouted one rather than hardcoding a header
+# layout, so they keep working as the underlying Firefox changes.
+
+from typing import Dict, List, Tuple
+
+from playwright.async_api import BrowserContext, Page, Route
+from tests.server import Server, TestServerRequest
+
+
+async def _request_headers(context: BrowserContext, server: Server, intercept: bool) -> List[Tuple[str, str]]:
+    """Load a page and return the document request's headers, in the order they arrived."""
+    seen: List[Tuple[str, str]] = []
+
+    def _handler(request: TestServerRequest) -> None:
+        # getAllRawHeaders() yields bytes, in the order the headers arrived.
+        for name, values in request.requestHeaders.getAllRawHeaders():
+            for value in values:
+                seen.append((name.decode().lower(), value.decode()))
+        request.setHeader("content-type", "text/html")
+        request.write(b"<html><body>hi</body></html>")
+        request.finish()
+
+    server.set_route("/fingerprint.html", _handler)
+
+    page = await context.new_page()
+    if intercept:
+        await page.route("**/*", lambda route: route.continue_())
+    await page.goto(server.PREFIX + "/fingerprint.html")
+    await page.close()
+    return seen
+
+
+async def test_page_route_should_not_change_request_headers(context: BrowserContext, server: Server) -> None:
+    await context.add_cookies([{"name": "sid", "value": "x", "url": server.PREFIX}])
+
+    without_route = await _request_headers(context, server, intercept=False)
+    with_route = await _request_headers(context, server, intercept=True)
+
+    assert with_route == without_route
+
+
+async def test_page_route_should_not_change_request_headers_with_extra_http_headers(
+    context: BrowserContext, server: Server
+) -> None:
+    # The extra headers are added at http-on-modify-request, which is after the cookie header,
+    # so they have to be accounted for when putting the cookie header back.
+    await context.add_cookies([{"name": "sid", "value": "x", "url": server.PREFIX}])
+    await context.set_extra_http_headers({"x-custom-hdr": "v1"})
+
+    without_route = await _request_headers(context, server, intercept=False)
+    with_route = await _request_headers(context, server, intercept=True)
+
+    assert with_route == without_route
+
+
+async def test_page_route_should_not_advertise_a_disabled_cache(context: BrowserContext, server: Server) -> None:
+    headers: Dict[str, str] = dict(await _request_headers(context, server, intercept=True))
+
+    # Firefox sends these on a forced reload. A routed page is not a forced reload.
+    assert "pragma" not in headers
+    assert headers.get("cache-control") != "no-cache"
+
+
+async def test_page_route_should_not_reorder_connection_and_cookie(context: BrowserContext, server: Server) -> None:
+    await context.add_cookies([{"name": "sid", "value": "x", "url": server.PREFIX}])
+
+    names = [name for name, _ in await _request_headers(context, server, intercept=True)]
+
+    # Both are added before necko appends the sec-fetch-* headers.
+    assert names.index("connection") < names.index("sec-fetch-mode")
+    assert names.index("cookie") < names.index("sec-fetch-mode")


### PR DESCRIPTION
## Related Issue

Closes #428
Closes #271

## Description

`page.route("**/*", lambda r: r.continue_())` changed what every request looked like on the wire, so anti-bot services blocked pages that load fine without the route. Both reports are the same root cause, and the block lands on the **document request, before any page script runs** — this is an HTTP-level tell, not a JS leak.

```
real Firefox:  Host UA Accept Accept-Language Accept-Encoding | Connection | Cookie | Sec-Fetch-* | Priority
with route:    Host UA Accept Accept-Language Accept-Encoding | Sec-Fetch-* | Connection | Cookie | Priority | Pragma | Cache-Control
```

Two independent causes:

**1. `Pragma: no-cache` + `Cache-Control: no-cache` on every request.** Playwright pairs every `setRequestInterception` with `setCacheDisabled(true)` (`ffNetworkManager.ts`, `ffBrowser.ts`), and juggler implements that as `LOAD_BYPASS_CACHE | INHIBIT_CACHING`. `LOAD_BYPASS_CACHE` makes necko attach both headers. Firefox only sends them for a forced reload, so every request announced itself as automated.

Dropping `LOAD_BYPASS_CACHE` and keeping `INHIBIT_CACHING` gives **identical** cache behaviour (verified: 6 network hits for a `max-age=99999` subresource either way — nothing is stored, so nothing is read) with no wire footprint. `Page.setCacheDisabled` is only ever called as a side effect of interception, so no public API changes.

**2. `Connection` and `Cookie` displaced past `Sec-Fetch-*`.** Resuming an intercepted request makes necko tear down the channel and build a new one (`InterceptedHttpChannel::ResetInterception`). The header copy skips `connection` and `cookie` — the replacement channel is expected to regenerate them — which it does, appended at the end. Header order feeds JA4H/Akamai-style fingerprints, and the resulting layout is one no real Firefox emits.

Both are fixable in `additions/juggler/` — no Firefox C++ patch needed, since the headers are still mutable at `http-on-modify-request` on the resumed channel.

## Type of Change

- [x] Bug fix

## Testing

Reproduced and verified against the prebuilt binary from the issue report (`official/135.0.1-beta.24`), driven with a raw-socket server that logs the exact request bytes in arrival order, with juggler patched inside `omni.ja`.

**This is inherited from upstream juggler, not a Camoufox regression** — stock Playwright Firefox 134 shows the identical diff. Worth reporting upstream too.

After the fix, a routed request is **byte-identical** to an unrouted one across the document, CSS and JS subresources, with and without cookies, and with `set_extra_http_headers`.

Playwright suite (`tests/`) against the patched binary: **203 passed, 0 regressions**. The 12 failures are pre-existing (HTTPS/service-worker/asset-path) and fail identically on the pristine binary.

New `tests/async/test_route_request_fingerprint.py` — 4 tests that compare a routed page against an unrouted one rather than hardcoding a header layout, so they survive Firefox upgrades. Confirmed they **fail on the unfixed binary and pass on the fixed one**:

```
######## PRISTINE (unfixed) ########
test_page_route_should_not_change_request_headers FAILED
test_page_route_should_not_change_request_headers_with_extra_http_headers FAILED
test_page_route_should_not_advertise_a_disabled_cache FAILED
test_page_route_should_not_reorder_connection_and_cookie FAILED
========================= 4 failed =========================

######## PATCHED (fixed) ########
========================= 4 passed =========================
```

Reproduction script and the before/after captures are in the issue thread on request.

## Fingerprint Report

I could not produce a meaningful build-tester report. The only binary I have is `135.0.1-beta.24`; the current build-tester scores it **0/0, Grade F** — and scores the **pristine, unmodified binary identically**, so the harness is simply incompatible with a binary that old (this branch targets 152). It needs a run on a real 152 build before merge.

<details>
<summary>Fingerprint report</summary>

```
Patched:  Grade: F   Score: 0/0   Profiles: 8   Status: ALL PASS
Pristine: Grade: F   Score: 0/0   Profiles: 8   Status: ALL PASS
```

</details>

## Notes for review

- **Verified on FF135, repo targets FF152.** The edited `_onInternalRedirectReady` hunk is textually identical across both versions and the helper ports verbatim, but this deserves one confirmation run on a 152 build.
- **`route.continue_(headers=...)` still reorders headers** — `clearRequestHeaders` pins `cookie` near the front, and any explicitly-passed header list replaces the layout wholesale. Different code path, left alone here to keep this focused; happy to open a separate issue.

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass~~ temporarily out of service
- [ ] Build test passes — see Fingerprint Report above; not runnable against a 135 binary, needs a 152 build
