### PR TITLE
Bump release to beta.29

### DIFF
--- a/upstream.sh
+++ b/upstream.sh
@@ -1,3 +1,3 @@
 version=152.0.4
-release=beta.28
+release=beta.29
 closedsrc_rev=1.0.0


### PR DESCRIPTION
Refs #707.

One line: `release=beta.28` -> `beta.29` in `upstream.sh`.

## Why

#707 changed the browser binary, not just the Python launcher — 16 of its 64 files are baked into the build:

| Where | What |
|---|---|
| `patches/` (3) | `debugger-invisible-to-content` (new, SpiderMonkey), `trusted-automation-events` (new, DOM), extended `screen-spoofing` |
| `additions/juggler/` (8) | packed into `omni.ja` — isolated-world evaluate, screencast, header order, mousemove deadlock |
| `settings/` (3) | `camoufox.cfg` (`history.length`, network partitioning), `properties.json`, `camoucfg.jvv` |
| `assets/*.mozconfig` (2) | `--enable-bundled-fonts` (macOS, #706), `--disable-debug-symbols` |

None of it reaches users until a rebuild. `--enable-bundled-fonts` in particular is a pure build flag — the macOS font fix is inert on every existing binary.

## Why the bump has to land before the tag

`Makefile` line 1-2 is `include upstream.sh` + `export`, and nothing in the build reads the git tag. Artifact filenames come from this file; the Release name comes from the tag. Tagging `v152.0.4-beta.29` without this commit would publish a release full of `camoufox-152.0.4-beta.28-*` files — colliding by name with the beta.28 already published from 0583c3e, but differing in content.

## After merge

`build.yml` triggers only on `workflow_dispatch` and `push: tags`, so merging this starts nothing. The build is started by tagging the merge commit:

```
git tag v152.0.4-beta.29 <merge-commit>
git push origin v152.0.4-beta.29
```

That runs the 6-target matrix and drafts a prerelease (`draft: true, prerelease: true`), so publishing stays a manual step.

Separately, the `pythonlib/` changes from #707 are not on PyPI either — 0.5.5 was published 2026-08-18, before that merge. Those need their own version bump plus a `publish-pypi.yml` dispatch.