### PR TITLE
Verify downloaded release assets and stop disabling TLS verification

### DIFF
--- a/pythonlib/camoufox/exceptions.py
+++ b/pythonlib/camoufox/exceptions.py
@@ -14,6 +14,14 @@ class MissingRelease(Exception):
     ...
 
 
+class CorruptedDownload(Exception):
+    """
+    Raised when a downloaded asset does not match its expected sha256 digest.
+    """
+
+    ...
+
+
 class UnsupportedArchitecture(Exception):
     """
     Raised when the architecture is not supported.

--- a/pythonlib/camoufox/gui/backend.py
+++ b/pythonlib/camoufox/gui/backend.py
@@ -32,7 +32,7 @@ from ..multiversion import (
     save_repo_cache,
     set_active,
 )
-from ..pkgman import RepoConfig, unzip, webdl
+from ..pkgman import RepoConfig, unzip, verify_sha256, webdl
 
 # Workers
 
@@ -74,8 +74,12 @@ class DownloadWorker(Worker):
 
             with tempfile.NamedTemporaryFile() as f:
                 webdl(self.version.url, buffer=f, bar=False, progress_callback=self._progress)
-                self.status.emit("Extracting...")
+                self.status.emit("Verifying...")
                 self.progress.emit(-1)
+                verify_sha256(
+                    f, self.version.sha256, desc=f"Camoufox v{self.version.version.full_string}"
+                )
+                self.status.emit("Extracting...")
                 unzip(f, str(path), bar=False)
 
             (path / 'version.json').write_bytes(orjson.dumps(self.version.to_metadata()))

--- a/pythonlib/camoufox/ip.py
+++ b/pythonlib/camoufox/ip.py
@@ -1,12 +1,9 @@
 import re
-import warnings
-from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Dict, Optional, Tuple
 
 import requests
-from urllib3.exceptions import InsecureRequestWarning
 
 from .exceptions import InvalidIP, InvalidProxy
 
@@ -78,13 +75,6 @@ def validate_ip(ip: str) -> None:
         raise InvalidIP(f"Invalid IP address: {ip}")
 
 
-@contextmanager
-def _suppress_insecure_warning():
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=InsecureRequestWarning)
-        yield
-
-
 @lru_cache(maxsize=None)
 def public_ip(proxy: Optional[str] = None) -> str:
     """
@@ -104,13 +94,12 @@ def public_ip(proxy: Optional[str] = None) -> str:
     end_exception = None
     for url in URLS:
         try:
-            with _suppress_insecure_warning():
-                resp = requests.get(  # nosec
-                    url,
-                    proxies=Proxy.as_requests_proxy(proxy) if proxy else None,
-                    timeout=5,
-                    verify=False,
-                )
+            resp = requests.get(
+                url,
+                proxies=Proxy.as_requests_proxy(proxy) if proxy else None,
+                timeout=5,
+                verify=True,
+            )
             resp.raise_for_status()
             ip = resp.text.strip()
             validate_ip(ip)

--- a/pythonlib/camoufox/multiversion.py
+++ b/pythonlib/camoufox/multiversion.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 import orjson
 import rich_click as click
 
-from .pkgman import INSTALL_DIR, OS_NAME, Version, rprint, unzip
+from .pkgman import INSTALL_DIR, OS_NAME, Version, rprint, unzip, verify_sha256
 
 BROWSERS_DIR: Path = INSTALL_DIR / "browsers"
 CONFIG_FILE: Path = INSTALL_DIR / "config.json"
@@ -420,6 +420,14 @@ def install_versioned(fetcher, replace: bool = False) -> bool:
 
         with tempfile.NamedTemporaryFile() as temp_file:
             fetcher.download_file(temp_file, fetcher.url)
+
+            expected_sha = (
+                fetcher._selected_version.sha256
+                if fetcher._selected_version
+                else getattr(fetcher, "installed_sha256", None)
+            )
+            verify_sha256(temp_file, expected_sha, desc=f"Camoufox v{fetcher.verstr}")
+
             rprint(f'Extracting Camoufox: {install_path}')
             unzip(temp_file, str(install_path))
 

--- a/pythonlib/camoufox/pkgman.py
+++ b/pythonlib/camoufox/pkgman.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import platform
 import re
@@ -31,6 +32,7 @@ from yaml import CLoader, load
 from .__version__ import CONSTRAINTS
 from .exceptions import (
     CamoufoxNotInstalled,
+    CorruptedDownload,
     MissingRelease,
     UnsupportedArchitecture,
     UnsupportedOS,
@@ -850,6 +852,33 @@ def webdl(
 
     buffer.seek(0)
     return buffer
+
+
+def verify_sha256(buffer: DownloadBuffer, expected: Optional[str], desc: str = "asset") -> None:
+    """
+    Check a downloaded buffer against its expected sha256 digest.
+
+    Raises CorruptedDownload on mismatch. Skips silently when no digest is
+    known, so installs from sources that publish no digest still work.
+    """
+    if not expected:
+        rprint(f"Warning: no sha256 published for {desc}; skipping verification.", fg="yellow")
+        return
+
+    buffer.seek(0)
+    digest = hashlib.sha256()
+    for block in iter(lambda: buffer.read(1024 * 1024), b""):
+        digest.update(block)
+    buffer.seek(0)
+
+    actual = digest.hexdigest()
+    if actual != expected.lower():
+        raise CorruptedDownload(
+            f"Checksum mismatch for {desc}.\n"
+            f"  expected sha256: {expected.lower()}\n"
+            f"  actual   sha256: {actual}\n"
+            "The download was corrupted or tampered with. Installation aborted."
+        )
 
 
 def unzip(

--- a/pythonlib/tests/test_download_integrity.py
+++ b/pythonlib/tests/test_download_integrity.py
@@ -1,0 +1,84 @@
+"""Guards for the integrity of downloaded release assets.
+
+`webdl()` streams a release asset straight into a buffer that `unzip()` then
+extracts over the install directory. The GitHub API already hands us the
+asset's `digest` field, and `check_asset()` parses it into `installed_sha256`
+-- but nothing ever compared it against the bytes on disk, so a corrupted or
+substituted archive was extracted and executed unchallenged.
+
+`verify_sha256()` closes that gap. These tests pin the behaviour that matters:
+a mismatch must abort the install, and a verified buffer must still be
+readable from position 0 so the extraction step keeps working.
+"""
+
+import hashlib
+from io import BytesIO
+
+import pytest
+
+from camoufox.exceptions import CorruptedDownload
+from camoufox.pkgman import verify_sha256
+
+# Large enough to span several read() blocks, so a single-shot read()
+# regression cannot pass by accident.
+PAYLOAD = b"camoufox release asset" * 100_000
+DIGEST = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+def test_matching_digest_is_accepted():
+    verify_sha256(BytesIO(PAYLOAD), DIGEST, "asset")
+
+
+def test_digest_comparison_is_case_insensitive():
+    """GitHub returns lowercase hex, but a hand-pinned digest may not be."""
+    verify_sha256(BytesIO(PAYLOAD), DIGEST.upper(), "asset")
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda b: bytes([b[0] ^ 0xFF]) + b[1:], id="first-byte-flipped"),
+        pytest.param(lambda b: b[:-1] + bytes([b[-1] ^ 0x01]), id="last-bit-flipped"),
+        pytest.param(lambda b: b[:-1], id="truncated"),
+        pytest.param(lambda b: b + b"\x00", id="appended"),
+        pytest.param(lambda b: b"", id="empty"),
+    ],
+)
+def test_tampered_payload_aborts_the_install(mutate):
+    """Any deviation must raise -- extraction never gets to run."""
+    with pytest.raises(CorruptedDownload):
+        verify_sha256(BytesIO(mutate(PAYLOAD)), DIGEST, "asset")
+
+
+def test_error_names_both_digests():
+    """The message has to be actionable when someone hits this in the wild."""
+    with pytest.raises(CorruptedDownload) as exc:
+        verify_sha256(BytesIO(b"wrong"), DIGEST, "Camoufox v1.2.3")
+    msg = str(exc.value)
+    assert "Camoufox v1.2.3" in msg
+    assert DIGEST in msg
+    assert hashlib.sha256(b"wrong").hexdigest() in msg
+
+
+@pytest.mark.parametrize("absent", [None, ""])
+def test_missing_digest_does_not_block_the_install(absent):
+    """Sources that publish no digest must stay installable, not hard-fail."""
+    verify_sha256(BytesIO(PAYLOAD), absent, "asset")
+
+
+def test_buffer_is_rewound_for_extraction():
+    """unzip() reads the same buffer next; leaving it at EOF yields an
+    empty archive rather than a loud failure."""
+    buf = BytesIO(PAYLOAD)
+    verify_sha256(buf, DIGEST, "asset")
+    assert buf.tell() == 0
+    assert buf.read() == PAYLOAD
+
+
+def test_verifies_a_real_temporary_file(tmp_path):
+    """The install path passes a NamedTemporaryFile, not a BytesIO."""
+    path = tmp_path / "asset.zip"
+    path.write_bytes(PAYLOAD)
+    with open(path, "rb") as f:
+        verify_sha256(f, DIGEST, "asset")
+        assert f.tell() == 0


### PR DESCRIPTION
## Related Issue

Closes #715

## Description

Two fixes in `pythonlib/`, one commit each.

**`Verify sha256 of downloaded release assets before extracting`**

`check_asset()` already parses the asset's `digest` from the GitHub API into `installed_sha256`, and `AvailableVersion.sha256` carries it into `version.json` — but nothing ever compared it against the downloaded bytes, so the archive that gets extracted over the install dir and `chmod 755`'d was accepted on transport security alone.

Adds `verify_sha256()` in `pkgman.py` and calls it between download and extraction on **both** install paths: `install_versioned()` (CLI) and `InstallWorker.run()` (GUI). Hashes in 1 MiB blocks so a multi-hundred-megabyte asset is not held in memory, and rewinds the buffer so `unzip()` still reads from position 0.

When no digest is published it warns and proceeds rather than failing — refusing to install from a source that publishes no digest would be a regression, not a fix.

**`Enable TLS verification for public IP lookups`**

`public_ip()` used `verify=False` inside a context manager that also silenced urllib3's `InsecureRequestWarning`. Since these requests are routed through the user's proxy, a forged response controls the value used to spoof the WebRTC IP.

Sets `verify=True` and removes the suppression helper. `requests` raises `SSLError`, a subclass of `RequestException` that the existing loop already catches, so a host with a bad certificate is now skipped in favour of the next entry in `URLS` instead of being trusted.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

New: `pythonlib/tests/test_download_integrity.py` — 12 tests.

```bash
cd pythonlib && python -m pytest tests/ -q
```

**Result: 57 passed, 2 failed.** The 2 failures are `test_virtdisplay.py::test_single_launch_...` and `::test_concurrent_reservations_...`, which fail identically on unmodified `main` in this environment — not introduced here.

What the new tests pin:

| Case | Expected |
|---|---|
| Digest matches | accepted |
| Digest differs in case | accepted |
| First byte flipped | `CorruptedDownload` |
| Last bit flipped | `CorruptedDownload` |
| Truncated by one byte | `CorruptedDownload` |
| One byte appended | `CorruptedDownload` |
| Empty payload | `CorruptedDownload` |
| Error message | names the asset and both digests |
| Digest `None` / `""` | proceeds with a warning |
| Buffer after verify | rewound to 0, fully readable |
| Real `NamedTemporaryFile` | verified and rewound |

The payload spans several read blocks, so a single-shot `read()` regression cannot pass by accident.

TLS change verified live — `public_ip()` returns normally with `verify=True`, and no `verify=False` or `InsecureRequestWarning` reference remains in the package.

## Fingerprint Report

**Not applicable — no browser patches or C++/JS browser-layer code touched.** This PR changes only `pythonlib/` (download integrity + an HTTP client flag); no fingerprint surface is affected.

Per the checklist below, build-tester covers patch changes, and service-tester — the suite that would apply to `pythonlib/` changes — is currently marked out of service. It also requires real proxies, which I do not have. Happy to run either if you'd like.

<details>
<summary>Fingerprint report</summary>

N/A — see above.

</details>

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change *(two commits, one per fix — happy to split into two PRs)*
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass (for python library changes)~~ — marked out of service in the template
- [ ] Build test passes (for patch changes) — N/A, no patches changed
