### PR TITLE
release: v152.0.4-beta.30 + pythonlib 0.5.6, with a Playwright-keyed browser floor

### DIFF
--- a/pythonlib/camoufox/__version__.py
+++ b/pythonlib/camoufox/__version__.py
@@ -8,8 +8,26 @@ class CONSTRAINTS:
     The minimum and maximum supported versions of the Camoufox browser.
     """
 
-    MIN_VERSION = 'beta.30'
+    MIN_VERSION = 'alpha.1'
     MAX_VERSION = '1'
+
+    # The browser floor is conditional on the resolved Playwright, not fixed.
+    #
+    # Each entry is (playwright_version, required_browser_build): from that
+    # Playwright on, the browser must be at least that build. 1.61 began
+    # sending viewport isMobile/screenSize in Browser.setDefaultViewport and
+    # Page.setViewportSize; beta.30 is the first build whose Protocol.js schema
+    # accepts them. Below that pairing every new_context() dies with
+    # "Protocol error (Browser.setDefaultViewport)". Measured: 1.60 works on
+    # beta.29 and beta.30; 1.61 and 1.62 fail on beta.29 and pass on beta.30.
+    #
+    # A flat MIN_VERSION cannot express this. It only knows about the browser,
+    # so to stay safe it has to assume the worst Playwright and force *every*
+    # user to re-download -- including the majority on <1.61, who are in no
+    # danger -- and it leaves the library unusable until the matching browser
+    # release is published. Keyed on Playwright, only the users who would
+    # actually break get moved.
+    PLAYWRIGHT_BROWSER_FLOORS = (((1, 61), 'beta.30'),)
 
     @staticmethod
     def as_range() -> str:

--- a/pythonlib/camoufox/__version__.py
+++ b/pythonlib/camoufox/__version__.py
@@ -8,7 +8,7 @@ class CONSTRAINTS:
     The minimum and maximum supported versions of the Camoufox browser.
     """
 
-    MIN_VERSION = 'alpha.1'
+    MIN_VERSION = 'beta.30'
     MAX_VERSION = '1'
 
     @staticmethod

--- a/pythonlib/camoufox/pkgman.py
+++ b/pythonlib/camoufox/pkgman.py
@@ -755,6 +755,22 @@ def installed_verstr() -> str:
     return Version.from_path(active).full_string
 
 
+def _root_install_supported() -> bool:
+    """
+    Whether INSTALL_DIR's root holds a supported build.
+
+    Only the pre-multiversion flat layout wrote version.json at the root; the
+    versioned layout keeps it under browsers/<repo>/<version>/. A missing root
+    version.json means "no legacy install here", so the caller should fall
+    through to a fetch rather than raise. The alpha.1 floor masked this: no
+    install was ever unsupported, so this branch was never reached.
+    """
+    try:
+        return Version.from_path().is_supported()
+    except FileNotFoundError:
+        return False
+
+
 def camoufox_path(download_if_missing: bool = True) -> Path:
     """
     Full path to the active camoufox folder
@@ -787,7 +803,7 @@ def camoufox_path(download_if_missing: bool = True) -> Path:
                 f"{active_display} is not installed. " f"Please run `camoufox fetch` to install."
             )
 
-    elif os.path.exists(INSTALL_DIR) and Version.from_path().is_supported():
+    elif os.path.exists(INSTALL_DIR) and _root_install_supported():
         return INSTALL_DIR
 
     else:

--- a/pythonlib/camoufox/pkgman.py
+++ b/pythonlib/camoufox/pkgman.py
@@ -811,7 +811,24 @@ def camoufox_path(download_if_missing: bool = True) -> Path:
             raise UnsupportedVersion("Camoufox executable is outdated.")
 
     CamoufoxFetcher().install()
-    return camoufox_path()
+
+    # Re-check rather than recurse.
+    #
+    # If the newest published build is still below the floor -- a library
+    # published ahead of its browser release, or a repos.yml source that does
+    # not carry it -- install() is a no-op ("already installed") and recursing
+    # here spun ~1000 fetch attempts into a RecursionError, having hammered the
+    # GitHub API into a rate limit on the way. Say what is actually wrong.
+    active = get_active_path()
+    if active and Version.from_path(active).is_supported():
+        return active
+    if os.path.exists(INSTALL_DIR) and _root_install_supported():
+        return INSTALL_DIR
+    raise UnsupportedVersion(
+        f"No available Camoufox build satisfies this library's minimum "
+        f"({CONSTRAINTS.MIN_VERSION}). The matching browser release may not be "
+        f"published yet; wait for it, or install an older camoufox release."
+    )
 
 
 def get_path(file: str) -> str:

--- a/pythonlib/camoufox/pkgman.py
+++ b/pythonlib/camoufox/pkgman.py
@@ -367,7 +367,7 @@ class Version:
         return self.sorted_rel < other.sorted_rel
 
     def is_supported(self) -> bool:
-        return VERSION_MIN <= self < VERSION_MAX
+        return effective_version_min() <= self < VERSION_MAX
 
     @staticmethod
     def from_path(path: Optional[Path] = None) -> 'Version':
@@ -404,6 +404,34 @@ class Version:
 
 
 VERSION_MIN, VERSION_MAX = Version.build_minmax()
+
+
+def _resolved_playwright_version() -> Optional[Tuple[int, ...]]:
+    """The installed Playwright version, or None if it cannot be determined."""
+    from importlib.metadata import version
+
+    try:
+        return _parse_semver(version('playwright'))
+    except Exception:
+        return None
+
+
+def effective_version_min() -> 'Version':
+    """The lowest browser build this install can actually talk to.
+
+    VERSION_MIN, raised by whatever the resolved Playwright requires. When the
+    Playwright version cannot be read we fall back to VERSION_MIN rather than
+    assuming the worst: a spurious forced re-download is worse than leaving a
+    working install alone, and pyproject caps Playwright anyway.
+    """
+    floor = VERSION_MIN
+    playwright_version = _resolved_playwright_version()
+    if playwright_version is None:
+        return floor
+    for required_playwright, build in CONSTRAINTS.PLAYWRIGHT_BROWSER_FLOORS:
+        if playwright_version >= required_playwright and floor < Version(build=build):
+            floor = Version(build=build)
+    return floor
 
 
 class GitHubDownloader:

--- a/pythonlib/camoufox/utils.py
+++ b/pythonlib/camoufox/utils.py
@@ -49,7 +49,7 @@ CACHE_PREFS = {
 }
 
 
-def _generate_fontconfig(fontconfig_path: str) -> str:
+def _generate_fontconfig(fontconfig_path: str, path: Optional[Path] = None) -> str:
     """
     Generates a runtime fontconfig that resolves bundled font paths absolutely.
     The bundled fonts.conf uses prefix="cwd" relative paths which break when
@@ -61,7 +61,8 @@ def _generate_fontconfig(fontconfig_path: str) -> str:
     """
     import hashlib
 
-    fonts_dir = get_path("fonts")
+    # Beside the caller's own binary when they supplied one; see get_env_vars.
+    fonts_dir = str(path.parent / "fonts") if path else get_path("fonts")
     fonts_conf_src = os.path.join(fontconfig_path, "fonts.conf")
 
     with open(fonts_conf_src, 'r') as f:
@@ -86,10 +87,18 @@ def _generate_fontconfig(fontconfig_path: str) -> str:
 
 
 def get_env_vars(
-    config_map: Dict[str, str], user_agent_os: str
+    config_map: Dict[str, str],
+    user_agent_os: str,
+    path: Optional[Path] = None,
 ) -> Dict[str, Union[str, float, bool]]:
     """
     Gets a dictionary of environment variables for Camoufox.
+
+    `path` is the caller's own executable, when they supplied one. The bundled
+    fontconfig is read from beside that binary rather than from the managed
+    install, the same way _load_properties() already treats properties.json:
+    a caller running their own build should not be resolved against, or made
+    to download, a different one.
     """
     env_vars: Dict[str, Union[str, float, bool]] = {}
     try:
@@ -123,9 +132,14 @@ def get_env_vars(
         os_dir = directory_map.get(user_agent_os, user_agent_os)
 
         # v150+ uses "fontconfig/" (matching the Go launcher); older bundles shipped "fontconfigs/".
-        fontconfig_path = get_path(os.path.join("fontconfig", os_dir))
+        def _bundle_path(*parts: str) -> str:
+            if path:
+                return str(path.parent.joinpath(*parts))
+            return get_path(os.path.join(*parts))
+
+        fontconfig_path = _bundle_path("fontconfig", os_dir)
         if not os.path.exists(os.path.join(fontconfig_path, "fonts.conf")):
-            fontconfig_path = get_path(os.path.join("fontconfigs", os_dir))
+            fontconfig_path = _bundle_path("fontconfigs", os_dir)
 
         # assert that fonts.conf exists in the directory
         if not os.path.exists(os.path.join(fontconfig_path, "fonts.conf")):
@@ -134,7 +148,7 @@ def get_env_vars(
                 f"fonts.conf not found in {fontconfig_path}!  Something ain't right with your camoufox bundle."
             )
 
-        env_vars['FONTCONFIG_FILE'] = _generate_fontconfig(fontconfig_path)
+        env_vars['FONTCONFIG_FILE'] = _generate_fontconfig(fontconfig_path, path=path)
 
     return env_vars
 
@@ -941,7 +955,7 @@ def launch_options(
 
     # Prepare environment variables to pass to Camoufox
     env_vars = {
-        **get_env_vars(config, target_os),
+        **get_env_vars(config, target_os, path=executable_path),
         **env,
     }
     # Prepare the executable path

--- a/pythonlib/pyproject.toml
+++ b/pythonlib/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "camoufox"
-version = "0.5.5"
+version = "0.5.6"
 description = "Wrapper around Playwright to help launch Camoufox"
 authors = ["daijro <daijro.dev@gmail.com>"]
 license = "MIT"

--- a/pythonlib/tests/test_executable_path_bundle.py
+++ b/pythonlib/tests/test_executable_path_bundle.py
@@ -1,0 +1,56 @@
+"""A caller's own binary must be resolved against itself, not the managed install.
+
+`executable_path` was honoured for launching and for properties.json, but the
+bundled fontconfig and fonts were still read from the managed install via
+get_path(). That silently mixed one build's fonts into another's launch, and
+once the version floor could actually reject something it became fatal: every
+launch raised UnsupportedVersion even though the caller had supplied a perfectly
+good binary.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from camoufox import pkgman, utils
+
+
+@pytest.fixture
+def bundle(tmp_path, monkeypatch):
+    """A self-contained browser bundle, plus a managed install that must not be touched."""
+    bin_dir = tmp_path / "dist" / "bin"
+    (bin_dir / "fontconfig" / "linux").mkdir(parents=True)
+    (bin_dir / "fontconfig" / "linux" / "fonts.conf").write_text(
+        '<?xml version="1.0"?><fontconfig><dir prefix="cwd">fonts</dir></fontconfig>'
+    )
+    (bin_dir / "fonts").mkdir()
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("resolved against the managed install despite executable_path")
+
+    monkeypatch.setattr(pkgman, "get_path", explode)
+    monkeypatch.setattr(utils, "get_path", explode)
+    monkeypatch.setattr(utils, "INSTALL_DIR", tmp_path / "cache")
+    monkeypatch.setattr(utils, "OS_NAME", "lin")
+    return bin_dir
+
+
+def test_fontconfig_comes_from_the_supplied_bundle(bundle, monkeypatch):
+    env = utils.get_env_vars({}, "lin", path=bundle / "camoufox-bin")
+
+    generated = Path(env["FONTCONFIG_FILE"])
+    assert generated.is_file()
+    # The bundled conf's cwd-relative <dir> is rewritten to this bundle's fonts.
+    assert str(bundle / "fonts") in generated.read_text()
+
+
+def test_managed_install_is_used_when_no_path_is_given(tmp_path, monkeypatch):
+    """Without executable_path the managed install is still the source."""
+    calls = []
+    monkeypatch.setattr(utils, "OS_NAME", "lin")
+    monkeypatch.setattr(utils, "get_path", lambda *a: calls.append(a) or "/nonexistent")
+
+    with pytest.raises(Exception):
+        utils.get_env_vars({}, "lin")
+
+    assert calls, "should have consulted the managed install"

--- a/pythonlib/tests/test_humanize.py
+++ b/pythonlib/tests/test_humanize.py
@@ -31,7 +31,7 @@ def captured_launch_config(monkeypatch):
     monkeypatch.setattr(utils, "launch_path", lambda *_args, **_kwargs: "/camoufox")
     monkeypatch.setattr(utils.LeakWarning, "warn", lambda *_args, **_kwargs: None)
 
-    def capture_env(config, _target_os):
+    def capture_env(config, _target_os, **_kwargs):
         captured.clear()
         captured.update(config)
         return {}

--- a/pythonlib/tests/test_version_floor_upgrade.py
+++ b/pythonlib/tests/test_version_floor_upgrade.py
@@ -119,3 +119,49 @@ def test_unsatisfiable_floor_reports_instead_of_recursing(tmp_path, monkeypatch)
         pkgman.camoufox_path()
 
     assert attempts == [True], "should fetch once, not spin"
+
+
+class TestConditionalFloor:
+    """The browser floor is keyed on the resolved Playwright, not fixed.
+
+    A flat floor can only speak about the browser, so to be safe it has to
+    assume the worst Playwright and re-download for everyone -- and it makes
+    the library unusable until the matching browser release exists. Keyed on
+    Playwright, only the pairing that actually breaks gets moved.
+    """
+
+    @staticmethod
+    def _with_playwright(monkeypatch, version):
+        parsed = pkgman._parse_semver(version) if version else None
+        monkeypatch.setattr(pkgman, "_resolved_playwright_version", lambda: parsed)
+
+    @pytest.mark.parametrize("version", ["1.53.0", "1.60.0"])
+    def test_old_playwright_leaves_older_builds_alone(self, monkeypatch, version):
+        """<1.61 never sends the fields beta.29 rejects, so nothing must move."""
+        self._with_playwright(monkeypatch, version)
+        assert pkgman.effective_version_min() == pkgman.Version(build="alpha.1")
+
+    @pytest.mark.parametrize("version", ["1.61.0", "1.62.0"])
+    def test_new_playwright_raises_the_floor(self, monkeypatch, version):
+        self._with_playwright(monkeypatch, version)
+        assert pkgman.effective_version_min() == pkgman.Version(build="beta.30")
+
+    def test_unreadable_playwright_falls_back_permissive(self, monkeypatch):
+        """A spurious forced re-download is worse than leaving a working install."""
+        self._with_playwright(monkeypatch, None)
+        assert pkgman.effective_version_min() == pkgman.Version(build="alpha.1")
+
+    def test_old_playwright_keeps_a_below_floor_install(self, tmp_path, monkeypatch):
+        _install(tmp_path, monkeypatch, "versioned", build="beta.29", floor="alpha.1")
+        self._with_playwright(monkeypatch, "1.60.0")
+
+        resolved = pkgman.camoufox_path(download_if_missing=False)
+
+        assert resolved.name == "152.0.4-beta.29"
+
+    def test_new_playwright_moves_a_below_floor_install(self, tmp_path, monkeypatch):
+        _install(tmp_path, monkeypatch, "versioned", build="beta.29", floor="alpha.1")
+        self._with_playwright(monkeypatch, "1.62.0")
+
+        with pytest.raises(UnsupportedVersion):
+            pkgman.camoufox_path(download_if_missing=False)

--- a/pythonlib/tests/test_version_floor_upgrade.py
+++ b/pythonlib/tests/test_version_floor_upgrade.py
@@ -95,3 +95,27 @@ def test_root_probe_tolerates_the_versioned_layout(tmp_path, monkeypatch):
     monkeypatch.setattr(pkgman, "INSTALL_DIR", root)
 
     assert pkgman._root_install_supported() is False
+
+
+def test_unsatisfiable_floor_reports_instead_of_recursing(tmp_path, monkeypatch):
+    """A floor no published build satisfies must report, not spin.
+
+    install() is a no-op when the newest release is already installed, so the
+    old `return camoufox_path()` tail recursed ~1000 times -- each iteration
+    firing another GitHub API call, which exhausts the unauthenticated rate
+    limit long before the RecursionError lands. That is the state a library
+    published ahead of its browser release puts every user in.
+    """
+    _install(tmp_path, monkeypatch, "versioned", build="beta.29", floor="beta.30")
+    attempts = []
+
+    class StubFetcher:
+        def install(self):
+            attempts.append(True)  # newest published build is still below the floor
+
+    monkeypatch.setattr(pkgman, "CamoufoxFetcher", StubFetcher)
+
+    with pytest.raises(UnsupportedVersion):
+        pkgman.camoufox_path()
+
+    assert attempts == [True], "should fetch once, not spin"

--- a/pythonlib/tests/test_version_floor_upgrade.py
+++ b/pythonlib/tests/test_version_floor_upgrade.py
@@ -1,0 +1,97 @@
+"""Regression coverage for raising the supported browser floor.
+
+Raising ``CONSTRAINTS.MIN_VERSION`` is how the library forces an existing
+install to upgrade when it can no longer talk to the old browser. That path
+had been dead since the floor was dropped to ``alpha.1``, and it hid a bug:
+``camoufox_path`` probed ``INSTALL_DIR/version.json``, which only the
+pre-multiversion flat layout ever wrote, so a below-floor versioned install
+raised ``FileNotFoundError`` instead of falling through to a fetch.
+"""
+
+import json
+
+import pytest
+
+from camoufox import multiversion, pkgman
+from camoufox.exceptions import UnsupportedVersion
+
+
+def _install(tmp_path, monkeypatch, layout, build, floor):
+    """Build an install dir in the given layout and point the library at it."""
+    root = tmp_path / "cache"
+    root.mkdir()
+    (root / ".0.5_FLAG").write_text("")
+    (root / "repo_cache.json").write_text("{}")
+
+    if layout == "versioned":
+        relative = f"browsers/official/152.0.4-{build}"
+        (root / "config.json").write_text(json.dumps({"active_version": relative}))
+        version_dir = root / relative
+        version_dir.mkdir(parents=True)
+    else:
+        (root / "config.json").write_text("{}")
+        version_dir = root
+    (version_dir / "version.json").write_text(
+        json.dumps({"version": "152.0.4", "build": build})
+    )
+
+    for module in (pkgman, multiversion):
+        monkeypatch.setattr(module, "INSTALL_DIR", root)
+    monkeypatch.setattr(multiversion, "BROWSERS_DIR", root / "browsers")
+    monkeypatch.setattr(multiversion, "CONFIG_FILE", root / "config.json")
+    monkeypatch.setattr(multiversion, "COMPAT_FLAG", root / ".0.5_FLAG")
+    monkeypatch.setattr(pkgman, "VERSION_MIN", pkgman.Version(build=floor))
+    return root
+
+
+@pytest.mark.parametrize("layout", ["versioned", "legacy"])
+def test_below_floor_install_is_reported_as_outdated(tmp_path, monkeypatch, layout):
+    """A build under the floor must report as outdated, never as missing."""
+    _install(tmp_path, monkeypatch, layout, build="beta.29", floor="beta.30")
+
+    with pytest.raises(UnsupportedVersion):
+        pkgman.camoufox_path(download_if_missing=False)
+
+
+@pytest.mark.parametrize("layout", ["versioned", "legacy"])
+def test_at_floor_install_is_kept(tmp_path, monkeypatch, layout):
+    """A build at the floor is still served, in either layout."""
+    root = _install(tmp_path, monkeypatch, layout, build="beta.30", floor="beta.30")
+
+    resolved = pkgman.camoufox_path(download_if_missing=False)
+
+    expected = root if layout == "legacy" else root / "browsers/official/152.0.4-beta.30"
+    assert resolved == expected
+
+
+def test_below_floor_install_triggers_a_fetch(tmp_path, monkeypatch):
+    """The default path upgrades the install instead of raising."""
+    root = _install(tmp_path, monkeypatch, "versioned", build="beta.29", floor="beta.30")
+    installed = []
+
+    class StubFetcher:
+        def install(self):
+            installed.append(True)
+            relative = "browsers/official/152.0.4-beta.30"
+            version_dir = root / relative
+            version_dir.mkdir(parents=True)
+            (version_dir / "version.json").write_text(
+                json.dumps({"version": "152.0.4", "build": "beta.30"})
+            )
+            (root / "config.json").write_text(json.dumps({"active_version": relative}))
+
+    monkeypatch.setattr(pkgman, "CamoufoxFetcher", StubFetcher)
+
+    resolved = pkgman.camoufox_path()
+
+    assert installed == [True]
+    assert resolved == root / "browsers/official/152.0.4-beta.30"
+
+
+def test_root_probe_tolerates_the_versioned_layout(tmp_path, monkeypatch):
+    """The root probe reports False, rather than raising, with no root file."""
+    root = tmp_path / "cache"
+    root.mkdir()
+    monkeypatch.setattr(pkgman, "INSTALL_DIR", root)
+
+    assert pkgman._root_install_supported() is False

--- a/upstream.sh
+++ b/upstream.sh
@@ -1,3 +1,3 @@
 version=152.0.4
-release=beta.29
+release=beta.30
 closedsrc_rev=1.0.0


### PR DESCRIPTION
Releases the work merged since beta.29 (#743, and #745 now that it has landed).

Rewritten since the first review: the flat `MIN_VERSION` this PR originally used has been replaced by a floor keyed on the resolved Playwright version, and auditing that turned up three further latent bugs, all fixed here.

## Why a browser floor is needed at all

`pyproject.toml` on main raises the Playwright cap to `<1.63`, which is only safe against a browser whose `Protocol.js` accepts the viewport fields 1.61 began sending. Measured against real builds:

| | playwright 1.60 | 1.61 | 1.62 |
|---|---|---|---|
| **beta.29** | OK | FAIL | FAIL |
| **beta.30** | OK | — | OK |

The failure is `Protocol error (Browser.setDefaultViewport)` on *every* `new_context()`. Old pythonlib against a new browser is safe — the new schema fields are `t.Optional`.

## Why the floor is conditional, not flat

The incompatibility is two-dimensional — it needs Playwright >= 1.61 **and** a browser < beta.30 — but `MIN_VERSION` only knows about the browser. A flat floor has to assume the worst Playwright, which means:

- every 0.5.6 user re-downloads the browser, including the majority on <1.61 who are in no danger;
- installs **pinned** to an older build lose the pin, and **prerelease/alpha** users are moved off their channel (every `alpha.*` sorts below `beta.30`);
- the library cannot run *at all* until the matching browser release is published, making the PyPI-after-release ordering load-bearing.

Keyed on Playwright instead, only the pairing that actually breaks moves:

```
playwright <1.61   -> floor alpha.1  -> every install kept
playwright >=1.61  -> floor beta.30  -> below-beta.30 installs upgraded
version unreadable -> floor alpha.1  -> kept (a spurious forced re-download is
                                        worse than leaving a working install)
```

## Three latent bugs the floor exposed

All the same shape: code downstream of the version check that had never executed, because an `alpha.1` floor never rejected anything.

1. **`camoufox_path()` raised `FileNotFoundError` instead of fetching.** It probed `INSTALL_DIR/version.json`, which only the pre-multiversion flat layout ever wrote. Any raised floor would have crashed every existing user rather than upgrading them.
2. **Unbounded recursion.** The function ended in `return camoufox_path()`. When the newest *published* build is still below the floor, `install()` is a no-op and that tail recursed — measured **990 fetch attempts before `RecursionError`**, exhausting the unauthenticated GitHub rate limit (60/hr) on the way. Now re-checks once and raises `UnsupportedVersion` naming the requirement.
3. **`executable_path` was ignored for bundle resolution.** `get_env_vars()`/`_generate_fontconfig()` read the bundled fontconfig and fonts through `get_path()` — the managed install — even when the caller supplied their own binary (`_load_properties()` already honoured it for `properties.json`). Previously this silently mixed one build's fonts into another's launch; with a live floor it became fatal, failing every launch while the caller held a perfectly good binary. Found by stress-testing, and it would have hit anyone running their own build or a CI-downloaded artifact.

## Verification — clean build, full runthrough

Built from scratch on this branch (`make dir` + Linux x86_64), then:

| Check | Result |
|---|---|
| Stress suite, 18 launch configurations | **18/18** |
| `tests/patches/*` | **7/7** |
| pythonlib | **172 passed** |
| vermin (3.8 gate) | pass |
| build-tester | **405/408 — identical to shipped beta.29** |
| Vendored Playwright suite (1.62, with display) | **6 failed / 1088 passed** |

The stress suite asserts observable behaviour through the DOM (page-world state is invisible to `page.evaluate` by design): OS spoofing reaching the page, explicit config passthrough, a user-set 1024x600 screen surviving the #729 floor, voices failing closed, all four init-script quadrants, `navigator.webdriver`, and invalid config being rejected loudly rather than degrading.

The 6 remaining suite failures are all pre-existing and characterised: 3 are stale vendored assertions against newer Playwright (the `Page.waitForEventInfo` -> `__waitInfo__` rename, verified in `_waiter.py`, and a websocket error-string change); 2 fail **0/5 on stock Playwright Firefox** too, so they are test defects rather than browser bugs; and 1 (`test_frame_goto_should_continue_after_client_redirect`) is a genuine camoufox `networkidle` issue that predates this work (vanilla 17/17, camoufox 9/17) and deserves its own issue. build-tester's 3 are the pre-existing `selfDestruct.setTimezone`, byte-identical to beta.29.

## Backwards compatibility for 0.5.6

Not all from this PR, but shipping in this release:

- **`voices` is now strictly validated** (#743). `voices=["Alex:en-US:local"]` — the string form in `camoufox/voices.json` — now raises `InvalidPropertyType`. Previously accepted and silently ignored, which was the #731 bug; converting a silent failure to a loud one is the point, but it *is* breaking for anyone passing that shape.
- **Generated fingerprints change** (#729): sub-1366x768 screens are lifted and WebGL is sampled to match the screen. Explicit `screen.*` values and presets are respected (covered by a stress case); defaults are not.
- **Forced browser upgrades are now limited** to users on Playwright >= 1.61, rather than everyone.

## Release order

Still browser-first — merge, tag `v152.0.4-beta.30`, let `build.yml` publish the assets, verify, then dispatch `publish-pypi.yml`. The conditional floor means an ordering slip is no longer catastrophic (users on <1.61 are unaffected either way), but it remains the right order.

Note this repo has no PR CI (`build.yml` and `publish-pypi.yml` are both tag/dispatch only), so the table above is the whole verification story. Linux x86_64 only — windows and macos are first exercised by the tag build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
