### PR TITLE
Re-using get_path for correct placement of the file(s) when XDG_CACHE…

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -63,7 +63,7 @@ def _generate_fontconfig(fontconfig_path: str) -> str:
         f'<dir>{fonts_dir}</dir>',
     )
 
-    cache_dir = os.path.join(os.path.expanduser('~'), '.cache', 'camoufox', 'fontconfig')
+    cache_dir = get_path('fontconfig')
     os.makedirs(cache_dir, exist_ok=True)
 
     content_hash = hashlib.sha256(conf_content.encode()).hexdigest()[:12]


### PR DESCRIPTION
## Related Issue

Closes #654

## Description

Re-using get_path for correct placement of the file(s) when XDG_CACHE_HOME env var is set

## Type of Change

- [ x ] Bug fix

## Testing

In Docker env with ENV XDG_CACHE_HOME

## Fingerprint Report

It's a trivial change

## Checklist

- [ x ] I have linked a related issue above
- [ x ] My changes are focused on a single logical change
- [ x ] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass (for python library changes) -`./service-tester/run_tests.sh --browser-version official/prerelease/146.0.1-alpha.25` (attach screenshot)~~ temporarily out of service lol
- [ ] Build test passes (for patch changes) - `./build-tester/run_tests.sh` A score of at least 1000 must be achieved (attach screenshot)
