### PR TITLE
feat: derive period-correct navigator.buildID when not explicitly set

### DIFF
--- a/pythonlib/camoufox/fingerprints.py
+++ b/pythonlib/camoufox/fingerprints.py
@@ -724,6 +724,56 @@ def _build_init_script(values: Dict[str, Any]) -> str:
     return '\n'.join(lines)
 
 
+def _default_build_id(ff_version: Optional[str]) -> Optional[str]:
+    """
+    Derive a plausible Firefox buildID (YYYYMMDDHHMMSS) for a given major
+    version.
+
+    Real Firefox buildIDs are the timestamp of the compiler run that produced
+    the release. Distributed Camoufox binaries carry their own (often stale)
+    engine buildID, and unless a user explicitly sets `navigator.buildID`,
+    Firefox's XULAppInfo reports it verbatim — letting a modern UA claim a
+    years-old build, which detectors cross-check.
+
+    Approximates each major version's release date (Firefox 94 shipped Nov
+    2021; releases follow ~every 4 weeks) with deterministic jitter so the
+    same version always yields the same ID.
+    """
+    if not ff_version:
+        return None
+    try:
+        major = int(str(ff_version).split('.', 1)[0])
+    except ValueError:
+        return None
+    # Anchor: Firefox 94 released 2021-11-02 (12:00:00 UTC).
+    months_since = max(major - 94, 0)
+    base_epoch = 1_635_854_400
+    jitter_days = (major * 7919) % 90
+    epoch = base_epoch + months_since * 30 * 86400 + jitter_days * 86400
+    days, secs_of_day = divmod(epoch, 86400)
+    # Civil-from-days (Howard Hinnant) — no external date dependency.
+    z = days + 719_468
+    era = z // 146_097
+    doe = z - era * 146_097
+    yoe = (doe - doe // 1460 + doe // 36524 - doe // 146_096) // 365
+    year = yoe + era * 400
+    doy = doe - (365 * yoe + yoe // 4 - yoe // 100)
+    mp = (5 * doy + 2) // 153
+    day = doy - (153 * mp + 2) // 5 + 1
+    month = mp + 3 if mp < 10 else mp - 9
+    if month <= 2:
+        year += 1
+    hh, rem = divmod(secs_of_day, 3600)
+    mm, ss = divmod(rem, 60)
+    return f"{year:04d}{month:02d}{day:02d}{hh:02d}{mm:02d}{ss:02d}"
+
+
+def _ff_major_from_ua(ua: str) -> Optional[str]:
+    """Extract the major Firefox version from a UA string like '...Firefox/152.0'."""
+    m = re.search(r"Firefox/(\d+)", ua or "")
+    return m.group(1) if m else None
+
+
 def generate_context_fingerprint(
     preset: Optional[Dict] = None,
     os: Optional[str] = None,
@@ -846,6 +896,21 @@ def generate_context_fingerprint(
         config['navigator.language'] = parsed.as_string
         if parsed.script:
             config['locale:script'] = parsed.script
+
+    # Default navigator.buildID to a period-correct value for the claimed UA
+    # version. Without this, XULAppInfo reports the (stale) engine buildID,
+    # letting a modern Firefox UA claim a years-old build — trivially
+    # cross-checkable by detectors. Users who set navigator.buildID
+    # explicitly are unaffected.
+    if 'navigator.buildID' not in config:
+        ff_major = (
+            str(ff_version).split('.', 1)[0]
+            if ff_version
+            else _ff_major_from_ua(config.get('navigator.userAgent', ''))
+        )
+        derived = _default_build_id(ff_major)
+        if derived:
+            config['navigator.buildID'] = derived
 
     # Apply caller overrides before rendering init_script
     if config_overrides:

--- a/pythonlib/tests/test_default_build_id.py
+++ b/pythonlib/tests/test_default_build_id.py
@@ -1,0 +1,80 @@
+"""
+Tests for the default navigator.buildID derivation in camoufox.fingerprints.
+
+Without an explicit navigator.buildID, XULAppInfo reports the engine binary's
+own (often stale) buildID — letting a modern Firefox UA claim a years-old
+build. generate_context_fingerprint() now derives a period-correct default
+when the user has not set one.
+
+Run with:
+    cd pythonlib && python -m pytest tests/test_default_build_id.py -v
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from camoufox.fingerprints import (  # noqa: E402
+    _default_build_id,
+    _ff_major_from_ua,
+    generate_context_fingerprint,
+)
+
+BUILDID_RE = re.compile(r"^\d{14}$")
+
+
+class TestDefaultBuildId:
+    def test_returns_14_digit_string(self):
+        bid = _default_build_id("152")
+        assert bid is not None
+        assert BUILDID_RE.match(bid)
+
+    def test_none_for_missing_version(self):
+        assert _default_build_id(None) is None
+        assert _default_build_id("") is None
+
+    def test_none_for_non_numeric(self):
+        assert _default_build_id("abc") is None
+
+    def test_deterministic(self):
+        assert _default_build_id("152") == _default_build_id("152")
+        assert _default_build_id("152.0.4") == _default_build_id("152")
+
+    def test_newer_version_is_later_date(self):
+        # A newer major version must never map to an earlier build date.
+        older = _default_build_id("130")
+        newer = _default_build_id("150")
+        assert older is not None and newer is not None
+        assert newer > older
+
+    def test_period_plausible_for_modern_firefox(self):
+        # Firefox 152 (2026) must map to a 2025/2026 build, not a stale one.
+        bid = _default_build_id("152")
+        assert bid is not None
+        assert bid.startswith("2025") or bid.startswith("2026")
+
+
+class TestFfMajorFromUa:
+    def test_extracts_major(self):
+        ua = "Mozilla/5.0 (X11; Linux x86_64; rv:152.0) Gecko/20100101 Firefox/152.0"
+        assert _ff_major_from_ua(ua) == "152"
+
+    def test_none_when_no_firefox(self):
+        assert _ff_major_from_ua("Mozilla/5.0 (Windows NT 10.0) Chrome/147.0") is None
+
+
+class TestGenerateContextFingerprintIntegration:
+    def test_config_gets_buildid_without_explicit(self):
+        result = generate_context_fingerprint(ff_version="152")
+        bid = result["config"].get("navigator.buildID")
+        assert bid is not None
+        assert BUILDID_RE.match(bid)
+
+    def test_explicit_buildid_is_preserved(self):
+        result = generate_context_fingerprint(
+            ff_version="152",
+            config_overrides={"navigator.buildID": "20200101000000"},
+        )
+        assert result["config"]["navigator.buildID"] == "20200101000000"


### PR DESCRIPTION
## Summary

Distributed Camoufox binaries carry their own engine `buildID`, and unless a user explicitly sets `navigator.buildID`, Firefox's XULAppInfo reports it verbatim. This lets a modern Firefox UA claim a years-old build (observed: UA `Firefox/152.0` with buildID `20181001000000`, i.e. a Firefox 63-era timestamp) — a trivially cross-checkable inconsistency that fingerprint detectors actively test for.

This PR defaults `navigator.buildID` to a period-correct value derived from the claimed major version when the user has not set one explicitly.

## Changes

- `_default_build_id(ff_version)` — deterministic YYYYMMDDHHMMSS within the plausible release window of the claimed Firefox major version (anchored to Firefox 94 = Nov 2021, ~4 weeks per subsequent release, stable jitter per version so the same version always yields the same ID).
- `_ff_major_from_ua(ua)` — fallback that extracts the major version from the generated UA when `ff_version` is not passed.
- Both wired into `generate_context_fingerprint()` via the same `setdefault` pattern already used for `fonts` / `voices` / `oscpu`, so both the preset and BrowserForge paths are covered.

Users who set `navigator.buildID` explicitly are completely unaffected.

## Testing

```
cd pythonlib && python -m pytest tests/test_default_build_id.py -v
# 10 passed
python -m pytest tests/ -q
# 118 passed (no regressions)
```

New tests cover: 14-digit format, determinism, monotonicity across versions (newer majors never map to earlier dates), period plausibility for modern versions, explicit-value preservation, and integration through `generate_context_fingerprint`.
