### PR TITLE
fix(fonts): keep the browser chrome out of the spoofed font list (#695)

### DIFF
--- a/additions/camoucfg/MaskConfig.hpp
+++ b/additions/camoucfg/MaskConfig.hpp
@@ -7,6 +7,7 @@ Written by daijro.
 #include "json.hpp"
 #include <memory>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <optional>
 #include <codecvt>
@@ -114,6 +115,31 @@ inline std::vector<std::string> GetStringListLower(const std::string& key) {
                    [](unsigned char c) { return std::tolower(c); });
   }
   return result;
+}
+
+/**
+ * The spoofed font family allowlist ("fonts"), lowercased and cached for the
+ * lifetime of the process. CAMOU_CONFIG is read once at startup and never
+ * changes, and the gfx font lookup paths consult this on every family
+ * resolution, so re-parsing the JSON per call is not an option.
+ * An empty list means no font spoofing is configured.
+ */
+inline const std::vector<std::string>& FontAllowlist() {
+  static const std::vector<std::string> fonts = GetStringListLower("fonts");
+  return fonts;
+}
+
+inline bool HasFontAllowlist() { return !FontAllowlist().empty(); }
+
+/**
+ * Whether a font family may be used. `family` must already be lowercased
+ * (gfxPlatformFontList::GenerateFontListKey output is). Always true when no
+ * allowlist is configured.
+ */
+inline bool IsFontAllowed(std::string_view family) {
+  const auto& fonts = FontAllowlist();
+  if (fonts.empty()) return true;
+  return std::find(fonts.begin(), fonts.end(), family) != fonts.end();
 }
 
 template <typename T>

--- a/patches/font-hijacker.patch
+++ b/patches/font-hijacker.patch
@@ -1,5 +1,42 @@
+Camoufox: restrict font family resolution to the spoofed "fonts" allowlist.
+
+The allowlist is applied when a family is looked up, NOT by handing the list to
+Firefox's `font.system.whitelist` pref (which is what this patch used to do).
+That pref drives gfxPlatformFontList::ApplyWhitelist(), which physically
+removes every non-listed family from the process-wide font list -- and, when
+the shared font list is enabled (the default on all three platforms), from the
+read-only list the parent process builds and shares with every content
+process.
+
+The parent process is also the process that paints the browser chrome, so
+pruning the list there strips the UI of the fonts it needs. On Windows that
+leaves the titlebar buttons drawing tofu boxes instead of their Segoe Fluent
+Icons / Segoe MDL2 Assets glyphs (U+E921 / U+E922 / U+E8BB) and the toolbar
+falling back to serif: the icon fonts are not in any of the generated masks,
+and "Segoe UI" only survives when the spoofed OS is Windows. Linux hosts were
+insulated by the bundled FONTCONFIG_FILE, which is why this only shows up on
+Windows and macOS builds.
+
+Filtering at lookup time instead keys off FontVisibilityProvider::IsChrome(),
+so chrome documents (browser UI, devtools, about: pages) keep the host's real
+font list while web content still only ever resolves families from the mask.
+The three content-reachable paths are covered:
+
+  - FindAndAddFamiliesLocked  -- font-family / CSS generic resolution, which is
+                                 what document.fonts.check() and text-metric
+                                 probing go through.
+  - GlobalFontFallback        -- per-character system fallback; also keeps the
+                                 cmap path forced, as the whitelist did, so the
+                                 platform fallback APIs can't pick a family
+                                 behind our back.
+  - gfxUserFontSet local()    -- upstream already refuses local() sources while
+                                 a whitelist is active; keep that behaviour for
+                                 content under the mask, so a page can't probe
+                                 for hidden families via src: local().
+
+Bug: daijro/camoufox#695
+
 diff --git a/gfx/thebes/gfxPlatformFontList.cpp b/gfx/thebes/gfxPlatformFontList.cpp
-index 6bdcd2a57c..41d46bf26c 100644
 --- a/gfx/thebes/gfxPlatformFontList.cpp
 +++ b/gfx/thebes/gfxPlatformFontList.cpp
 @@ -13,6 +13,7 @@
@@ -10,28 +47,131 @@ index 6bdcd2a57c..41d46bf26c 100644
  
  #include "FontVisibilityProvider.h"
  
-@@ -313,6 +314,16 @@ gfxPlatformFontList::gfxPlatformFontList(bool aNeedFullnamePostscriptNames)
+@@ -890,6 +891,29 @@
+   ToLowerCase(aKeyName);
+ }
  
-   mFontPrefs = MakeUnique<FontPrefs>();
- 
-+  // Hijack the kFontSystemWhitelistPref pref
-+  if (std::vector<std::string> fontValues = MaskConfig::GetStringList("fonts");
-+      !fontValues.empty()) {
-+    std::string fontValuesJoined =
-+        std::accumulate(fontValues.begin(), fontValues.end(), std::string(),
-+                        [](const std::string& acc, const std::string& s) {
-+                          return acc.empty() ? s : acc + "," + s;
-+                        });
-+    Preferences::SetCString(kFontSystemWhitelistPref, fontValuesJoined.data());
++/* static */
++bool gfxPlatformFontList::MaskedFontListAppliesTo(
++    FontVisibilityProvider* aFontVisibilityProvider) {
++  if (!MaskConfig::HasFontAllowlist()) {
++    return false;
 +  }
-   gfxFontUtils::GetPrefsFontList(kFontSystemWhitelistPref, mEnabledFontsList);
-   mFontFamilyWhitelistActive = !mEnabledFontsList.IsEmpty();
++  // Chrome documents are not inspectable by the page and they need the host's
++  // real UI fonts -- on Windows the titlebar buttons are Segoe Fluent Icons
++  // glyphs and the toolbar is Segoe UI -- so they are exempt. A null provider
++  // is an internal lookup with no document behind it, which upstream likewise
++  // treats as fully privileged.
++  return aFontVisibilityProvider && !aFontVisibilityProvider->IsChrome();
++}
++
++/* static */
++bool gfxPlatformFontList::MaskedFontListBlocks(
++    FontVisibilityProvider* aFontVisibilityProvider,
++    const nsACString& aLowercaseFamily) {
++  return MaskedFontListAppliesTo(aFontVisibilityProvider) &&
++         !MaskConfig::IsFontAllowed(std::string_view(
++             aLowercaseFamily.BeginReading(), aLowercaseFamily.Length()));
++}
++
+ // Used if a stylo thread wants to trigger InitOtherFamilyNames in the main
+ // process: we can't do IPC from the stylo thread so we post this to the main
+ // thread instead.
+@@ -1418,7 +1442,11 @@
+     uint32_t aNextCh, Script aRunScript, FontPresentation aPresentation,
+     const gfxFontStyle* aMatchStyle, uint32_t& aCmapCount,
+     FontFamily& aMatchedFamily) {
+-  bool useCmaps = IsFontFamilyWhitelistActive() ||
++  // Camoufox: under the spoofed font list, force the cmap path for the same
++  // reason a whitelist does -- the platform fallback APIs choose a family for
++  // us, which would bypass the filtering in the loops below.
++  const bool maskedFontList = MaskedFontListAppliesTo(aFontVisibilityProvider);
++  bool useCmaps = IsFontFamilyWhitelistActive() || maskedFontList ||
+                   gfxPlatform::GetPlatform()->UseCmapsDuringSystemFallback();
+   FontVisibility level = aFontVisibilityProvider
+                              ? aFontVisibilityProvider->GetFontVisibility()
+@@ -1468,6 +1496,11 @@
+         if (!IsVisibleToCSS(family, level)) {
+           continue;
+         }
++        if (maskedFontList &&
++            MaskedFontListBlocks(aFontVisibilityProvider,
++                                 family.Key().AsString(SharedFontList()))) {
++          continue;
++        }
+         if (!family.IsFullyInitialized() &&
+             StaticPrefs::gfx_font_rendering_fallback_async() &&
+             !XRE_IsParentProcess()) {
+@@ -1494,6 +1527,13 @@
+       if (!IsVisibleToCSS(*family, level)) {
+         continue;
+       }
++      if (maskedFontList) {
++        nsAutoCString familyKey;
++        GenerateFontListKey(family->Name(), familyKey);
++        if (MaskedFontListBlocks(aFontVisibilityProvider, familyKey)) {
++          continue;
++        }
++      }
+       // evaluate all fonts in this family for a match
+       family->FindFontForChar(&data);
+       if (data.mMatchDistance == 0.0) {
+@@ -1754,6 +1794,11 @@
+       aFontVisibilityProvider ? aFontVisibilityProvider->GetFontVisibility()
+                               : FontVisibility::User;
  
++  // Camoufox: content only ever resolves families from the spoofed font list.
++  if (MaskedFontListBlocks(aFontVisibilityProvider, key)) {
++    return false;
++  }
++
+   // If this font lookup is the result of resolving a CSS generic (not a direct
+   // font-family request by the page), and RFP settings allow generics to be
+   // unrestricted, bump the effective visibility level applied here so as to
+diff --git a/gfx/thebes/gfxPlatformFontList.h b/gfx/thebes/gfxPlatformFontList.h
+--- a/gfx/thebes/gfxPlatformFontList.h
++++ b/gfx/thebes/gfxPlatformFontList.h
+@@ -652,6 +652,19 @@
+     return mFontFamilyWhitelistActive;
+   };
+ 
++  // Camoufox: the spoofed "fonts" allowlist is applied when a family is looked
++  // up rather than by pruning the process-wide (and cross-process shared) font
++  // list, so that the browser's own chrome UI keeps the host's real UI fonts.
++  // See daijro/camoufox#695.
++  //
++  // MaskedFontListAppliesTo: is aFontVisibilityProvider subject to the mask?
++  // MaskedFontListBlocks: ...and is aLowercaseFamily absent from it?
++  static bool MaskedFontListAppliesTo(
++      FontVisibilityProvider* aFontVisibilityProvider);
++  static bool MaskedFontListBlocks(
++      FontVisibilityProvider* aFontVisibilityProvider,
++      const nsACString& aLowercaseFamily);
++
+   static void FontWhitelistPrefChanged(const char* aPref, void* aClosure);
+ 
+   bool AddWithLegacyFamilyName(const nsACString& aLegacyName,
+diff --git a/gfx/thebes/gfxUserFontSet.cpp b/gfx/thebes/gfxUserFontSet.cpp
+--- a/gfx/thebes/gfxUserFontSet.cpp
++++ b/gfx/thebes/gfxUserFontSet.cpp
+@@ -461,8 +461,12 @@
+       gfxPlatformFontList* pfl = gfxPlatformFontList::PlatformFontList();
+       pfl->AddUserFontSet(fontSet);
+       // Don't look up local fonts if the font whitelist is being used.
++      // Camoufox: nor for content under the spoofed font list -- src: local()
++      // would otherwise let a page probe for families the mask hides.
+       gfxFontEntry* fe = nullptr;
+-      if (!pfl->IsFontFamilyWhitelistActive()) {
++      if (!pfl->IsFontFamilyWhitelistActive() &&
++          !gfxPlatformFontList::MaskedFontListAppliesTo(
++              fontSet->GetFontVisibilityProvider())) {
+         fe = gfxPlatform::GetPlatform()->LookupLocalFont(
+             fontSet->GetFontVisibilityProvider(), currSrc.mLocalName, Weight(),
+             Stretch(), SlantStyle());
 diff --git a/gfx/thebes/moz.build b/gfx/thebes/moz.build
-index 2bb893d84f..0088f6cab7 100644
 --- a/gfx/thebes/moz.build
 +++ b/gfx/thebes/moz.build
-@@ -299,3 +299,6 @@ DEFINES["GRAPHITE2_STATIC"] = True
+@@ -299,3 +299,6 @@
  COMPILE_FLAGS["WARNINGS_CXXFLAGS"] += ["-Werror=switch"]
  
  include("/tools/fuzzing/libfuzzer-config.mozbuild")
@@ -39,10 +179,9 @@ index 2bb893d84f..0088f6cab7 100644
 +# DOM Mask
 +LOCAL_INCLUDES += ["/camoucfg"]
 diff --git a/layout/style/FontFace.cpp b/layout/style/FontFace.cpp
-index 56e579eb33..5a679f75ba 100644
 --- a/layout/style/FontFace.cpp
 +++ b/layout/style/FontFace.cpp
-@@ -239,7 +239,16 @@ void FontFace::SetSizeAdjust(const nsACString& aValue, ErrorResult& aRv) {
+@@ -239,7 +239,16 @@
    mImpl->SetSizeAdjust(aValue, aRv);
  }
  
@@ -60,7 +199,7 @@ index 56e579eb33..5a679f75ba 100644
  
  Promise* FontFace::Load(ErrorResult& aRv) {
    EnsurePromise();
-@@ -249,7 +258,17 @@ Promise* FontFace::Load(ErrorResult& aRv) {
+@@ -249,7 +258,17 @@
      return nullptr;
    }
  
@@ -80,10 +219,9 @@ index 56e579eb33..5a679f75ba 100644
    return mLoaded;
  }
 diff --git a/layout/style/FontFaceImpl.cpp b/layout/style/FontFaceImpl.cpp
-index f13782ae6d..abb8d83fb3 100644
 --- a/layout/style/FontFaceImpl.cpp
 +++ b/layout/style/FontFaceImpl.cpp
-@@ -354,21 +354,15 @@ void FontFaceImpl::DoLoad() {
+@@ -354,21 +354,15 @@
  void FontFaceImpl::SetStatus(FontFaceLoadStatus aStatus) {
    gfxFontUtils::AssertSafeThreadOrServoFontMetricsLocked();
  
@@ -112,7 +250,6 @@ index f13782ae6d..abb8d83fb3 100644
      mFontFaceSet->OnFontFaceStatusChanged(this);
    }
 diff --git a/layout/style/FontFaceImpl.h b/layout/style/FontFaceImpl.h
-index c94388212e..2826682e7b 100644
 --- a/layout/style/FontFaceImpl.h
 +++ b/layout/style/FontFaceImpl.h
 @@ -8,6 +8,7 @@
@@ -123,32 +260,25 @@ index c94388212e..2826682e7b 100644
  #include "nsTHashSet.h"
  
  class gfxFontFaceBufferSource;
-@@ -27,6 +28,20 @@ class UTF8StringOrArrayBufferOrArrayBufferView;
+@@ -27,6 +28,14 @@
  
  namespace mozilla::dom {
  
 +// Helper function to check if a font is in the allowed list
 +inline bool IsFontAllowed(const nsACString& aFontName) {
-+  if (std::vector<std::string> maskValues =
-+          MaskConfig::GetStringListLower("fonts");
-+      !maskValues.empty()) {
-+    std::string fontName(aFontName.BeginReading(), aFontName.EndReading());
-+    std::transform(fontName.begin(), fontName.end(), fontName.begin(),
-+                   ::tolower);
-+    return std::find(maskValues.begin(), maskValues.end(), fontName) !=
-+           maskValues.end();
-+  }
-+  return true;
++  std::string fontName(aFontName.BeginReading(), aFontName.Length());
++  std::transform(fontName.begin(), fontName.end(), fontName.begin(),
++                 [](unsigned char c) { return std::tolower(c); });
++  return MaskConfig::IsFontAllowed(fontName);
 +}
 +
  class FontFaceImpl final {
    NS_INLINE_DECL_THREADSAFE_REFCOUNTING(FontFaceImpl)
  
 diff --git a/layout/style/moz.build b/layout/style/moz.build
-index b3886e491f..9236483cec 100644
 --- a/layout/style/moz.build
 +++ b/layout/style/moz.build
-@@ -370,3 +370,6 @@ if CONFIG["COMPILE_ENVIRONMENT"]:
+@@ -370,3 +370,6 @@
          "ServoStyleConsts.h",
          inputs=["/servo/ports/geckolib", "/servo/components/style"],
      )

--- a/patches/font-system-fonts-css2.patch
+++ b/patches/font-system-fonts-css2.patch
@@ -1,8 +1,8 @@
 Camoufox: spoof CSS2 system-font keyword resolution to match navigator.platform.
 
-Sibling to font-system-ui.patch. That patch covers the `system-ui` generic
-via gfxPlatformFontList::GetSystemUIFontFamilies(). It does NOT cover the
-older CSS2 system-font shorthand keywords:
+Sibling to system-ui-font-spoofing.patch. That patch covers the `system-ui`
+generic via gfxPlatformFontList::GetSystemUIFontFamilies(). It does NOT cover
+the older CSS2 system-font shorthand keywords:
 
     font: caption | icon | menu | message-box | small-caption | status-bar
 
@@ -18,19 +18,17 @@ keywords:
     // GeckoFonts["Sans"] === GeckoFonts["sans-serif"] === "Linux"
     //   -> emits "Sans:Linux" / "sans-serif:Linux"
 
-Firefox routes CSS system-font resolution through TWO different paths
-depending on whether RFP's FontVisibilityRestrictGenerics target is on:
+Firefox routes CSS system-font resolution through nsLayoutUtils::
+ComputeSystemFont(), which either asks nsLayoutUtils' own
+GetSpoofedSystemFontForRFP() (when RFP's FontVisibilityRestrictGenerics target
+is on) or the platform LookAndFeel (otherwise). FontVisibilityRestrictGenerics
+is not in Firefox's default-enabled set (RFPTargetsDefault.inc) and Camoufox
+never turns it on, so upstream always took the LookAndFeel branch and the real
+host system font leaked through getComputedStyle().fontFamily.
 
-  1. RFP off (or target off): nsLookAndFeel::PerThemeData::GetFont()
-     returns the GTK system font (e.g. "Cantarell").
-  2. RFP on (Camoufox default):   nsLayoutUtils::GetSpoofedSystemFontForRFP()
-     returns "sans-serif" (Linux build) or "-apple-system" (Mac build) etc.
-
-Camoufox runs RFP on by default, so CreepJS sees path 2 — which on the
-Linux build hardcodes "sans-serif" and entirely bypasses the
-LookAndFeel::GetFont call site.
-
-This patch hooks BOTH paths to honor navigator.platform:
+This patch makes ComputeSystemFont() take the spoof branch whenever
+navigator.platform is spoofed, and teaches GetSpoofedSystemFontForRFP() to
+answer for the spoofed OS:
 
   - "-apple-system"  when navigator.platform starts with "Mac"
                      (matches CreepJS GeckoFonts entry "-apple-system" -> "Mac")
@@ -38,90 +36,29 @@ This patch hooks BOTH paths to honor navigator.platform:
                      (matches CreepJS GeckoFonts entry "Segoe UI" -> "Windows")
   - (falls through)  otherwise (Linux / iPhone / unspoofed)
 
-For path 1 we patch widget/gtk/nsLookAndFeel.cpp's PerThemeData::GetFont.
-For path 2 we patch layout/base/nsLayoutUtils.cpp's
-GetSpoofedSystemFontForRFP (file-static) helper. Both files need
-LOCAL_INCLUDES += ["/camoucfg"] in their respective moz.build to expose
-MaskConfig.hpp.
+Chrome documents are excluded from the spoof branch and keep the host's real
+system font. They are not reachable by the page, and handing the browser's own
+UI a family name from another OS ("Segoe UI" on Linux, "-apple-system" on
+Windows) leaves the toolbar, menus and titlebar falling back to the default
+serif font -- see daijro/camoufox#695.
 
-Both hooks classify navigator.platform once via a function-static and
-keep the result for the lifetime of the process. CreepJS calls the CSS
-resolver six times in tight succession (one per CSS2 keyword) and uses
-probe duration as a probabilistic headless signal, so we don't want to
-re-parse CAMOU_CONFIG on every call. The config is set at process start
-and never changes, so a single classification per process is safe.
+Because ComputeSystemFont() is the single entry point and now covers every
+content document unconditionally, the LookAndFeel-level hooks this patch used
+to carry (widget/gtk/nsLookAndFeel.cpp::PerThemeData::GetFont and
+gfxMacPlatformFontList::LookupSystemFont) can never fire for content: they are
+reached only when the spoof branch is *not* taken, which is exactly when
+navigator.platform is unspoofed (where they were no-ops) or when the document
+is chrome (where they broke the UI). They are dropped here.
 
-Bug: daijro/camoufox#598 (sibling of font-system-ui.patch)
+The classification is cached in a function-static. CreepJS calls the CSS
+resolver six times in tight succession (one per CSS2 keyword) and uses probe
+duration as a probabilistic headless signal, so we don't want to re-parse
+CAMOU_CONFIG on every call. The config is set at process start and never
+changes, so a single classification per process is safe.
 
---- a/widget/gtk/moz.build
-+++ b/widget/gtk/moz.build
-@@ -155,6 +155,7 @@
- FINAL_LIBRARY = "xul"
+Bug: daijro/camoufox#598, daijro/camoufox#695
 
- LOCAL_INCLUDES += [
-+    "/camoucfg",
-     "/layout/base",
-     "/layout/forms",
-     "/layout/generic",
---- a/widget/gtk/nsLookAndFeel.cpp
-+++ b/widget/gtk/nsLookAndFeel.cpp
-@@ -34,6 +34,7 @@
- #include "mozilla/glean/WidgetGtkMetrics.h"
- #include "mozilla/ScopeExit.h"
- #include "mozilla/WidgetUtilsGtk.h"
-+#include "MaskConfig.hpp"
- #include "ScreenHelperGTK.h"
- #include "ScrollbarDrawing.h"
-
-@@ -1302,6 +1303,48 @@
- bool nsLookAndFeel::PerThemeData::GetFont(FontID aID, nsString& aFontName,
-                                           gfxFontStyle& aFontStyle,
-                                           float aTextScaleFactor) const {
-+  // Camoufox: spoof the CSS2 system-font keyword family resolution
-+  // (caption / icon / menu / message-box / small-caption / status-bar)
-+  // based on navigator.platform so we don't leak the host's GTK system
-+  // font through getComputedStyle().fontFamily. Sibling to
-+  // font-system-ui.patch which handles the `system-ui` generic.
-+  //
-+  // The platform classification is cached in a function-static. CreepJS's
-+  // headless detector calls getComputedStyle().fontFamily after setting
-+  // `font: caption !important` six times in tight succession, and uses
-+  // probe duration as a probabilistic headless signal. navigator.platform
-+  // is set from CAMOU_CONFIG at process start and never changes, so a
-+  // single lookup per process is safe and removes the per-call overhead.
-+  enum class SpoofedOS { Other, Mac, Win };
-+  static const SpoofedOS sSpoofedOS = []() {
-+    auto platform = MaskConfig::GetString("navigator.platform");
-+    if (!platform) return SpoofedOS::Other;
-+    const std::string& p = platform.value();
-+    auto starts_with = [&](const char* prefix) {
-+      size_t n = std::strlen(prefix);
-+      return p.size() >= n &&
-+             std::equal(prefix, prefix + n, p.begin(),
-+                        [](char a, char b) {
-+                          return std::tolower(static_cast<unsigned char>(a)) ==
-+                                 std::tolower(static_cast<unsigned char>(b));
-+                        });
-+    };
-+    if (starts_with("mac")) return SpoofedOS::Mac;
-+    if (starts_with("win")) return SpoofedOS::Win;
-+    return SpoofedOS::Other;
-+  }();
-+  if (sSpoofedOS == SpoofedOS::Mac) {
-+    aFontName.AssignLiteral(u"-apple-system");
-+    aFontStyle = mDefaultFontStyle;
-+    return true;
-+  }
-+  if (sSpoofedOS == SpoofedOS::Win) {
-+    aFontName.AssignLiteral(u"Segoe UI");
-+    aFontStyle = mDefaultFontStyle;
-+    return true;
-+  }
-+  // Linux / iPhone / unknown: fall through to upstream behavior.
-+
-   switch (aID) {
-     case FontID::Menu:             // css2
-     case FontID::MozPullDownMenu:  // css3
+diff --git a/layout/base/moz.build b/layout/base/moz.build
 --- a/layout/base/moz.build
 +++ b/layout/base/moz.build
 @@ -146,6 +146,7 @@
@@ -132,38 +69,40 @@ Bug: daijro/camoufox#598 (sibling of font-system-ui.patch)
      "/docshell/base",
      "/dom/base",
      "/dom/html",
+diff --git a/layout/base/nsLayoutUtils.cpp b/layout/base/nsLayoutUtils.cpp
 --- a/layout/base/nsLayoutUtils.cpp
 +++ b/layout/base/nsLayoutUtils.cpp
-@@ -6,6 +6,7 @@
-
+@@ -4,6 +4,7 @@
+ 
  #include "nsLayoutUtils.h"
-
+ 
 +#include "MaskConfig.hpp"
  #include <algorithm>
  #include <limits>
-
-@@ -9623,6 +9654,54 @@
-
+ 
+@@ -9718,6 +9719,55 @@
+ 
  static void GetSpoofedSystemFontForRFP(LookAndFeel::FontID aFontID,
                                         gfxFontStyle& aStyle, nsAString& aName) {
 +  // Camoufox: when navigator.platform is spoofed, return the family-name
 +  // string the spoofed OS would. Firefox's CSS resolver routes the CSS2
 +  // system-font keywords (caption / icon / menu / message-box /
-+  // small-caption / status-bar) through this function whenever RFP's
-+  // FontVisibilityRestrictGenerics target is on (default for Camoufox),
-+  // bypassing nsLookAndFeel::PerThemeData::GetFont entirely. CreepJS's
-+  // headless detector reads `getComputedStyle().fontFamily` after setting
-+  // `font: caption !important` and emits "<family>:Linux" / "<family>:Mac"
-+  // / "<family>:Windows" attributions. Without this hook the Linux build
-+  // emits `sans-serif` (which fontconfig resolves to "Sans") for every
-+  // spoofed OS, leaking Linux. Sibling to the nsLookAndFeel::GetFont hook
-+  // in widget/gtk/nsLookAndFeel.cpp.
++  // small-caption / status-bar) through this function. CreepJS's headless
++  // detector reads `getComputedStyle().fontFamily` after setting
++  // `font: caption !important` and emits "<family>:Linux" / "<family>:Mac" /
++  // "<family>:Windows" attributions. Without this hook the Linux build emits
++  // `sans-serif` (which fontconfig resolves to "Sans") for every spoofed OS,
++  // leaking Linux. Sibling to the system-ui hook in
++  // gfxPlatformFontList::GetSystemUIFontFamilies().
++  //
++  // ComputeSystemFont() below only routes *content* documents here, so this
++  // never changes what the browser's own chrome UI resolves to.
 +  //
 +  // The platform classification is cached in a function-static because
-+  // CreepJS calls this six times in tight succession (one per CSS2
-+  // keyword) and uses probe duration as a probabilistic headless signal.
-+  // navigator.platform is set from CAMOU_CONFIG at process start and
-+  // never changes, so a single lookup per process is safe.
++  // CreepJS calls this six times in tight succession (one per CSS2 keyword)
++  // and uses probe duration as a probabilistic headless signal.
++  // navigator.platform is set from CAMOU_CONFIG at process start and never
++  // changes, so a single lookup per process is safe.
 +  enum class SpoofedOS { Other, Mac, Win };
 +  static const SpoofedOS sSpoofedOS = []() {
 +    auto platform = MaskConfig::GetString("navigator.platform");
@@ -192,101 +131,33 @@ Bug: daijro/camoufox#598 (sibling of font-system-ui.patch)
 +    aStyle.size = 12;
 +    return;
 +  }
-+  // Linux / iPhone / unknown: fall through to upstream behavior.
++  // Linux / iPhone / unspoofed: fall through to upstream behavior.
 +
  #if defined(XP_MACOSX) || defined(MOZ_WIDGET_UIKIT)
    aName = u"-apple-system"_ns;
    // Values taken from a macOS 10.15 system.
-@@ -9729,7 +9729,17 @@ void nsLayoutUtils::ComputeSystemFont(nsFont* aSystemFont,
+@@ -9772,8 +9822,22 @@
                                        const Document* aDocument) {
    gfxFontStyle fontStyle;
    nsAutoString systemFontName;
 -  if (aDocument->ShouldResistFingerprinting(
+-          RFPTarget::FontVisibilityRestrictGenerics)) {
 +  // Camoufox: take the spoof path whenever navigator.platform is spoofed, not
 +  // only when the FontVisibilityRestrictGenerics RFP target is active. That
 +  // target is NOT in Firefox's default-enabled set (RFPTargetsDefault.inc) and
 +  // Camoufox never turns it on, so the original guard left the spoof dead: the
-+  // real GTK system font ("sans-serif" on Linux) leaked through
++  // real system font ("sans-serif" on Linux) leaked through
 +  // getComputedStyle().fontFamily for the CSS2 system-font keywords, exposing
-+  // the host OS (CreepJS "platform hints: sans-serif:Linux"). When no platform
-+  // is spoofed, GetSpoofedSystemFontForRFP falls through to the native value,
-+  // so this is a no-op for unspoofed contexts.
-+  if (MaskConfig::GetString("navigator.platform").has_value() ||
-+      aDocument->ShouldResistFingerprinting(
-           RFPTarget::FontVisibilityRestrictGenerics)) {
++  // the host OS (CreepJS "platform hints: sans-serif:Linux").
++  //
++  // Chrome documents are excluded. They are not reachable by the page, and
++  // handing the browser's own UI a family name from another OS ("Segoe UI" on
++  // Linux, "-apple-system" on Windows) leaves the toolbar and menus falling
++  // back to the default serif font -- see daijro/camoufox#695.
++  if (aDocument && !aDocument->IsInChromeDocShell() &&
++      (MaskConfig::GetString("navigator.platform").has_value() ||
++       aDocument->ShouldResistFingerprinting(
++           RFPTarget::FontVisibilityRestrictGenerics))) {
      GetSpoofedSystemFontForRFP(aFontID, fontStyle, systemFontName);
    } else if (!LookAndFeel::GetFont(aFontID, systemFontName, fontStyle)) {
-diff --git a/gfx/thebes/gfxMacPlatformFontList.mm b/gfx/thebes/gfxMacPlatformFontList.mm
---- a/gfx/thebes/gfxMacPlatformFontList.mm
-+++ b/gfx/thebes/gfxMacPlatformFontList.mm
-@@ -17,6 +17,7 @@
- #include "SharedFontList-impl.h"
- 
- #include "harfbuzz/hb.h"
-+#include "MaskConfig.hpp"
- 
- #include "AppleUtils.h"
- #include "MainThreadUtils.h"
-@@ -394,7 +395,48 @@ void gfxMacPlatformFontList::LookupSystemFont(LookAndFeel::FontID aSystemFontID,
-   }
-   NS_ASSERTION(font, "system font not set");
- 
--  aSystemFontName.AssignASCII("-apple-system");
-+  // Camoufox: spoof the CSS2 system-font keyword family resolution
-+  // (caption / icon / menu / message-box / small-caption / status-bar)
-+  // based on navigator.platform. This is the cocoa sibling of the GTK
-+  // hook in widget/gtk/nsLookAndFeel.cpp::PerThemeData::GetFont.
-+  //
-+  // Without this hook the Mac build always emits "-apple-system" here,
-+  // which CreepJS's GeckoFonts map attributes to "Mac" — leaking the
-+  // host OS through `getComputedStyle().fontFamily` even when
-+  // navigator.platform is spoofed to Win32.
-+  //
-+  // The Camoufox-runs-RFP-by-default premise that the nsLayoutUtils.cpp
-+  // hunk relied on is no longer true: privacy.resistFingerprinting is
-+  // off and FontVisibilityRestrictGenerics is not in the default RFP
-+  // target set, so ComputeSystemFont takes the LookAndFeel::GetFont
-+  // branch on every call. On Mac that lands here.
-+  //
-+  // The platform classification is cached in a function-static for the
-+  // same reason as the sibling hooks: CreepJS uses probe duration as a
-+  // probabilistic headless signal.
-+  enum class SpoofedOS { Other, Mac, Win };
-+  static const SpoofedOS sSpoofedOS = []() {
-+    auto platform = MaskConfig::GetString("navigator.platform");
-+    if (!platform) return SpoofedOS::Other;
-+    const std::string& p = platform.value();
-+    auto starts_with = [&](const char* prefix) {
-+      size_t n = std::strlen(prefix);
-+      return p.size() >= n &&
-+             std::equal(prefix, prefix + n, p.begin(),
-+                        [](char a, char b) {
-+                          return std::tolower(static_cast<unsigned char>(a)) ==
-+                                 std::tolower(static_cast<unsigned char>(b));
-+                        });
-+    };
-+    if (starts_with("mac")) return SpoofedOS::Mac;
-+    if (starts_with("win")) return SpoofedOS::Win;
-+    return SpoofedOS::Other;
-+  }();
-+  if (sSpoofedOS == SpoofedOS::Win) {
-+    aSystemFontName.AssignASCII("Segoe UI");
-+  } else {
-+    aSystemFontName.AssignASCII("-apple-system");
-+  }
- 
-   NSFontSymbolicTraits traits = font.fontDescriptor.symbolicTraits;
-   aFontStyle.style = (traits & NSFontItalicTrait) ? FontSlantStyle::ITALIC
-
---- a/gfx/thebes/moz.build
-+++ b/gfx/thebes/moz.build
-@@ -302,3 +302,9 @@
-
- # DOM Mask
- LOCAL_INCLUDES += ["/camoucfg"]
-+
-+# Objective-C++ compilation in this directory keeps exceptions enabled for
-+# ObjC @try/@catch even when C++ has -fno-exceptions, which makes
-+# nlohmann/json (transitively included via MaskConfig.hpp) emit `throw`
-+# expressions that don't compile. Force the JSON_THROW=std::abort path.
-+DEFINES["JSON_NOEXCEPTION"] = True
+     return;

--- a/patches/system-ui-font-spoofing.patch
+++ b/patches/system-ui-font-spoofing.patch
@@ -1,20 +1,38 @@
+Camoufox: spoof the `system-ui` CSS generic to match the spoofed OS.
+
+Sibling to font-system-fonts-css2.patch, which covers the older CSS2
+system-font shorthand keywords (caption / icon / menu / message-box /
+small-caption / status-bar) via nsLayoutUtils::ComputeSystemFont().
+
+Chrome documents are excluded. The browser's own UI is not reachable by the
+page, and resolving its `system-ui` to a family from another OS ("Helvetica"
+or "Segoe UI" on a host that has neither) leaves the toolbar and menus falling
+back to the default serif font.
+
+Bug: daijro/camoufox#695 (chrome exemption), daijro/camoufox#599 (spoof)
+
 diff --git a/gfx/thebes/gfxPlatformFontList.cpp b/gfx/thebes/gfxPlatformFontList.cpp
-index d82edfc767..2e05cedcb3 100644
 --- a/gfx/thebes/gfxPlatformFontList.cpp
 +++ b/gfx/thebes/gfxPlatformFontList.cpp
-@@ -2246,6 +2246,18 @@ void gfxPlatformFontList::MaybeRemoveCmap(gfxCharacterMap* aCharMap,
+@@ -2245,6 +2245,24 @@
  static void GetSystemUIFontFamilies(
      FontVisibilityProvider* aFontVisibilityProvider,
      [[maybe_unused]] nsAtom* aLangGroup, nsTArray<nsCString>& aFamilies) {
-+  // Camoufox: spoof system-ui to match the spoofed OS
-+  if (auto platform = MaskConfig::GetString("navigator.platform"); platform) {
-+    if (*platform == "MacIntel") {
-+      *aFamilies.AppendElement() = "Helvetica"_ns;
-+      return;
-+    }
-+    if (*platform == "Win32") {
-+      *aFamilies.AppendElement() = "Segoe UI"_ns;
-+      return;
++  // Camoufox: spoof system-ui to match the spoofed OS. Chrome documents are
++  // excluded: they are not reachable by the page, and pointing the browser's
++  // own UI at a family from another OS leaves it falling back to the default
++  // serif font (daijro/camoufox#695). A null provider means there is no
++  // document behind the lookup, where spoofing is the safe default.
++  if (!(aFontVisibilityProvider && aFontVisibilityProvider->IsChrome())) {
++    if (auto platform = MaskConfig::GetString("navigator.platform"); platform) {
++      if (*platform == "MacIntel") {
++        *aFamilies.AppendElement() = "Helvetica"_ns;
++        return;
++      }
++      if (*platform == "Win32") {
++        *aFamilies.AppendElement() = "Segoe UI"_ns;
++        return;
++      }
 +    }
 +  }
 +


### PR DESCRIPTION
Fixes #695.

## Root cause

Two independent bugs, both "spoofing leaks into the browser's own chrome UI".

### 1. Tofu titlebar buttons

The boxes in the report are `U+E921` / `U+E922` / `U+E8BB` — Firefox's Windows titlebar glyphs:

```css
/* browser/themes/windows/browser.css */
.titlebar-button { font: … "Segoe Fluent Icons", "Segoe MDL2 Assets"; }
.titlebar-min::before   { content: "\e921" }
.titlebar-max::before   { content: "\e922" }
.titlebar-close::before { content: "\e8bb" }
```

`font-hijacker.patch` fed the spoofed `fonts` list into Firefox's `font.system.whitelist` pref. That pref drives `gfxPlatformFontList::ApplyWhitelist()`, which **removes** every non-listed family from the font list — and with the shared font list (default on all three platforms) that pruning runs in the **parent process**, i.e. the process that paints the chrome.

Neither icon font is in any generated mask, and `Segoe UI` only survives when the spoofed OS is Windows. Linux hosts are insulated by the bundled `FONTCONFIG_FILE`, which is why this only shows up on Windows and macOS builds.

### 2. Serif toolbar

`font-system-fonts-css2.patch` hooked `nsLayoutUtils::ComputeSystemFont` for *every* document whenever `navigator.platform` is spoofed. Chrome CSS is `font: message-box`, so the browser UI was handed `"Segoe UI"` on Linux / `"-apple-system"` on Windows — families that aren't installed → fallback to the default serif font. `system-ui-font-spoofing.patch` had the same problem for the `system-ui` generic.

## Fix

| File | Change |
| --- | --- |
| `additions/camoucfg/MaskConfig.hpp` | `FontAllowlist()` / `HasFontAllowlist()` / `IsFontAllowed()`, parsed once per process — the gfx paths consult this on every family resolution |
| `patches/font-hijacker.patch` | Stop writing `font.system.whitelist`. Filter at **lookup** time on `FontVisibilityProvider::IsChrome()`, across all three content-reachable paths |
| `patches/font-system-fonts-css2.patch` | Chrome docs exempt from the spoof branch |
| `patches/system-ui-font-spoofing.patch` | Chrome docs exempt |

The three content-reachable font paths now covered by the lookup-time filter:

- **`FindAndAddFamiliesLocked`** — `font-family` / CSS generic resolution, i.e. what `document.fonts.check()` and text-metric probing go through.
- **`GlobalFontFallback`** — per-character system fallback. The cmap path stays forced (as the whitelist did), so the platform fallback APIs can't pick a family behind our back.
- **`gfxUserFontSet` `src: local()`** — upstream already refuses `local()` sources while a whitelist is active; that behaviour is kept for content under the mask, so a page can't probe for hidden families.

`font-system-fonts-css2.patch` also drops its GTK `nsLookAndFeel::PerThemeData::GetFont` and cocoa `gfxMacPlatformFontList::LookupSystemFont` hooks. With the `ComputeSystemFont` guard in place they are reachable only when the spoof branch is *not* taken — which is exactly when `navigator.platform` is unspoofed (where they were no-ops) or when the document is chrome (where they broke the UI).

## Behaviour for web content is unchanged

- Pages still resolve only families from the mask.
- `src: local()` probing stays blocked.
- `getComputedStyle().fontFamily` for the CSS2 keywords and `system-ui` returns the same spoofed values (CreepJS attribution unchanged).
- `IsChrome()` is Firefox's own notion of privileged (`Document::IsInChromeDocShell()`), the same predicate `FontVisibilityProvider::ComputeFontVisibility()` uses for its "chrome gets User level" rule — so `about:` pages are still treated as content, as upstream does.

## Testing

- The full patch chain (`anti-font-fingerprinting` → `font-hijacker` → `font-list-spoofing` → `font-system-fonts-css2` → `system-ui-font-spoofing`) applies to pristine Firefox 152.0.4 with **zero rejects**. Verified in particular that `font-hijacker`'s new `FindAndAddFamiliesLocked` hunk and `font-list-spoofing`'s per-user-context hunk coexist in that function.
- The new `MaskConfig` helpers compile under `-std=c++20 -Wall -Wextra` and were unit-tested against a real `CAMOU_CONFIG` payload.
- `build-tester`'s `cssFingerprint.systemFonts` and `fontAvailability` checks run in content, so they are unaffected by the chrome exemption.

I do not have a full build in this environment — the C++ is written and reviewed against the real FF152 sources but has not been compiled in-tree. Happy to iterate if CI turns up anything.

## Two adjacent issues found, deliberately left alone

- `Segoe Fluent Icons` / `Segoe MDL2 Assets` are non-essential in `_ESSENTIAL_FONTS_WINDOWS` (`pythonlib/camoufox/fingerprints.py`), so a Windows profile randomly claims not to have fonts that ship on every real Windows install — a weak tell. Would have masked this bug too, but it's a separate change.
- `GetSpoofedSystemFontForRFP`'s fall-through for a **Linux** spoof is `#if defined(XP_WIN)` / `XP_MACOSX` etc., so a Linux fingerprint on a Windows host reports `Segoe UI` rather than `sans-serif`.
