### PR TITLE
fix(python): close browser server on launcher shutdown

### DIFF
--- a/pythonlib/camoufox/launchServer.js
+++ b/pythonlib/camoufox/launchServer.js
@@ -17,35 +17,102 @@ try {
     process.exit(1)
 }
 
-function collectData() {
-    return new Promise((resolve) => {
-        let data = '';
-        process.stdin.setEncoding('utf8');
+process.stdin.setEncoding('utf8')
 
-        process.stdin.on('data', (chunk) => {
-            data += chunk;
-        });
+// Attach lifecycle listeners before reading configuration so an early terminal
+// event cannot arrive between setup and browser launch. Resolve with a possible
+// stream error instead of rejecting early, which would otherwise become an
+// unhandled rejection while configuration is still being collected.
+const stdinTerminated = new Promise((resolve) => {
+    let settled = false
+    const cleanup = () => {
+        process.stdin.removeListener('end', onEnd)
+        process.stdin.removeListener('close', onClose)
+        process.stdin.removeListener('error', onError)
+    }
+    const finish = (error = null) => {
+        if (settled)
+            return
+        settled = true
+        cleanup()
+        resolve(error)
+    }
+    const onEnd = () => finish()
+    const onClose = () => finish()
+    const onError = (error) => finish(error)
 
-        process.stdin.on('end', () => {
-            resolve(JSON.parse(Buffer.from(data, "base64").toString()));
-        });
-    });
+    process.stdin.once('end', onEnd)
+    process.stdin.once('close', onClose)
+    process.stdin.once('error', onError)
+})
+
+function parseOptions(data) {
+    return JSON.parse(Buffer.from(data, 'base64').toString())
 }
 
-collectData().then((options) => {
-    console.time('Server launched');
-    console.info('Launching server...');
-    
-    playwright.firefox.launchServer(options).then(browserServer => {
-        console.timeEnd('Server launched');
-        console.log('Websocket endpoint:\x1b[93m', browserServer.wsEndpoint(), '\x1b[0m');
-        // Continue forever
-        process.stdin.resume();
-    }).catch(error => {
-        console.error('Error launching server:', error.message);
-        process.exit(1);
-    });
-}).catch((error) => {
-    console.error('Error collecting data:', error.message);
-    process.exit(1);  // Exit with error code
-});
+function collectData() {
+    return new Promise((resolve, reject) => {
+        let data = ''
+        let settled = false
+
+        const cleanup = () => {
+            process.stdin.removeListener('data', onData)
+            process.stdin.removeListener('end', onEnd)
+            process.stdin.removeListener('close', onClose)
+            process.stdin.removeListener('error', onError)
+        }
+        const finish = (encoded) => {
+            if (settled)
+                return
+            settled = true
+            cleanup()
+            try {
+                resolve(parseOptions(encoded))
+            } catch (error) {
+                reject(error)
+            }
+        }
+        const onData = (chunk) => {
+            data += chunk
+            const newline = data.indexOf('\n')
+            if (newline !== -1)
+                finish(data.slice(0, newline))
+        }
+        // Accept the old EOF-delimited format as a fallback for direct callers.
+        const onEnd = () => finish(data)
+        const onClose = () => finish(data)
+        const onError = (error) => {
+            if (settled)
+                return
+            settled = true
+            cleanup()
+            reject(error)
+        }
+
+        process.stdin.on('data', onData)
+        process.stdin.once('end', onEnd)
+        process.stdin.once('close', onClose)
+        process.stdin.once('error', onError)
+        process.stdin.resume()
+    })
+}
+
+async function main() {
+    const options = await collectData()
+
+    console.time('Server launched')
+    console.info('Launching server...')
+    const browserServer = await playwright.firefox.launchServer(options)
+    console.timeEnd('Server launched')
+    console.log('Websocket endpoint:\x1b[93m', browserServer.wsEndpoint(), '\x1b[0m')
+
+    const stdinError = await stdinTerminated
+    await browserServer.close()
+    if (stdinError)
+        throw stdinError
+}
+
+main().catch((error) => {
+    console.error('Error launching server:', error.message)
+    process.exit(1)
+})

--- a/pythonlib/camoufox/server.py
+++ b/pythonlib/camoufox/server.py
@@ -63,12 +63,55 @@ def launch_server(**kwargs) -> NoReturn:
         stdin=subprocess.PIPE,
         text=True,
     )
-    # Write data to stdin, close the stream, and wait forever.
-    # communicate() tolerates the pipe closing early if the server exits before reading
-    # its config, keeping that error visible instead of masking it with an OSError.
-    process.communicate(input=base64.b64encode(data).decode())
+    # Send one newline-delimited configuration frame, then keep the pipe open.
+    # The Node process treats EOF as a shutdown request and can close Playwright
+    # cleanly before exiting, which removes its temporary browser profile.
+    assert process.stdin is not None
+    stdin = process.stdin
+    encoded_config = base64.b64encode(data).decode() + '\n'
 
-    # Add an explicit return statement to satisfy the NoReturn type hint
+    def close_stdin() -> None:
+        if stdin.closed:
+            return
+        try:
+            stdin.close()
+        except OSError:
+            pass
+
+    def shutdown_process() -> None:
+        """Ask Node to close BrowserServer, then reap it with bounded fallbacks."""
+        close_stdin()
+        if process.poll() is not None:
+            process.wait()
+            return
+        try:
+            process.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+
+    try:
+        stdin.write(encoded_config)
+        stdin.flush()
+        process.wait()
+    except OSError as error:
+        # If Node failed before reading the frame, preserve its exit status
+        # instead of masking the original failure with a pipe exception.
+        shutdown_process()
+        raise RuntimeError(
+            f"Server process terminated unexpectedly with exit code {process.returncode}"
+        ) from error
+    except BaseException:
+        shutdown_process()
+        raise
+    finally:
+        close_stdin()
+
+    # Add an explicit exception to satisfy the NoReturn type hint.
     raise RuntimeError(
         f"Server process terminated unexpectedly with exit code {process.returncode}"
     )

--- a/pythonlib/tests/test_server.py
+++ b/pythonlib/tests/test_server.py
@@ -16,8 +16,11 @@ Run with:
 
 import base64
 import os
+import queue
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 
 import orjson
@@ -36,6 +39,27 @@ MODULE_ERRORS = ("Cannot find module", "MODULE_NOT_FOUND")
 
 def _driver_package() -> Path:
     return Path(get_nodejs()).parent / "package"
+
+
+def _read_until(process, expected: str, timeout: float = 5) -> str:
+    lines = queue.Queue()
+
+    def read_stdout():
+        for line in process.stdout:
+            lines.put(line)
+
+    threading.Thread(target=read_stdout, daemon=True).start()
+    output = []
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            line = lines.get(timeout=deadline - time.monotonic())
+        except queue.Empty:
+            break
+        output.append(line)
+        if expected in line:
+            return "".join(output)
+    raise AssertionError(f"Did not receive {expected!r}; stdout was {''.join(output)!r}")
 
 
 def test_driver_entrypoint_exposes_launch_server():
@@ -81,6 +105,155 @@ def test_launch_script_resolves_driver_against_installed_playwright():
         assert error not in combined, f"driver failed to resolve:\n{combined}"
     assert "Launching server..." in combined, combined
     assert "executable doesn't exist" in combined, combined
+
+
+def test_launch_script_closes_server_gracefully(tmp_path):
+    driver = tmp_path / "driver"
+    driver.mkdir()
+    close_marker = tmp_path / "closed"
+    (driver / "index.js").write_text(
+        "const fs = require('fs');\n"
+        "module.exports = { firefox: { launchServer: async () => ({\n"
+        "  wsEndpoint: () => 'ws://test-server',\n"
+        "  close: async () => fs.writeFileSync(process.env.CLOSE_MARKER, 'closed')\n"
+        "}) } };\n"
+    )
+    env = os.environ.copy()
+    env["CLOSE_MARKER"] = str(close_marker)
+    process = subprocess.Popen(
+        [get_nodejs(), str(server.LAUNCH_SCRIPT), str(driver)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert process.stdin is not None
+    try:
+        config = base64.b64encode(orjson.dumps({})).decode()
+        midpoint = len(config) // 2
+        process.stdin.write(config[:midpoint])
+        process.stdin.flush()
+        process.stdin.write(config[midpoint:] + "\nignored-after-first-frame\n")
+        process.stdin.flush()
+
+        output = _read_until(process, "ws://test-server")
+        assert "Launching server..." in output
+        assert process.poll() is None
+        assert not close_marker.exists()
+
+        process.stdin.close()
+        assert process.wait(timeout=5) == 0
+        assert close_marker.read_text() == "closed"
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+        if not process.stdin.closed:
+            process.stdin.close()
+
+
+@pytest.mark.parametrize(
+    ("destroy_argument", "expected_returncode"),
+    [("", 0), ("new Error('control stream failed')", 1)],
+)
+def test_launch_script_closes_server_on_stdin_close_or_error(
+    tmp_path, destroy_argument, expected_returncode
+):
+    driver = tmp_path / "driver"
+    driver.mkdir()
+    close_marker = tmp_path / "closed"
+    (driver / "index.js").write_text(
+        "const fs = require('fs');\n"
+        "module.exports = { firefox: { launchServer: async () => {\n"
+        f"  setTimeout(() => process.stdin.destroy({destroy_argument}), 25);\n"
+        "  return {\n"
+        "    wsEndpoint: () => 'ws://test-server',\n"
+        "    close: async () => fs.writeFileSync(process.env.CLOSE_MARKER, 'closed')\n"
+        "  };\n"
+        "} } };\n"
+    )
+    env = os.environ.copy()
+    env["CLOSE_MARKER"] = str(close_marker)
+    process = subprocess.Popen(
+        [get_nodejs(), str(server.LAUNCH_SCRIPT), str(driver)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert process.stdin is not None
+    try:
+        config = base64.b64encode(orjson.dumps({})).decode()
+        process.stdin.write(config + "\n")
+        process.stdin.flush()
+        _read_until(process, "ws://test-server")
+
+        assert process.wait(timeout=5) == expected_returncode
+        assert close_marker.read_text() == "closed"
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+        if not process.stdin.closed:
+            process.stdin.close()
+
+
+@pytest.mark.parametrize("interrupt_at", ["write", "flush"])
+def test_launch_server_reaps_child_when_sending_config_is_interrupted(
+    monkeypatch, interrupt_at
+):
+    class InterruptingStdin:
+        def __init__(self):
+            self.closed = False
+
+        def write(self, data):
+            if interrupt_at == "write":
+                raise KeyboardInterrupt
+            return len(data)
+
+        def flush(self):
+            if interrupt_at == "flush":
+                raise KeyboardInterrupt
+
+        def close(self):
+            self.closed = True
+
+    class FakeProcess:
+        def __init__(self):
+            self.stdin = InterruptingStdin()
+            self.returncode = None
+            self.wait_timeouts = []
+            self.terminated = False
+            self.killed = False
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout=None):
+            self.wait_timeouts.append(timeout)
+            self.returncode = 0
+            return 0
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+
+    process = FakeProcess()
+    monkeypatch.setattr(server, "get_nodejs", lambda: "/node")
+    monkeypatch.setattr(server, "launch_options", lambda **kwargs: {})
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *args, **kwargs: process)
+
+    with pytest.raises(KeyboardInterrupt):
+        server.launch_server()
+
+    assert process.stdin.closed
+    assert process.wait_timeouts == [15]
+    assert not process.terminated
+    assert not process.killed
 
 
 def test_launch_server_surfaces_child_exit_instead_of_pipe_error(monkeypatch, tmp_path):


### PR DESCRIPTION
## Related Issue

Closes #172

## Description

The Python server launcher previously closed stdin immediately after sending configuration, while the Node process then used that same stream only as a keepalive. That prevented stdin EOF from representing controller shutdown and left BrowserServer cleanup dependent on abrupt process termination.

Python now sends one newline-delimited base64 configuration frame and keeps the pipe open. The Node launcher parses exactly that first frame, latches early stream termination, and treats later stdin end, close, or error as a shutdown request. It closes BrowserServer before exiting so Playwright can remove its temporary profile. The Python side closes the control pipe and reaps the child with bounded terminate/kill fallbacks for interruptions during write, flush, or wait.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

- `python -m pytest pythonlib/tests/test_server.py -q`: 8 passed
- `python -m pytest pythonlib/tests -q`: 48 passed, 4 skipped
- `node --check pythonlib/camoufox/launchServer.js`: passed
- The focused tests use real Node subprocesses to cover split/combined framing, first-frame-only parsing, clean EOF, close-only termination, stream errors, BrowserServer close completion, and interrupted Python write/flush cleanup

## Fingerprint Report

Not applicable: this changes the Python/Node server lifecycle and does not alter fingerprint behavior.

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass (for python library changes) -`./service-tester/run_tests.sh --browser-version official/prerelease/146.0.1-alpha.25` (attach screenshot)~~ temporarily out of service lol
- [ ] Build test passes (for patch changes) - not applicable to this server-lifecycle change
