### PR TITLE
fix: use platformdirs for fontconfig cache directory

### DIFF
--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 import numpy as np
 import orjson
+import platformdirs
 from browserforge.fingerprints import Fingerprint, Screen
 from screeninfo import get_monitors
 from typing_extensions import TypeAlias
@@ -47,7 +48,7 @@ def _generate_fontconfig(fontconfig_path: str) -> str:
     Generates a runtime fontconfig that resolves bundled font paths absolutely.
     The bundled fonts.conf uses prefix="cwd" relative paths which break when
     Playwright's working directory differs from the browser install directory.
-    Writes a patched copy to ~/.cache/camoufox/fontconfig/ (deterministic,
+    Writes a patched copy to the platform cache dir (deterministic,
     only regenerated when content changes).
     """
     import hashlib
@@ -63,7 +64,7 @@ def _generate_fontconfig(fontconfig_path: str) -> str:
         f'<dir>{fonts_dir}</dir>',
     )
 
-    cache_dir = os.path.join(os.path.expanduser('~'), '.cache', 'camoufox', 'fontconfig')
+    cache_dir = os.path.join(platformdirs.user_cache_dir("camoufox"), "fontconfig")
     os.makedirs(cache_dir, exist_ok=True)
 
     content_hash = hashlib.sha256(conf_content.encode()).hexdigest()[:12]


### PR DESCRIPTION
## Related Issue

Closes #654

## Description

`_generate_fontconfig` in `pythonlib/camoufox/utils.py` hardcoded the cache directory as `~/.cache/camoufox/fontconfig` via `os.path.join(os.path.expanduser("~"), ".cache", "camoufox", "fontconfig")`. This ignores `XDG_CACHE_HOME` on Linux, causing an `OSError: [Errno 30] Read-only file system` crash in environments where `~/.cache` is read-only (e.g. containers with read-only rootfs).

This PR replaces the hardcoded path with `platformdirs.user_cache_dir("camoufox")`, which:
- Respects `XDG_CACHE_HOME` on Linux
- Uses `~/Library/Caches` on macOS
- Uses `%LOCALAPPDATA%` on Windows

`platformdirs` is already a declared dependency in `pyproject.toml` (`platformdirs = "*"`). The default path (when `XDG_CACHE_HOME` is not set) is unchanged — `platformdirs.user_cache_dir("camoufox")` returns `~/.cache/camoufox` on Linux by default, matching the previous behaviour.

Also updated the docstring to stop referencing the hardcoded `~/.cache/camoufox/fontconfig/` path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

Verified that `platformdirs.user_cache_dir("camoufox")` returns the same path as the old hardcoded value when `XDG_CACHE_HOME` is not set, and respects `XDG_CACHE_HOME` when it is:

```python
import platformdirs, os

# Default (no XDG_CACHE_HOME)
platformdirs.user_cache_dir("camoufox")
# -> /home/user/.cache/camoufox (same as before)

# With XDG_CACHE_HOME set
os.environ["XDG_CACHE_HOME"] = "/tmp/xdg-test"
platformdirs.user_cache_dir("camoufox")
# -> /tmp/xdg-test/camoufox (respects XDG)
```

This is a Python library change (`pythonlib/`), not a browser patch. The build-tester suite tests the raw binary in isolation and is not applicable here. Service tests are temporarily out of service per the PR template.

## Fingerprint Report

N/A — this change does not affect fingerprint injection or browser patches. It only changes where the fontconfig cache file is written on disk.

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass (for python library changes)~~ temporarily out of service
- [x] Build test passes (for patch changes) — N/A, this is not a patch change