### PR TITLE
fix: use 1920x1080 screen size for virtual display (#458)

### DIFF
--- a/pythonlib/camoufox/virtdisplay.py
+++ b/pythonlib/camoufox/virtdisplay.py
@@ -22,7 +22,7 @@ class VirtualDisplay:
 
     xvfb_args = (
         # fmt: off
-        "-screen", "0", "1x1x24",
+        "-screen", "0", "1920x1080x24",
         "-ac",
         "-nolisten", "tcp",
         "-extension", "RENDER",


### PR DESCRIPTION
## Related Issue

Closes #458

## Description

The Xvfb virtual display screen size was hardcoded to `1x1x24` in `pythonlib/camoufox/virtdisplay.py`, causing pages to exist in the DOM but not render correctly in screenshots. Screenshots appear mostly blank or dark with elements positioned incorrectly, making `headless="virtual"` mode unusable for visual output on Linux.

Changed to `1920x1080x24` -- a standard desktop resolution that allows proper rendering.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

Tested with `headless="virtual"` on Linux (Ubuntu 24.04, Camoufox v152.0.4-beta.28):

Before fix: Xvfb starts with `1x1x24` screen, screenshot is blank.
After fix: Xvfb starts with `1920x1080x24` screen, screenshot renders correctly.

## Fingerprint Report

This change only affects the Xvfb virtual display resolution used in `headless="virtual"` mode on Linux. It does not modify any browser fingerprinting, spoofing, or patch code. The screen resolution of the virtual display is not a fingerprinting vector -- the browser `screen.width`/`screen.height` properties are controlled by the Camoufox spoofing layer, not by the Xvfb display size.

Service tester: noted as temporarily out of service in the PR template.
Build tester: N/A -- this is a Python library change, not a C++ patch or browser build change.

## Checklist

- [x] I have linked a related issue above (#458)
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result