### PR TITLE
fix(build): resolve the rust host triplet under rustc 1.98

### DIFF
--- a/patches/rust-vendor-unknown-fallback.patch
+++ b/patches/rust-vendor-unknown-fallback.patch
@@ -1,0 +1,27 @@
+diff --git a/build/moz.configure/rust.configure b/build/moz.configure/rust.configure
+index 33a9309..6240b77 100644
+--- a/build/moz.configure/rust.configure
++++ b/build/moz.configure/rust.configure
+@@ -427,6 +427,22 @@ def detect_rustc_target(
+         if len(narrowed) == 1:
+             return narrowed[0].rust_target
+ 
++        # Rust spells its canonical Linux targets with the vendor-neutral
++        # "unknown" (x86_64-unknown-linux-gnu); the distro-flavoured spellings
++        # are the exceptions -- "gentoo" just above, and "oe" (OpenEmbedded),
++        # which rustc 1.98 added as x86_64-oe-linux-gnu. An autoconf host like
++        # x86_64-pc-linux-gnu has vendor "pc", which matches neither of those
++        # and has no rust target of its own, so the moment a second raw_os
++        # match exists no step above narrows to one and configure dies with
++        # "Don't know how to translate x86_64-pc-linux-gnu for rustc".
++        #
++        # By here `candidates` has already been reduced to the raw_os matches,
++        # so preferring the vendor-neutral one picks the canonical target and
++        # leaves every triplet that resolved before this reaching it at all.
++        narrowed = [c for c in candidates if c.target.vendor == "unknown"]
++        if len(narrowed) == 1:
++            return narrowed[0].rust_target
++
+         return None
+ 
+     rustc_target = find_candidate(candidates)


### PR DESCRIPTION
Unblocks the release build. The `v152.0.4-beta.30` tag build ([run 33444689404](https://github.com/daijro/camoufox/actions/runs/33444689404)) died in configure on every target, before compiling a single file:

```
checking rustc version... 1.98.0
checking for rust host triplet...
ERROR: Don't know how to translate x86_64-pc-linux-gnu for rustc
```

## Not caused by the release

`git diff --name-only v152.0.4-beta.29..v152.0.4-beta.30` touches **no build-system file** — no `scripts/`, `assets/`, `Makefile`, `Dockerfile` or `.github/`. It is juggler JS, pythonlib, two patches and settings. The same tree built green as beta.29 on 2026-08-20; the runner image moved underneath it.

## What actually changed

rustc 1.98 added five OpenEmbedded targets, one being `x86_64-oe-linux-gnu`. That is enough to break the host lookup in `build/moz.configure/rust.configure`, whose narrowing steps only return when they reduce to exactly one candidate:

```
1.97.1  raw_os "linux-gnu" -> [x86_64-unknown-linux-gnu]                -> resolved
1.98.0  raw_os "linux-gnu" -> [x86_64-oe-linux-gnu, x86_64-unknown-...] -> 2, falls through
        exact alias        -> no rust target is spelled x86_64-pc-linux-gnu
        vendor == "pc"     -> 0 (candidates are "oe" and "unknown")
        gentoo alias       -> 0
        -> None -> die
```

It takes out every target, not just linux, because all of them cross-compile from the Linux runner and it is the **host** that fails to resolve.

## The fix

One final fallback preferring the vendor-neutral `"unknown"` spelling. Rust writes its canonical Linux targets that way; the distro-flavoured ones (`gentoo`, `oe`) are the exceptions. So when an autoconf vendor like `pc` matches nothing, the canonical target is the right answer. By that point `candidates` is already reduced to the raw_os matches, so every triplet that resolved before never reaches the new branch.

Sorts after `rust-gentoo-musl.patch` by basename — the order `patch.py` applies in — and its context includes that patch's block, so a future reordering fails loudly as a reject rather than misapplying.

## Verification

`./mach configure` against the real 152.0.4 tree:

| toolchain | patch | result |
|---|---|---|
| rustc 1.98.0 | without | `ERROR: Don't know how to translate…`, exit 1 — reproduces CI exactly |
| rustc 1.98.0 | with | `rust host triplet... x86_64-unknown-linux-gnu`, `Configure complete!`, exit 0 |
| rustc 1.96.1 | with | `x86_64-unknown-linux-gnu`, `Configure complete!`, exit 0 — no regression |

A full Linux x86_64 build under 1.98 is running to confirm the whole build, not just configure.

Ported from JWriter20/camoufox `ef5f54d`, which carries the same fix under that fork's restructured layout (it could not be cherry-picked directly — paths differ). That branch also removed a 1.97.1 CI pin; upstream never had the pin, so only the patch is needed here.

## After merging

`v152.0.4-beta.30` can be deleted and re-pushed to re-run the build — nothing was published from the failed run, so that version was never a real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)