### PR TITLE
fix(linux): prepare profile directory before read-only launch

### DIFF
--- a/pythonlib/camoufox/exceptions.py
+++ b/pythonlib/camoufox/exceptions.py
@@ -194,3 +194,9 @@ class CamoufoxNotInstalled(FileNotFoundError):
     """
 
     ...
+
+
+class ProfileDirectoryError(RuntimeError):
+    """Raised when Camoufox's required runtime directory cannot be prepared."""
+
+    ...

--- a/pythonlib/camoufox/pkgman.py
+++ b/pythonlib/camoufox/pkgman.py
@@ -32,6 +32,7 @@ from .__version__ import CONSTRAINTS
 from .exceptions import (
     CamoufoxNotInstalled,
     MissingRelease,
+    ProfileDirectoryError,
     UnsupportedArchitecture,
     UnsupportedOS,
     UnsupportedVersion,
@@ -76,6 +77,41 @@ LAUNCH_FILE = {
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 
 console = Console()
+
+
+def ensure_browser_profile_dir(
+    env: Optional[Dict[str, Union[str, float, bool]]] = None,
+) -> Optional[Path]:
+    """Ensure Firefox's Linux application directory exists before startup.
+
+    Firefox probes ``~/.camoufox`` even when Playwright supplies a temporary
+    profile. On a read-only HOME, a missing directory makes startup stall; an
+    existing directory may itself remain read-only.
+    """
+    if OS_NAME != 'lin':
+        return None
+
+    environment = os.environ if env is None else env
+    configured_home = environment.get('HOME')
+    home = Path(str(configured_home)).expanduser() if configured_home else Path.home()
+    profile_dir = home / '.camoufox'
+    if profile_dir.is_dir():
+        return profile_dir
+
+    try:
+        profile_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError as error:
+        raise ProfileDirectoryError(
+            f"Camoufox requires '{profile_dir}' to exist before launch, but it "
+            "could not be created. For a read-only runtime, create this directory "
+            "before making HOME read-only."
+        ) from error
+
+    if not profile_dir.is_dir():
+        raise ProfileDirectoryError(
+            f"Camoufox requires '{profile_dir}' to be a directory before launch."
+        )
+    return profile_dir
 
 
 def rprint(msg: str, fg: Optional[str] = None, nl: bool = True) -> None:
@@ -595,6 +631,7 @@ class CamoufoxFetcher(GitHubDownloader):
         from .multiversion import install_versioned
 
         install_versioned(self, replace=replace)
+        ensure_browser_profile_dir()
 
     @property
     def url(self) -> str:

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -25,7 +25,13 @@ from .fingerprints import from_browserforge, from_preset, generate_fingerprint, 
 from .geolocation import geoip_allowed, get_geolocation
 from .ip import Proxy, public_ip, valid_ipv4, valid_ipv6
 from .locales import handle_locales
-from .pkgman import OS_NAME, get_path, installed_verstr, launch_path
+from .pkgman import (
+    OS_NAME,
+    ensure_browser_profile_dir,
+    get_path,
+    installed_verstr,
+    launch_path,
+)
 from .virtdisplay import VirtualDisplay
 from ._warnings import LeakWarning
 from .webgl import sample_webgl
@@ -584,6 +590,8 @@ def launch_options(
         **launch_options (Dict[str, Any]):
             Additional Firefox launch options.
     """
+    ensure_browser_profile_dir(env)
+
     # Build the config
     if config is None:
         config = {}

--- a/pythonlib/tests/test_profile_directory.py
+++ b/pythonlib/tests/test_profile_directory.py
@@ -1,0 +1,81 @@
+"""Regression coverage for the Linux runtime directory required at startup."""
+
+import os
+
+import pytest
+
+from camoufox import multiversion, pkgman, utils
+
+
+def test_missing_linux_profile_directory_is_created(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(pkgman, "OS_NAME", "lin")
+
+    profile_dir = pkgman.ensure_browser_profile_dir({"HOME": str(home)})
+
+    assert profile_dir == home / ".camoufox"
+    assert profile_dir.is_dir()
+
+
+def test_existing_profile_directory_can_be_read_only(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    profile_dir = home / ".camoufox"
+    profile_dir.mkdir(parents=True)
+    monkeypatch.setattr(pkgman, "OS_NAME", "lin")
+    home.chmod(0o500)
+    profile_dir.chmod(0o500)
+    try:
+        assert pkgman.ensure_browser_profile_dir({"HOME": str(home)}) == profile_dir
+    finally:
+        profile_dir.chmod(0o700)
+        home.chmod(0o700)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permissions required")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root bypasses directory permission bits",
+)
+def test_missing_profile_directory_in_read_only_home_fails_fast(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(pkgman, "OS_NAME", "lin")
+    home.chmod(0o500)
+    try:
+        with pytest.raises(RuntimeError, match=r"\.camoufox.*before.*read-only"):
+            pkgman.ensure_browser_profile_dir({"HOME": str(home)})
+    finally:
+        home.chmod(0o700)
+
+
+def test_other_platforms_do_not_create_linux_profile_directory(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(pkgman, "OS_NAME", "mac")
+
+    assert pkgman.ensure_browser_profile_dir({"HOME": str(home)}) is None
+    assert not (home / ".camoufox").exists()
+
+
+def test_fetch_prepares_profile_directory(monkeypatch):
+    calls = []
+    monkeypatch.setattr(multiversion, "install_versioned", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pkgman, "ensure_browser_profile_dir", lambda: calls.append(True))
+    fetcher = object.__new__(pkgman.CamoufoxFetcher)
+
+    fetcher.install()
+
+    assert calls == [True]
+
+
+def test_launch_preflight_runs_before_fingerprint_generation(monkeypatch):
+    class PreflightReached(Exception):
+        pass
+
+    def stop_at_preflight(env):
+        raise PreflightReached
+
+    monkeypatch.setattr(utils, "ensure_browser_profile_dir", stop_at_preflight)
+    with pytest.raises(PreflightReached):
+        utils.launch_options(env={"HOME": "/read-only"})


### PR DESCRIPTION
## Related Issue

Closes #572

## Description

Firefox probes `~/.camoufox` during Linux startup even when Playwright supplies a temporary profile. If that directory is missing after the runtime filesystem becomes read-only, the browser can hang without a useful error.

This change creates the required directory during `camoufox fetch`, verifies it again before launch, accepts an existing read-only directory, and raises an actionable `ProfileDirectoryError` when a missing directory cannot be created. The preflight is Linux-only and honors the launch environment's `HOME`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

- `python -m pytest pythonlib/tests/test_profile_directory.py -q`: 6 passed
- `python -m pytest pythonlib/tests -q`: 49 passed, 4 skipped
- Independent static review: PASS, no blocking findings
- Linux proof: [Ubuntu 24.04 run 29750736883](https://github.com/Cloudymap1e/camoufox/actions/runs/29750736883) passed all steps: 6 focused tests, `camoufox fetch` pre-created `~/.camoufox`, an actual bind-mounted read-only HOME accepted the existing directory, and a missing directory failed fast with `ProfileDirectoryError` caused by `EROFS`.

## Fingerprint Report

Not applicable: this is a Linux startup preflight and does not alter the browser binary or fingerprint patches.

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass (for python library changes) -`./service-tester/run_tests.sh --browser-version official/prerelease/146.0.1-alpha.25` (attach screenshot)~~ temporarily out of service lol
- [ ] Build test passes (for patch changes) - not applicable to this Python-only change
