### PR TITLE
fix(build): enable bundled fonts on macOS

### DIFF
--- a/assets/macos.mozconfig
+++ b/assets/macos.mozconfig
@@ -1,6 +1,23 @@
 ac_add_options --disable-update-agent
 # ac_add_options --disable-alsa
 
+# Bundled fonts.
+#
+# MOZ_BUNDLED_FONTS is what compiles in CoreTextFontList::ActivateBundledFonts(),
+# the only caller of ActivateFontsFromDir() -- which is what registers
+# <GRE>/fonts with CoreText via CTFontManagerRegisterFontURLs(). Without the
+# define, that whole path is compiled out and the fonts we ship under
+# Contents/Resources/fonts (Makefile passes `--fonts windows linux` for macOS)
+# are never loaded, so a spoofed font list resolves against the host's own
+# fonts instead of ours.
+#
+# Upstream's default is `target.os == "WINNT" or target.kernel == "Linux"`
+# (toolkit/moz.configure), so Linux and Windows get this for free and macOS
+# does not. settings/camoufox.cfg already sets
+# `defaultPref("gfx.bundled-fonts.activate", 1)`, i.e. the pref side is on --
+# only the build flag was missing.
+ac_add_options --enable-bundled-fonts
+
 # Packaging related
 # #export DSYMUTIL="$MOZBUILD/clang/bin/dsymutil"
 # export DMG_TOOL="$MOZBUILD/dmg/dmg"


### PR DESCRIPTION
Fixes the macOS side of #706.

## What's wrong

Camoufox ships 287 font files under `Contents/Resources/fonts` on macOS
(`Makefile` passes `--fonts windows linux` to `package.py`) and already sets
`defaultPref("gfx.bundled-fonts.activate", 1)` in `settings/camoufox.cfg` — but
none of them are ever loaded.

Firefox does have the macOS code for this:
`CoreTextFontList::ActivateBundledFonts()` reads `<GRE>/fonts` and hands it to
`ActivateFontsFromDir()`, which registers the files with
`CTFontManagerRegisterFontURLs(urls, kCTFontManagerScopeProcess, ...)`. That
function is guarded by `#ifdef MOZ_BUNDLED_FONTS`, and upstream defaults the
option to:

```python
@depends(target)
def bundled_fonts_default(target):
    return target.os == "WINNT" or target.kernel == "Linux"
```

macOS is not in that set, so the whole path is compiled out. Linux and Windows
get it implicitly and never needed the flag written down; macOS does. The option
itself is gated only on `project == "browser"` — there is no platform
restriction.

Note that `ActivateFontsFromDir()` is *not* inside the `#ifdef`, which is why
`CTFontManagerRegisterFontURLs` still shows up in XUL's symbol table on macOS
even though nothing calls it for the bundled set. That misleads binary
inspection.

## Why it matters

On a macOS host the spoofed font list currently resolves against the host's own
fonts, so the measurable set is `host fonts ∩ claimed list`. Font metrics are a
cross-checked surface — a UA claiming Windows next to macOS font metrics is a
contradiction detectors specifically look for — so this weakens the spoof rather
than merely narrowing it.

## Verification

Built this branch on CI (macos/arm64) and measured both builds with **the same
frozen config**, so the claimed font list is identical on both sides and the only
variable is the flag. Measurement is the usual metrics probe (render a string in
`"<family>", monospace|serif|sans-serif` and compare against each generic's
baseline), not an enumeration API.

| | before | after |
|---|---|---|
| measurable, of 51 claimed | 12 (23%) | **35 (68%)** |
| macOS-native fonts leaking | 0/8 | 0/8 |

Calibri, Consolas, Segoe UI, Cambria Math and Nirmala UI all go from
unmeasurable to measurable.

### The 16 that remain

Not failures of this change:

* **4 are weight variants whose base family does resolve** (`Segoe UI Semilight`
  → `Segoe UI` ✓, `Yu Gothic UI Light` → `Yu Gothic UI` ✓). CSS collapses these
  onto one family, so a metrics probe cannot distinguish them. Measurement-method
  floor, not a spoofing gap.

* **Most of the rest are localized family names.** Eight pairs, tested with every
  name added to the whitelist so filtering is not a factor:

  | English | | Localized | |
  |---|---|---|---|
  | SimSun / NSimSun | ✓ | 宋体 / 新宋体 | ✗ |
  | Microsoft YaHei | ✓ | 微软雅黑 | ✗ |
  | Microsoft JhengHei | ✓ | 微軟正黑體 | ✗ |
  | Yu Gothic | ✓ | 游ゴシック | ✗ |
  | MS PGothic / MS Gothic | ✓ | ＭＳ Ｐゴシック / ＭＳ ゴシック | ✗ |
  | MingLiU-ExtB | ✓ | 細明體-ExtB | ✗ |

  English 8/8 resolve, localized 8/8 do not. The fonts are loaded — the English
  names prove that — but CoreText registration only exposes the en-US family name
  (nameID 1), not the localized aliases. DirectWrite on real Windows honours
  both, so this is a separate and much narrower gap, worth its own issue.

I also briefly suspected `.ttc` collections were the problem, since most of the
stragglers are `.ttc`. `Cambria Math` comes from `cambria.ttc` and resolves
fine, so that theory is wrong.

`-apple-system` still resolves on both builds. That is the
`font-system-fonts-css2.patch` path, unrelated to this change.

## Open question

Do you know why Mozilla defaults this off on macOS? I could not find a rationale.
If it is just that nobody needed it, this is the whole fix. If there is a known
problem with process-scoped CoreText registration (startup cost, sandboxing),
that would be worth knowing before this ships.

Untested here: whether the metrics of the now-loaded fonts match real Windows,
and whether the Windows build's implicit `MOZ_BUNDLED_FONTS` actually works in
practice — I only have a macOS host.
