### PR TITLE
fix(juggler): restore humanized mouse trajectory dropped in FF146 migration (#677)

### DIFF
--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -81,6 +81,9 @@ export class PageHandler {
 
     this._isDragging = false;
     this._lastMousePosition = { x: 0, y: 0 };
+    // Camoufox: last position an actual mousemove landed on. Used as the
+    // start point for the humanized cursor trajectory (humanize=True).
+    this._lastTrackedPos = { x: 0, y: 0 };
 
     this._reportedFrameIds = new Set();
     this._networkEventsForUnreportedFrameIds = new Map();
@@ -523,13 +526,14 @@ export class PageHandler {
         await helper.awaitTopic('apz-repaints-flushed');
 
       const watcher = new EventWatcher(this._pageEventSink, types, this._pendingEventWatchers);
-      const promises = [];
-      for (const type of types) {
+      // Dispatch a single synthesized mouse event to the renderer and return a
+      // promise that resolves once the renderer acks it.
+      const sendOne = (eventType, eventX, eventY) => {
         // This dispatches to the renderer synchronously.
         const jugglerEventId = win.windowUtils.jugglerSendMouseEvent(
-          type,
-          x + boundingBox.left,
-          y + boundingBox.top,
+          eventType,
+          eventX + boundingBox.left,
+          eventY + boundingBox.top,
           button,
           clickCount,
           modifiers,
@@ -542,7 +546,33 @@ export class PageHandler {
           win.windowUtils.DEFAULT_MOUSE_POINTER_ID /* pointerIdentifier */,
           false /* disablePointerEvent */
         );
-        promises.push(watcher.ensureEvent(type, eventObject => eventObject.jugglerEventId === jugglerEventId));
+        return watcher.ensureEvent(eventType, eventObject => eventObject.jugglerEventId === jugglerEventId);
+      };
+
+      const promises = [];
+      for (const type of types) {
+        // Camoufox: when humanize is enabled, expand a direct mousemove into a
+        // human-like trajectory of intermediate mousemoves generated in C++
+        // (ChromeUtils.camouGetMouseTrajectory / MouseTrajectories.hpp).
+        if (type === 'mousemove' && ChromeUtils.camouGetBool('humanize', false)) {
+          const trajectory = ChromeUtils.camouGetMouseTrajectory(this._lastTrackedPos.x, this._lastTrackedPos.y, x, y);
+          // Dispatch intermediate points sequentially with a short delay. The
+          // first/last pairs are skipped: the last pair is the exact
+          // destination, which is dispatched explicitly below.
+          for (let i = 2; i < trajectory.length - 2; i += 2) {
+            const currentX = trajectory[i];
+            const currentY = trajectory[i + 1];
+            // Skip movement that is out of bounds
+            if (currentX < 0 || currentY < 0 || currentX > boundingBox.width || currentY > boundingBox.height)
+              continue;
+            await sendOne('mousemove', currentX, currentY);
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+          // Always finish exactly on the requested destination.
+          promises.push(sendOne('mousemove', x, y));
+        } else {
+          promises.push(sendOne(type, x, y));
+        }
       }
       await Promise.all(promises);
       await watcher.dispose();
@@ -603,6 +633,9 @@ export class PageHandler {
 
         const watcher = new EventWatcher(this._pageEventSink, ['dragstart', 'juggler-drag-finalized'], this._pendingEventWatchers);
         await sendEvents(['mousemove']);
+        // Camoufox: remember where the cursor landed so the next humanized
+        // move starts its trajectory from the real previous position.
+        this._lastTrackedPos = { x, y };
 
         // The order of events after 'mousemove' is sent:
         // 1. [dragstart] - might or might NOT be emitted

--- a/tests/patches/humanize-mouse-trajectory.py
+++ b/tests/patches/humanize-mouse-trajectory.py
@@ -1,0 +1,111 @@
+"""
+Verify humanize=True produces a native cursor trajectory (daijro/camoufox#677).
+
+Camoufox's cursor humanization has a single call site: the `mousemove` branch of
+`sendEvents()` in additions/juggler/protocol/PageHandler.js, which calls
+`ChromeUtils.camouGetMouseTrajectory(...)` and dispatches the intermediate
+points. The Firefox 146 Juggler migration (commit 03c1230) rewrote that helper
+and silently dropped the branch, so from FF146 through v152 `humanize=True`
+emitted only the endpoint mousemove -- no trajectory at all.
+
+This is runtime-only: the C++ generator (MouseTrajectories.hpp), the ChromeUtils
+bindings, and the config plumbing all stay intact and every patch applies
+cleanly, so nothing fails loudly. Only driving a real browser and counting the
+emitted mousemove events catches it.
+
+Run against a specific build:
+    CAMOUFOX_EXECUTABLE_PATH=/path/to/camoufox-bin python tests/patches/humanize-mouse-trajectory.py
+(without the env var it uses the camoufox-managed browser download.)
+
+What PASS means:
+    * humanize=True expands one long mouse.move into many intermediate
+      mousemove events, ending exactly on the requested destination;
+    * a humanized click still lands on the target element;
+    * without humanize, each move emits only its endpoint (pins the other
+      direction so accidental always-on humanization is also caught).
+"""
+
+import asyncio
+import os
+import sys
+
+from camoufox.async_api import AsyncCamoufox
+
+DEST = (1100, 650)
+BODY = '<body style="margin:0;width:1400px;height:800px"></body>'
+RECORDER = """
+    window.moves = [];
+    addEventListener("mousemove", e => moves.push([e.clientX, e.clientY]));
+"""
+
+EXECUTABLE_PATH = os.environ.get("CAMOUFOX_EXECUTABLE_PATH")
+
+
+def _launch_kwargs(humanize):
+    kwargs = dict(headless=True, os="linux", humanize=humanize)
+    if EXECUTABLE_PATH:
+        kwargs["executable_path"] = EXECUTABLE_PATH
+    return kwargs
+
+
+async def _collect_moves(humanize):
+    async with AsyncCamoufox(**_launch_kwargs(humanize)) as browser:
+        page = await browser.new_page()
+        await page.set_content(BODY)
+        await page.evaluate(RECORDER)
+        await page.mouse.move(20, 20)
+        await page.mouse.move(*DEST)
+        return await page.evaluate("moves")
+
+
+async def _humanized_click_hits_target():
+    async with AsyncCamoufox(**_launch_kwargs(True)) as browser:
+        page = await browser.new_page()
+        await page.set_content(
+            '<button id="b" style="position:absolute;left:600px;top:400px">go</button>'
+        )
+        await page.evaluate(
+            "window.moves=0;window.clicked=false;"
+            "addEventListener('mousemove',()=>moves++);"
+            "document.getElementById('b').addEventListener('click',()=>clicked=true)"
+        )
+        await page.click("#b")
+        return await page.evaluate("moves"), await page.evaluate("clicked")
+
+
+async def main() -> int:
+    passed = True
+
+    humanized = await _collect_moves(True)
+    print("\n=== humanize=True ===")
+    print(f"  mousemove events: {len(humanized)}  (endpoint: {humanized[-1] if humanized else None})")
+    if len(humanized) >= 10 and humanized[-1] == list(DEST):
+        print("  PASS: humanized trajectory emitted, ending on destination")
+    else:
+        passed = False
+        print("  FAIL: expected >=10 intermediate points ending exactly on the destination")
+
+    plain = await _collect_moves(False)
+    print("\n=== humanize off ===")
+    print(f"  mousemove events: {plain}")
+    if plain == [[20, 20], list(DEST)]:
+        print("  PASS: only endpoints emitted")
+    else:
+        passed = False
+        print("  FAIL: expected only the two endpoints")
+
+    moves, clicked = await _humanized_click_hits_target()
+    print("\n=== humanized click ===")
+    print(f"  intermediate moves: {moves}  clicked: {clicked}")
+    if moves >= 10 and clicked:
+        print("  PASS: humanized click landed on the target")
+    else:
+        passed = False
+        print("  FAIL: humanized click did not humanize or missed the target")
+
+    print()
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
This was actually a fairly minor fix, but seems like its been around awhile. Just affects juggler.
__________________________________________________________________

Fixes #677

### Problem

Since the Firefox 146 Juggler migration (commit `03c1230`), `humanize=True` has had no effect: a long `page.mouse.move()` emits only the single endpoint `mousemove`, with no intermediate trajectory points. This affects `locator.click()`, drag, and press-and-hold flows used by CAPTCHA solvers.

As the issue correctly diagnosed, `03c1230` rewrote the `sendEvents()` helper inside `Page.dispatchMouseEvent` to batch events via `Promise.all`, and in doing so dropped the Camoufox humanize branch. The native C++ generator (`MouseTrajectories.hpp` / `ChromeUtils.camouGetMouseTrajectory`) and all config plumbing (`settings/properties.json`, `pythonlib`) remained intact — only the call site in `PageHandler.js` was lost.

### Fix

Reintroduce the trajectory expansion inside the current `sendEvents()`:

- Factor single-event dispatch into a `sendOne()` helper (keeps the FF152 `jugglerSendMouseEvent` signature).
- When `humanize` is enabled, expand a `mousemove` into the C++-generated trajectory, dispatching intermediate points sequentially with a 10 ms delay, then **always finishing exactly on the requested destination** so clicks/hover still land on target (the raw trajectory's last point is skipped, matching the original loop, but the exact endpoint is now dispatched explicitly for accuracy).
- Restore `_lastTrackedPos` so each move's trajectory starts from the real previous cursor position.

### Regression test

Adds `tests/patches/humanize-mouse-trajectory.py` (following the existing `tests/patches/` convention) that drives a real build and counts emitted mousemove events:

- `humanize=True` must expand a long move into ≥10 intermediate points ending exactly on the destination;
- a humanized `click()` must still land on the target element;
- without humanize, each move emits only its endpoint (pins the other direction so accidental always-on humanization is caught too).

### Verification

Tested end-to-end against the built `v152.0.4-beta.25` Linux binary by swapping the updated loose `PageHandler.js` into the dist (no rebuild needed). The regression test was confirmed to have teeth — it **fails on the pre-fix code and passes on the fix**:

| Config | pre-fix | with fix |
|---|---|---|
| `humanize=True`, long move | 2 events (bug) | ~149 events, ends `[1100,650]` |
| humanized `click()` | 1 intermediate move (missed humanization) | ~111 moves, lands on target |
| `humanize` off | 2 endpoints | 2 endpoints (unchanged) |
| test exit code | `1` (FAIL) | `0` (PASS) |

Regression checks on the same binary: normal `click`/`fill`/`drag_and_drop` behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)