### PR TITLE
fix: use 1920x1080 screen size for virtual display

### DIFF
--- a/pythonlib/camoufox/virtdisplay.py
+++ b/pythonlib/camoufox/virtdisplay.py
@@ -22,7 +22,7 @@ class VirtualDisplay:
 
     xvfb_args = (
         # fmt: off
-        "-screen", "0", "1x1x24",
+        "-screen", "0", "1920x1080x24",
         "-ac",
         "-nolisten", "tcp",
         "-extension", "RENDER",


### PR DESCRIPTION
## Related Issue

Closes #458

## Description

The hardcoded `1x1x24` screen size in `VirtualDisplay.xvfb_args` produces blank screenshots and prevents any visual output in headless virtual display mode. Screenshots, page rendering, and any visual debugging are impossible with a 1x1 pixel screen.

This changes the screen size to `1920x1080x24` — a standard desktop resolution that allows proper page rendering and screenshot capture.

## Type of Change

- [x] Bug fix

## Testing

Verified on Linux headless with `headless="virtual"`:
- Before: screenshots are blank (1x1 pixel)
- After: screenshots render correctly at 1920x1080

Also used in production by [Wolverine](https://github.com/dyiapanis/wolverine) (Rust browser automation server) — we pass `--geometry 1920x1080` to Xvfb and have confirmed proper rendering.

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result