### PR TITLE
Spoof navigator.maxTouchPoints from config

### DIFF
--- a/patches/mobile-fingerprint-spoofing.patch
+++ b/patches/mobile-fingerprint-spoofing.patch
@@ -1,0 +1,17 @@
+diff --git a/dom/base/Navigator.cpp b/dom/base/Navigator.cpp
+--- a/dom/base/Navigator.cpp
++++ b/dom/base/Navigator.cpp
+@@ -896,6 +896,13 @@
+ //*****************************************************************************
+
+ uint32_t Navigator::MaxTouchPoints(CallerType aCallerType) {
++  // Camoufox: allow spoofing navigator.maxTouchPoints via config. A desktop
++  // build has no touch digitizer, so the real value is 0 and Firefox's RFP
++  // path only ever collapses it to 0 - there is no way to report a phone's
++  // value without this override.
++  if (auto value = MaskConfig::GetUint32("navigator.maxTouchPoints")) {
++    return value.value();
++  }
+   nsIDocShell* docshell = GetDocShell();
+   BrowsingContext* bc = docshell ? docshell->GetBrowsingContext() : nullptr;
+


### PR DESCRIPTION
## Related Issue

Closes #696

## Description

`navigator.maxTouchPoints` was already a recognized config property (`settings/properties.json` declares it) but nothing read it, so it always reported `0` on a desktop build regardless of the config. Under a Firefox-for-Android user agent that `0` is a mobile-detection tell — a real phone reports `5`, and Firefox's RFP path only ever collapses the value to `0` (`MaxTouchPointsCollapse`), with no path to a phone value without an explicit override.

This adds the standard `MaskConfig` early-return at the top of `Navigator::MaxTouchPoints`, matching how every other navigator/screen property is spoofed (`GetPlatform`, `GetOscpu`, `HardwareConcurrency`, `nsScreen::PixelDepth`, …):

```cpp
if (auto value = MaskConfig::GetUint32("navigator.maxTouchPoints")) {
  return value.value();
}
```

`Navigator.cpp` already includes `MaskConfig.hpp` via `navigator-spoofing.patch`, so no extra include is needed and no schema change is required. With this, `navigator.maxTouchPoints` in the config is honoured (e.g. `5` for a phone).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Testing

Built and driven against the raw binary (same mechanism as `build-tester/runner.py`: `firefox.launch(executable_path=…, env={CAMOU_CONFIG})`), reading `navigator.maxTouchPoints` on a page:

| Case | `CAMOU_CONFIG` | Result |
| --- | --- | --- |
| Control (no config) | — | `0` (unchanged desktop default) |
| Phone value | `{"navigator.maxTouchPoints": 5}` | `5` |
| Single-touch | `{"navigator.maxTouchPoints": 1}` | `1` |

- Patch applies cleanly against the current `main` (Firefox `152.0.4`, `beta.28`) — `patching file dom/base/Navigator.cpp`, no rejects/fuzz.
- Verified on a `linux/arm64` build.

## Fingerprint Report

<details>
<summary>Fingerprint report</summary>

_build-tester score/screenshot to be attached once the current beta.28 arm64 build completes — this PR is opened as a draft until then._

</details>

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass~~ (no `pythonlib/` changes)
- [ ] Build test passes (score ≥ 1000, screenshot) — pending, will attach before marking ready
