### PR TITLE
Fix window opening larger than the screen under display scaling

### DIFF
--- a/pythonlib/camoufox/display.py
+++ b/pythonlib/camoufox/display.py
@@ -1,0 +1,101 @@
+"""
+Host display geometry, in the units Firefox lays its windows out in.
+
+Firefox sizes windows in **CSS pixels**, but `screeninfo` marks the process
+per-monitor DPI aware and therefore reports **physical** pixels. Where Windows
+display scaling is enabled the two differ by the scale factor: a 1920x1080 panel
+at 150% is only 1280x720 CSS px. Deriving a window size from the physical
+numbers overshoots the screen by that factor, so the window opens partly
+off-screen (daijro/camoufox#425).
+
+macOS (`NSScreen.frame`) and X11 (xrandr) already report CSS pixels, so scaling
+only ever applies on Windows.
+"""
+
+from typing import Any, NamedTuple, Optional
+
+from screeninfo import get_monitors
+
+from .pkgman import OS_NAME
+
+# Windows expresses DPI relative to this baseline: 144 DPI == 150% scaling.
+_WINDOWS_BASE_DPI = 96
+
+# shcore.h / winuser.h constants
+_MDT_EFFECTIVE_DPI = 0
+_MONITOR_DEFAULTTONEAREST = 2
+
+
+class DisplaySize(NamedTuple):
+    """Size of a monitor in CSS pixels."""
+
+    width: int
+    height: int
+
+
+def largest_display() -> Optional[DisplaySize]:
+    """
+    Size of the roomiest attached monitor in CSS pixels, or None when the
+    display cannot be probed (no monitors, or enumeration failed).
+    """
+    try:
+        monitors = get_monitors()
+    except Exception:
+        return None
+    if not monitors:
+        return None
+
+    monitor = max(monitors, key=lambda m: m.width * m.height)
+    scale = _scale_factor(monitor)
+    return DisplaySize(
+        width=max(1, int(monitor.width / scale)),
+        height=max(1, int(monitor.height / scale)),
+    )
+
+
+def _scale_factor(monitor: Any) -> float:
+    """
+    Physical pixels per CSS pixel on `monitor`. Always 1.0 outside Windows.
+    """
+    if OS_NAME != 'win':
+        return 1.0
+    try:
+        dpi = _windows_monitor_dpi(monitor)
+    except Exception:
+        return 1.0  # Pre-Windows 8.1, or the shcore call is unavailable
+    return dpi / _WINDOWS_BASE_DPI if dpi > 0 else 1.0
+
+
+def _windows_monitor_dpi(monitor: Any) -> int:
+    """
+    Effective DPI of `monitor`, via shcore!GetDpiForMonitor (Windows 8.1+).
+
+    Private WinDLL handles are used rather than the process-wide `ctypes.windll`
+    cache so that annotating the prototypes cannot affect other libraries.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    user32 = ctypes.WinDLL('user32')  # type: ignore[attr-defined]
+    user32.MonitorFromPoint.argtypes = (wintypes.POINT, wintypes.DWORD)
+    user32.MonitorFromPoint.restype = wintypes.HANDLE
+    handle = user32.MonitorFromPoint(
+        wintypes.POINT(int(monitor.x), int(monitor.y)), _MONITOR_DEFAULTTONEAREST
+    )
+
+    shcore = ctypes.WinDLL('shcore')  # type: ignore[attr-defined]
+    shcore.GetDpiForMonitor.argtypes = (
+        wintypes.HANDLE,
+        ctypes.c_int,
+        ctypes.POINTER(wintypes.UINT),
+        ctypes.POINTER(wintypes.UINT),
+    )
+    shcore.GetDpiForMonitor.restype = ctypes.c_long  # HRESULT
+    dpi_x, dpi_y = wintypes.UINT(), wintypes.UINT()
+
+    hresult = shcore.GetDpiForMonitor(
+        handle, _MDT_EFFECTIVE_DPI, ctypes.byref(dpi_x), ctypes.byref(dpi_y)
+    )
+    if hresult != 0:
+        raise OSError(f'GetDpiForMonitor failed (0x{hresult & 0xFFFFFFFF:08X})')
+    return dpi_x.value

--- a/pythonlib/camoufox/display.py
+++ b/pythonlib/camoufox/display.py
@@ -12,7 +12,7 @@ macOS (`NSScreen.frame`) and X11 (xrandr) already report CSS pixels, so scaling
 only ever applies on Windows.
 """
 
-from typing import Any, NamedTuple, Optional
+from typing import Any, Mapping, NamedTuple, Optional
 
 from screeninfo import get_monitors
 
@@ -31,6 +31,19 @@ class DisplaySize(NamedTuple):
 
     width: int
     height: int
+
+
+def has_display(env: Mapping[str, Any]) -> bool:
+    """
+    Whether the host has a desktop session for Camoufox's window to open on.
+
+    DISPLAY / WAYLAND_DISPLAY only ever exist on Linux, so they cannot be the
+    sole probe: keying off DISPLAY alone skipped the screen constraints entirely
+    on Windows and macOS, where a session is always present.
+    """
+    if OS_NAME != 'lin':
+        return True
+    return bool(env.get('DISPLAY') or env.get('WAYLAND_DISPLAY'))
 
 
 def largest_display() -> Optional[DisplaySize]:

--- a/pythonlib/camoufox/fingerprints.py
+++ b/pythonlib/camoufox/fingerprints.py
@@ -406,6 +406,52 @@ def clamp_window_dimensions(config: Dict[str, Any]) -> None:
             config[f'window.inner{axis}'] = outer_clamped
 
 
+def clamp_screen_to_display(
+    config: Dict[str, Any],
+    max_width: Optional[int],
+    max_height: Optional[int],
+) -> None:
+    """Shrink screen.width/height down to the bounds of the real display.
+
+    BrowserForge takes a Screen constraint but drops it silently whenever it
+    filters the fingerprint pool too far: FingerprintGenerator.partial_csp
+    swallows the resulting failure and deletes the constraint unless strict=True.
+    So the bound from get_screen_cons() is best-effort only, and a 1366x768
+    laptop routinely gets a 2560x1440 fingerprint. browser-init.patch resizes the
+    real chrome window to window.outerWidth/outerHeight, so an unbounded value
+    renders past the edge of the monitor (daijro/camoufox#499).
+
+    Keeps the taskbar delta (screen - avail) intact so fix_screen_no_taskbar's
+    invariant survives. Callers must run clamp_window_dimensions afterwards to
+    cascade the new bounds down to avail/outer/inner.
+    """
+    for axis, cap in (('width', max_width), ('height', max_height)):
+        screen = config.get(f'screen.{axis}')
+        if not (screen and cap) or screen <= cap:
+            continue
+        avail_key = 'screen.availWidth' if axis == 'width' else 'screen.availHeight'
+        avail = config.get(avail_key)
+        config[f'screen.{axis}'] = cap
+        if avail:
+            config[avail_key] = max(1, cap - max(0, screen - avail))
+
+
+def clamp_window_position(config: Dict[str, Any]) -> None:
+    """Keep the window box inside the screen: 0 <= screenX/Y <= screen - outer.
+
+    BrowserForge's screenX/screenY are consistent with the screen it generated
+    them against, so clamp_screen_to_display invalidates them. A window
+    positioned partly off its own reported screen is an impossible geometry.
+    """
+    for axis, pos_key in (('Width', 'window.screenX'), ('Height', 'window.screenY')):
+        screen = config.get(f'screen.{axis.lower()}')
+        outer = config.get(f'window.outer{axis}')
+        pos = config.get(pos_key)
+        if pos is None or not (screen and outer):
+            continue
+        config[pos_key] = max(0, min(pos, screen - outer))
+
+
 def set_media_devices_defaults(config: Dict[str, Any]) -> None:
     """Spoof navigator.mediaDevices.enumerateDevices() so headless contexts
     expose a plausible device list.

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -692,11 +692,11 @@ def launch_options(
     if not _user_set_navigator:
         fix_navigator_arch(config, target_os)
     if not _user_set_screen_window:
-        # Headful only: this bound exists so the real window fits the monitor.
-        # headless has no window to overflow, and headless='virtual' runs a 1x1
-        # Xvfb (see virtdisplay.py) that would otherwise shrink the whole
-        # fingerprint to 1x1.
-        if headless is False and screen_cons:
+        # Headful on a real monitor only: this bound exists so the window fits
+        # the screen it is drawn on. headless has no window to overflow, and
+        # headless='virtual' reaches here as headless=False (see async_api) with
+        # a 1x1 Xvfb (virtdisplay.py) that is not a real screen.
+        if headless is False and not virtual_display and screen_cons:
             clamp_screen_to_display(config, screen_cons.max_width, screen_cons.max_height)
         fix_screen_no_taskbar(config, target_os)
         clamp_window_dimensions(config)

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -15,7 +15,7 @@ from typing_extensions import TypeAlias
 from ua_parser import user_agent_parser
 
 from .addons import DefaultAddons, add_default_addons, confirm_paths
-from .display import largest_display
+from .display import has_display, largest_display
 from .exceptions import (
     InvalidOS,
     InvalidPropertyType,
@@ -665,7 +665,7 @@ def launch_options(
 
     # Bound the geometry to the real display. BrowserForge only honours this when
     # its pool has a match, so it is re-applied after generation as well.
-    screen_cons = screen or get_screen_cons(headless or 'DISPLAY' in env)
+    screen_cons = screen or get_screen_cons(headless or has_display(env))
 
     if not _used_preset and fingerprint is None:
         # Default: BrowserForge synthetic generation (infinite unique fingerprints)

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -11,11 +11,11 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 import numpy as np
 import orjson
 from browserforge.fingerprints import Fingerprint, Screen
-from screeninfo import get_monitors
 from typing_extensions import TypeAlias
 from ua_parser import user_agent_parser
 
 from .addons import DefaultAddons, add_default_addons, confirm_paths
+from .display import largest_display
 from .exceptions import (
     InvalidOS,
     InvalidPropertyType,
@@ -212,19 +212,16 @@ def determine_ua_os(user_agent: str) -> Literal['mac', 'win', 'lin']:
 def get_screen_cons(headless: Optional[bool] = None) -> Optional[Screen]:
     """
     Determines a sane viewport size for Camoufox if being ran in headful mode.
+
+    Bounds are CSS pixels, the unit Firefox lays its windows out in -- see
+    camoufox.display for why that differs from the monitor's physical size.
     """
     if headless is False:
         return None  # Skip if headless
-    try:
-        monitors = get_monitors()
-    except Exception:
-        return None  # Skip if there's an error getting the monitors
-    if not monitors:
-        return None  # Skip if there are no monitors
-
-    # Use the dimensions from the monitor with greatest screen real estate
-    monitor = max(monitors, key=lambda m: m.width * m.height)
-    return Screen(max_width=monitor.width, max_height=monitor.height)
+    display = largest_display()
+    if display is None:
+        return None  # Skip if the display can't be probed
+    return Screen(max_width=display.width, max_height=display.height)
 
 
 def update_fonts(config: Dict[str, Any], target_os: str) -> None:

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -21,7 +21,7 @@ from .exceptions import (
     InvalidPropertyType,
     NonFirefoxFingerprint,
 )
-from .fingerprints import from_browserforge, from_preset, generate_fingerprint, get_random_preset, _generate_random_font_subset, _generate_random_voice_subset, fix_navigator_arch, fix_screen_no_taskbar, clamp_window_dimensions, set_media_devices_defaults
+from .fingerprints import from_browserforge, from_preset, generate_fingerprint, get_random_preset, _generate_random_font_subset, _generate_random_voice_subset, fix_navigator_arch, fix_screen_no_taskbar, clamp_screen_to_display, clamp_window_dimensions, clamp_window_position, set_media_devices_defaults
 from .geolocation import geoip_allowed, get_geolocation
 from .ip import Proxy, public_ip, valid_ipv4, valid_ipv6
 from .locales import handle_locales
@@ -666,10 +666,14 @@ def launch_options(
             merge_into(config, from_preset(preset, ff_version_str))
             _used_preset = True
 
+    # Bound the geometry to the real display. BrowserForge only honours this when
+    # its pool has a match, so it is re-applied after generation as well.
+    screen_cons = screen or get_screen_cons(headless or 'DISPLAY' in env)
+
     if not _used_preset and fingerprint is None:
         # Default: BrowserForge synthetic generation (infinite unique fingerprints)
         fingerprint = generate_fingerprint(
-            screen=screen or get_screen_cons(headless or 'DISPLAY' in env),
+            screen=screen_cons,
             window=window,
             os=os,
         )
@@ -688,8 +692,15 @@ def launch_options(
     if not _user_set_navigator:
         fix_navigator_arch(config, target_os)
     if not _user_set_screen_window:
+        # Headful only: this bound exists so the real window fits the monitor.
+        # headless has no window to overflow, and headless='virtual' runs a 1x1
+        # Xvfb (see virtdisplay.py) that would otherwise shrink the whole
+        # fingerprint to 1x1.
+        if headless is False and screen_cons:
+            clamp_screen_to_display(config, screen_cons.max_width, screen_cons.max_height)
         fix_screen_no_taskbar(config, target_os)
         clamp_window_dimensions(config)
+        clamp_window_position(config)
 
     # Set a random window.history.length
     set_into(config, 'window.history.length', randrange(1, 6))  # nosec

--- a/pythonlib/tests/test_display.py
+++ b/pythonlib/tests/test_display.py
@@ -1,0 +1,92 @@
+"""
+Tests for camoufox.display -- probing the host monitor in CSS pixels.
+
+Guards daijro/camoufox#425: with Windows display scaling enabled, screeninfo
+reports physical pixels while Firefox lays windows out in CSS pixels, so the
+browser window opened larger than the screen.
+
+Run with:
+    cd pythonlib && python -m pytest tests/test_display.py -v
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest  # noqa: E402
+
+from camoufox import display  # noqa: E402
+
+
+def monitor(width, height, x=0, y=0):
+    return SimpleNamespace(width=width, height=height, x=x, y=y)
+
+
+@pytest.fixture
+def monitors(monkeypatch):
+    """Stub out screeninfo with an explicit monitor list."""
+
+    def _set(*found):
+        monkeypatch.setattr(display, "get_monitors", lambda: list(found))
+
+    return _set
+
+
+class TestLargestDisplay:
+    def test_reports_unscaled_display_verbatim(self, monkeypatch, monitors):
+        monkeypatch.setattr(display, "OS_NAME", "lin")
+        monitors(monitor(1920, 1080))
+        assert display.largest_display() == (1920, 1080)
+
+    @pytest.mark.parametrize(
+        ("dpi", "expected"),
+        [(96, (1920, 1080)), (120, (1536, 864)), (144, (1280, 720)), (192, (960, 540))],
+    )
+    def test_windows_scaling_converts_to_css_pixels(
+        self, monkeypatch, monitors, dpi, expected
+    ):
+        monkeypatch.setattr(display, "OS_NAME", "win")
+        monkeypatch.setattr(display, "_windows_monitor_dpi", lambda m: dpi)
+        monitors(monitor(1920, 1080))
+        assert display.largest_display() == expected
+
+    def test_scaling_is_windows_only(self, monkeypatch, monitors):
+        """macOS and X11 already report CSS pixels; never rescale them."""
+        monkeypatch.setattr(display, "_windows_monitor_dpi", lambda m: 192)
+        monitors(monitor(1920, 1080))
+        for os_name in ("mac", "lin"):
+            monkeypatch.setattr(display, "OS_NAME", os_name)
+            assert display.largest_display() == (1920, 1080)
+
+    def test_falls_back_to_1x_when_dpi_lookup_fails(self, monkeypatch, monitors):
+        def unavailable(_):
+            raise OSError("GetDpiForMonitor failed")
+
+        monkeypatch.setattr(display, "OS_NAME", "win")
+        monkeypatch.setattr(display, "_windows_monitor_dpi", unavailable)
+        monitors(monitor(1920, 1080))
+        assert display.largest_display() == (1920, 1080)
+
+    def test_falls_back_to_1x_on_nonsense_dpi(self, monkeypatch, monitors):
+        monkeypatch.setattr(display, "OS_NAME", "win")
+        monkeypatch.setattr(display, "_windows_monitor_dpi", lambda m: 0)
+        monitors(monitor(1920, 1080))
+        assert display.largest_display() == (1920, 1080)
+
+    def test_picks_the_roomiest_monitor(self, monkeypatch, monitors):
+        monkeypatch.setattr(display, "OS_NAME", "lin")
+        monitors(monitor(1280, 720), monitor(2560, 1440), monitor(1920, 1080))
+        assert display.largest_display() == (2560, 1440)
+
+    def test_none_when_no_monitors(self, monitors):
+        monitors()
+        assert display.largest_display() is None
+
+    def test_none_when_enumeration_raises(self, monkeypatch):
+        def boom():
+            raise RuntimeError("no display")
+
+        monkeypatch.setattr(display, "get_monitors", boom)
+        assert display.largest_display() is None

--- a/pythonlib/tests/test_display.py
+++ b/pythonlib/tests/test_display.py
@@ -90,3 +90,24 @@ class TestLargestDisplay:
 
         monkeypatch.setattr(display, "get_monitors", boom)
         assert display.largest_display() is None
+
+
+class TestHasDisplay:
+    @pytest.mark.parametrize("os_name", ["win", "mac"])
+    def test_always_present_off_linux(self, monkeypatch, os_name):
+        """Regression: keying off DISPLAY alone skipped Windows/macOS entirely."""
+        monkeypatch.setattr(display, "OS_NAME", os_name)
+        assert display.has_display({}) is True
+
+    @pytest.mark.parametrize(
+        ("env", "expected"),
+        [
+            ({}, False),
+            ({"DISPLAY": ":0"}, True),
+            ({"WAYLAND_DISPLAY": "wayland-0"}, True),
+            ({"DISPLAY": ""}, False),
+        ],
+    )
+    def test_linux_requires_a_session(self, monkeypatch, env, expected):
+        monkeypatch.setattr(display, "OS_NAME", "lin")
+        assert display.has_display(env) is expected

--- a/pythonlib/tests/test_fingerprint_fixes.py
+++ b/pythonlib/tests/test_fingerprint_fixes.py
@@ -16,7 +16,9 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from camoufox.fingerprints import (  # noqa: E402
+    clamp_screen_to_display,
     clamp_window_dimensions,
+    clamp_window_position,
     fix_navigator_arch,
     fix_screen_no_taskbar,
     set_media_devices_defaults,
@@ -126,6 +128,99 @@ class TestClampWindowDimensions:
         clamp_window_dimensions(c)
         assert c["window.outerWidth"] == 1280
         assert c["window.innerWidth"] == 1264
+
+
+class TestClampScreenToDisplay:
+    def test_shrinks_screen_to_display(self):
+        # BrowserForge routinely ships a 2560x1440 fingerprint to a 1366x768
+        # laptop; browser-init then resizes the real window past the monitor.
+        c = {
+            "screen.width": 2560,
+            "screen.height": 1440,
+            "screen.availWidth": 2560,
+            "screen.availHeight": 1400,
+        }
+        clamp_screen_to_display(c, 1366, 768)
+        assert c["screen.width"] == 1366
+        assert c["screen.height"] == 768
+        # taskbar delta (1440-1400=40) preserved, so fix_screen_no_taskbar's
+        # avail < height invariant still holds
+        assert c["screen.availWidth"] == 1366
+        assert c["screen.availHeight"] == 768 - 40
+
+    def test_noop_when_already_within_display(self):
+        c = {"screen.width": 1280, "screen.height": 720, "screen.availHeight": 700}
+        clamp_screen_to_display(c, 1366, 768)
+        assert c["screen.width"] == 1280
+        assert c["screen.height"] == 720
+        assert c["screen.availHeight"] == 700
+
+    def test_ignores_unset_bounds(self):
+        c = {"screen.width": 2560, "screen.height": 1440}
+        clamp_screen_to_display(c, None, None)
+        assert c["screen.width"] == 2560
+        assert c["screen.height"] == 1440
+
+    def test_avail_never_drops_below_one(self):
+        # taskbar delta larger than the display must not produce a <= 0 avail
+        c = {"screen.height": 2000, "screen.availHeight": 100}
+        clamp_screen_to_display(c, None, 768)
+        assert c["screen.availHeight"] >= 1
+
+    def test_clamped_result_survives_cascade(self):
+        c = {
+            "screen.width": 2560,
+            "screen.height": 1440,
+            "screen.availWidth": 2560,
+            "screen.availHeight": 1400,
+            "window.outerWidth": 1920,
+            "window.outerHeight": 1055,
+            "window.innerWidth": 1920,
+            "window.innerHeight": 1000,
+        }
+        clamp_screen_to_display(c, 1366, 768)
+        clamp_window_dimensions(c)
+        assert c["window.outerWidth"] <= c["screen.availWidth"] <= c["screen.width"] == 1366
+        assert c["window.outerHeight"] <= c["screen.availHeight"] <= c["screen.height"] == 768
+        assert c["window.innerWidth"] <= c["window.outerWidth"]
+        assert c["window.innerHeight"] <= c["window.outerHeight"]
+
+
+class TestClampWindowPosition:
+    def test_pulls_window_back_inside_screen(self):
+        c = {
+            "screen.width": 1366,
+            "screen.height": 768,
+            "window.outerWidth": 1366,
+            "window.outerHeight": 728,
+            "window.screenX": 250,
+            "window.screenY": 281,
+        }
+        clamp_window_position(c)
+        assert c["window.screenX"] == 0
+        assert c["window.screenY"] == 40
+
+    def test_noop_when_window_already_inside(self):
+        c = {
+            "screen.width": 1920,
+            "screen.height": 1080,
+            "window.outerWidth": 1280,
+            "window.outerHeight": 720,
+            "window.screenX": 100,
+            "window.screenY": 50,
+        }
+        clamp_window_position(c)
+        assert c["window.screenX"] == 100
+        assert c["window.screenY"] == 50
+
+    def test_never_negative(self):
+        c = {
+            "screen.width": 800,
+            "window.outerWidth": 1000,  # wider than screen
+            "window.screenX": 50,
+        }
+        clamp_window_position(c)
+        assert c["window.screenX"] == 0
 
 
 class TestSetMediaDevicesDefaults:

--- a/pythonlib/tests/test_launch_geometry.py
+++ b/pythonlib/tests/test_launch_geometry.py
@@ -1,0 +1,70 @@
+"""
+Launch-level guards for the display clamp in launch_options().
+
+Run with:
+    cd pythonlib && python -m pytest tests/test_launch_geometry.py -v
+"""
+
+import os
+import sys
+from contextlib import contextmanager
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import orjson  # noqa: E402
+from browserforge.fingerprints import Screen  # noqa: E402
+
+from camoufox import utils  # noqa: E402
+
+# What get_screen_cons() reports under the Xvfb that headless='virtual' starts:
+# virtdisplay.py sizes it "1x1x24", and launch_options mutates os.environ's
+# DISPLAY, so the parent process enumerates that stub as its only monitor.
+XVFB_STUB = Screen(max_width=1, max_height=1)
+
+
+@contextmanager
+def host(screen_cons):
+    """Run launch_options() against a stubbed host, without touching the disk."""
+    with mock.patch.object(utils, "get_screen_cons", lambda headless: screen_cons), (
+        mock.patch.object(utils, "installed_verstr", lambda: "150.0.2")
+    ), mock.patch.object(utils, "launch_path", lambda **kwargs: "/nonexistent/camoufox"):
+        yield
+
+
+def config_of(options):
+    """Reassemble the chunked CAMOU_CONFIG_<n> env vars into a dict."""
+    env = options["env"]
+    chunks = sorted(
+        (int(k.rsplit("_", 1)[1]), v) for k, v in env.items() if k.startswith("CAMOU_CONFIG_")
+    )
+    return orjson.loads("".join(chunk for _, chunk in chunks))
+
+
+def launch(**kwargs):
+    kwargs.setdefault("os", "windows")
+    kwargs.setdefault("i_know_what_im_doing", True)
+    return config_of(utils.launch_options(**kwargs))
+
+
+class TestVirtualDisplayIsNotAScreen:
+    """headless='virtual' arrives here as headless=False (async_api rewrites it),
+    so the headful gate alone would clamp the fingerprint to the 1x1 Xvfb."""
+
+    def test_fingerprint_is_not_shrunk_to_the_xvfb(self):
+        with host(XVFB_STUB):
+            config = launch(headless=False, virtual_display=":99")
+
+        assert config["screen.width"] > 1
+        assert config["screen.height"] > 1
+        assert config["window.outerWidth"] > 1
+
+    def test_screen_dimensions_stay_valid(self):
+        """Clamping to 1x1 drives availHeight negative once fix_screen_no_taskbar
+        subtracts the taskbar, which validate_config rejects as a uint."""
+        with host(XVFB_STUB):
+            config = launch(headless=False, virtual_display=":99")
+
+        for key, value in config.items():
+            if key.startswith("screen.") or key.startswith("window.outer"):
+                assert value >= 0, f"{key} is negative: {value}"

--- a/pythonlib/tests/test_launch_geometry.py
+++ b/pythonlib/tests/test_launch_geometry.py
@@ -13,6 +13,7 @@ from unittest import mock
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import orjson  # noqa: E402
+import pytest  # noqa: E402
 from browserforge.fingerprints import Screen  # noqa: E402
 
 from camoufox import utils  # noqa: E402
@@ -68,3 +69,45 @@ class TestVirtualDisplayIsNotAScreen:
         for key, value in config.items():
             if key.startswith("screen.") or key.startswith("window.outer"):
                 assert value >= 0, f"{key} is negative: {value}"
+
+
+# A 1920x1080 panel at 150% Windows scaling, in CSS pixels
+SCALED_DISPLAY = Screen(max_width=1280, max_height=720)
+
+# Config key -> the display bound it must respect
+BOUNDED_BY = {
+    "screen.width": "max_width",
+    "screen.height": "max_height",
+    "window.outerWidth": "max_width",
+    "window.outerHeight": "max_height",
+}
+
+
+class TestHeadfulFitsOnDisplay:
+    """BrowserForge drops a screen constraint it cannot satisfy, so assert the
+    outcome rather than trusting the constraint to have been honoured."""
+
+    @pytest.mark.parametrize("attempt", range(15))
+    def test_generated_geometry_never_exceeds_the_display(self, attempt):
+        with host(SCALED_DISPLAY):
+            config = launch(headless=False)
+
+        for key, bound in BOUNDED_BY.items():
+            limit = getattr(SCALED_DISPLAY, bound)
+            assert config[key] <= limit, f"{key}={config[key]} exceeds {limit}"
+
+    def test_geometry_stays_internally_consistent(self):
+        with host(SCALED_DISPLAY):
+            config = launch(headless=False)
+
+        assert config["screen.availWidth"] <= config["screen.width"]
+        assert config["screen.availHeight"] < config["screen.height"]  # taskbar
+        assert config["window.outerWidth"] <= config["screen.availWidth"]
+        assert config["window.outerHeight"] <= config["screen.availHeight"]
+
+    def test_unprobeable_display_is_not_clamped(self):
+        """A host we cannot measure must not silently shrink the fingerprint."""
+        with host(None), mock.patch.object(utils, "clamp_screen_to_display") as clamp:
+            launch(headless=False)
+
+        clamp.assert_not_called()


### PR DESCRIPTION
Fixes #425.

> **Stacked on #674.** Only the last two commits belong to this PR:
> `Probe the host monitor in CSS pixels` and `Apply screen constraints on Windows and macOS`.
> The first two are #674's branch, which this builds on to avoid duplicating its clamp.
> Rebase onto `main` once #674 lands.

## Problem

With Windows display scaling enabled (150% / 200%), the browser window opens larger than the monitor.

## Cause

Two independent defects, both in `get_screen_cons()`'s contract.

**1. The bound is computed in the wrong unit.**

`screeninfo`'s Windows enumerator calls `SetProcessDpiAwareness(2)` before enumerating, explicitly so that it reports *physical* pixels:

```python
# Make the process DPI aware so it will detect the actual
# resolution and not a virtualized resolution reported by
# Windows when DPI virtualization is in use.
ctypes.windll.shcore.SetProcessDpiAwareness(2)
```

Firefox lays windows out in **CSS pixels**. Nothing in this repo pins `layout.css.devPixelsPerPx`, so it stays at `-1` and tracks the system scale factor. `browser-init.patch` then calls `window.resizeTo(outerWidth, outerHeight)` with a value the Python layer derived from physical pixels.

At 150% on a 1920x1080 panel the CSS screen is 1280x720, so a fingerprint bounded at "1920x1080" produces a window of 2880x1620 device pixels — 1.5x the screen on both axes.

**2. The bound is never applied on Windows or macOS.**

```python
screen_cons = screen or get_screen_cons(headless or 'DISPLAY' in env)
```

`DISPLAY` is X11-only. On Windows and macOS it is never set, so headful runs took the `headless is False` early return and generated with **no monitor bound at all** — the scaling mismatch above then applied to whatever BrowserForge picked, up to 2560x1440.

## Change

**`camoufox/display.py`** (new) — probes the host monitor in CSS pixels.

- `largest_display()` returns a `DisplaySize` in CSS px. On Windows it divides the physical size by the monitor's effective DPI (`shcore!GetDpiForMonitor` via `MonitorFromPoint`); macOS (`NSScreen.frame`) and X11 already report CSS px, so scaling is Windows-only.
- Degrades to 1.0 whenever the DPI cannot be read (pre-Windows 8.1, `shcore` missing, non-zero `HRESULT`), so behaviour is unchanged where it does not apply.
- Uses private `ctypes.WinDLL` handles rather than the process-wide `ctypes.windll` cache, so annotating the prototypes cannot leak into other libraries in the same process.
- `has_display(env)` replaces the `'DISPLAY' in env` probe: always true off Linux, `DISPLAY` or `WAYLAND_DISPLAY` on Linux.

`get_screen_cons()` keeps its signature and now returns CSS-pixel bounds.

## Scope

Untouched: headless (no window to overflow), `headless='virtual'` (excluded by #674's gate), any caller passing `screen=` or `window=`, and any host whose display cannot be probed.

Windows without scaling is also unaffected — `GetDpiForMonitor` returns 96 DPI, the scale factor is 1.0, and the bound is the physical size as before.

## Tests

`pythonlib/tests/test_display.py` (new) — the DPI conversion table (96/120/144/192 -> 1.0/1.25/1.5/2.0), the Windows-only guard, both fallback paths, monitor selection, and `has_display` per platform.

`pythonlib/tests/test_launch_geometry.py` — adds `TestHeadfulFitsOnDisplay`: 15 randomised headful launches against a 1280x720 CSS display, asserting no `screen.*` or `window.outer*` value exceeds it, plus the geometry invariants and the unprobeable-host case. Asserts the outcome rather than the constraint, since BrowserForge silently drops constraints it cannot satisfy.

Full pythonlib suite: **89 passed**. The 2 `test_virtdisplay.py` failures are pre-existing (no Xvfb on this host) and reproduce unchanged on a clean tree.

## Not addressed

Launching the binary directly, without the Python package, still uses the hardcoded `window.resizeTo(1280, 1040)` in `browser-init.patch`, which can overflow a small scaled display. That needs a patch regeneration through `make edits`.
