### PR TITLE
fix(python): normalize humanize duration types

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -773,8 +773,10 @@ def launch_options(
     # Pass the humanize option
     if humanize:
         set_into(config, 'humanize', True)
-        if isinstance(humanize, (int, float)):
-            set_into(config, 'humanize:maxTime', humanize)
+        # bool is a subclass of int, but MaskConfig expects maxTime to be a
+        # JSON number with a floating-point representation.
+        if isinstance(humanize, (int, float)) and not isinstance(humanize, bool):
+            set_into(config, 'humanize:maxTime', float(humanize))
 
     # Enable the main world context creation
     if main_world_eval:

--- a/pythonlib/tests/test_humanize.py
+++ b/pythonlib/tests/test_humanize.py
@@ -1,0 +1,67 @@
+"""Regression tests for humanized cursor launch configuration."""
+
+import pytest
+
+from camoufox import utils
+
+
+@pytest.fixture
+def captured_launch_config(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(utils, "generate_fingerprint", lambda **_kwargs: object())
+    monkeypatch.setattr(utils, "from_browserforge", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(utils, "get_screen_cons", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        utils, "_generate_random_font_subset", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(
+        utils, "_generate_random_voice_subset", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(utils, "validate_config", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(utils, "add_default_addons", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(utils, "fix_navigator_arch", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        utils, "fix_screen_no_taskbar", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        utils, "clamp_window_dimensions", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(utils, "installed_verstr", lambda *_args, **_kwargs: "152.0")
+    monkeypatch.setattr(utils, "launch_path", lambda *_args, **_kwargs: "/camoufox")
+    monkeypatch.setattr(utils.LeakWarning, "warn", lambda *_args, **_kwargs: None)
+
+    def capture_env(config, _target_os):
+        captured.clear()
+        captured.update(config)
+        return {}
+
+    monkeypatch.setattr(utils, "get_env_vars", capture_env)
+
+    def launch(humanize):
+        utils.launch_options(
+            humanize=humanize,
+            block_webgl=True,
+            i_know_what_im_doing=True,
+        )
+        return captured.copy()
+
+    return launch
+
+
+def test_humanize_true_does_not_set_boolean_duration(captured_launch_config) -> None:
+    config = captured_launch_config(True)
+
+    assert config["humanize"] is True
+    assert "humanize:maxTime" not in config
+
+
+@pytest.mark.parametrize("duration", [1, 5, 1.25])
+def test_humanize_duration_is_encoded_as_double(
+    captured_launch_config, duration
+) -> None:
+    config = captured_launch_config(duration)
+
+    assert config["humanize"] is True
+    assert config["humanize:maxTime"] == float(duration)
+    assert type(config["humanize:maxTime"]) is float


### PR DESCRIPTION
## Related Issue

Closes #498

## Description

Python's `bool` is a subclass of `int`, so `humanize=True` was incorrectly serialized as a numeric duration. Integer durations were also left as integers even though the browser-side configuration parser expects a floating-point value.

This change treats Boolean enablement separately and normalizes numeric durations to `float`. `True` enables humanization without writing `humanize:maxTime`; explicit integer or floating-point durations produce a floating-point `maxTime`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

- `python -m pytest pythonlib/tests/test_humanize.py -q`: 4 passed
- `python -m pytest pythonlib/tests -q`: 47 passed, 4 skipped
- Real Camoufox 152.0.4-beta.28 launches and mouse movement completed for Boolean, integer, and floating-point configurations
- Independent static review: PASS, no blocking findings

## Fingerprint Report

Not applicable: this corrects Python-side configuration typing and does not change fingerprint patches.

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass (for python library changes) -`./service-tester/run_tests.sh --browser-version official/prerelease/146.0.1-alpha.25` (attach screenshot)~~ temporarily out of service lol
- [ ] Build test passes (for patch changes) - not applicable to this Python-only change
