### PR TITLE
fix(juggler): make the input-dispatch deadlock structurally unreachable (#751, #752)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+# Static checks only -- no browser build, so these can gate every pull request.
+# The build workflow runs on tags and takes ~40 minutes; nothing was checking
+# pull requests before this.
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  input-dispatch:
+    name: Synthesized input goes through one chokepoint
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3 scripts/check-input-dispatch.py

--- a/additions/juggler/Helper.js
+++ b/additions/juggler/Helper.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const uuidGen = Cc["@mozilla.org/uuid-generator;1"].getService(Ci.nsIUUIDGenerator);
+const {setTimeout, clearTimeout} = ChromeUtils.importESModule("resource://gre/modules/Timer.sys.mjs");
 
 export class Helper {
   decorateAsEventEmitter(objectToDecorate) {
@@ -172,6 +173,8 @@ export class Helper {
 
 const helper = new Helper();
 
+const kEventTimedOut = Symbol('event-timed-out');
+
 export class EventWatcher {
   constructor(receiver, eventNames, pendingEventWatchers = new Set()) {
     this._pendingEventWatchers = pendingEventWatchers;
@@ -199,6 +202,35 @@ export class EventWatcher {
       if (result)
         return result;
       await new Promise((resolve, reject) => this._pendingPromises.push({resolve, reject}));
+    }
+  }
+
+  /**
+   * Like ensureEvent, but gives up after timeoutMs and resolves null instead of
+   * waiting forever.
+   *
+   * Callers awaiting an ack for synthesized input must use this. Input dispatch
+   * is serialized on activateAndRun()'s process-global promise chain, so an ack
+   * that never arrives does not merely lose one event -- it wedges every later
+   * input event in the process, in every tab, permanently, at 0% CPU with no
+   * diagnostic. Four shipped deadlocks (#225, #677, #751, #752) were all that
+   * failure. Bounding the wait is what makes the fifth one a log line.
+   */
+  async ensureEventWithin(aEventName, timeoutMs, predicate) {
+    const pending = this.ensureEvent(aEventName, predicate);
+    // Whichever promise loses the race stays pending until dispose() rejects
+    // it; swallow that so a timed-out wait never surfaces as an unhandled
+    // rejection in chrome JS.
+    pending.catch(() => {});
+    let timer;
+    const timedOut = new Promise(resolve => {
+      timer = setTimeout(() => resolve(kEventTimedOut), timeoutMs);
+    });
+    try {
+      const result = await Promise.race([pending, timedOut]);
+      return result === kEventTimedOut ? null : result;
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/additions/juggler/TargetRegistry.js
+++ b/additions/juggler/TargetRegistry.js
@@ -11,6 +11,23 @@ const {AppConstants} = ChromeUtils.importESModule("resource://gre/modules/AppCon
 // scripts), so the screencast tick has to import them explicitly.
 const {setTimeout, clearTimeout} = ChromeUtils.importESModule("resource://gre/modules/Timer.sys.mjs");
 
+// Last-resort bound on how long one callback may occupy the process-global
+// activation chain below. The chain must always advance: a callback that never
+// returns wedges every later input event in every tab, permanently.
+//
+// The per-ack deadline in MouseDispatch.js covers the await that has actually
+// caused all four shipped deadlocks, but it is one of several unbounded waits
+// reachable from a single slot -- apz-repaints-flushed, TabSwitchDone below,
+// the drag path's juggler-drag-finalized and dragover waits, and the
+// cross-process dispatchDragEvent sends all have the same shape. None of them
+// has failed yet. Bounding only the wait that has already bitten us is the
+// posture that produced those four fixes, so bound the slot itself too.
+//
+// Sized as a backstop, not a tuning knob: with a 5s ack deadline a legitimate
+// worst-case input slot approaches 10s, so this must sit well clear of that.
+const kActivationSlotBudgetMs = 30000;
+const kSlotExpired = Symbol('activation-slot-expired');
+
 const Cr = Components.results;
 
 const helper = new Helper();
@@ -512,7 +529,18 @@ export class PageTarget {
       const notificationsPopup = muteNotificationsPopup ? this._linkedBrowser?.ownerDocument.getElementById('notification-popup') : null;
       notificationsPopup?.style.setProperty('pointer-events', 'none');
       try {
-        await callback();
+        let timer;
+        const expired = new Promise(resolve => {
+          timer = setTimeout(() => resolve(kSlotExpired), kActivationSlotBudgetMs);
+        });
+        try {
+          if (await Promise.race([callback(), expired]) === kSlotExpired) {
+            dump(`[juggler] WARN activation-chain slot exceeded ` +
+                 `${kActivationSlotBudgetMs}ms; advancing the chain without it\n`);
+          }
+        } finally {
+          clearTimeout(timer);
+        }
       } finally {
         notificationsPopup?.style.removeProperty('pointer-events');
       }

--- a/additions/juggler/input/MouseDispatch.js
+++ b/additions/juggler/input/MouseDispatch.js
@@ -1,0 +1,229 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/**
+ * The one place in the parent process that dispatches synthesized mouse input.
+ *
+ * It exists because the alternative did not work. Between 2026-04 and 2026-09,
+ * four separate deadlocks shipped -- exact-edge coordinates (#225), humanized
+ * trajectory points that bypassed the endpoint's guard (#677/#225), a
+ * zero-displacement move, and the top-edge row (#751/#752) -- each fixed by
+ * adding one more coordinate guard at one more call site. The guards were
+ * correct; the arithmetic behind them was copied per call site, so every new
+ * dispatch site was a fresh chance to get it wrong, and every mistake cost the
+ * whole browser process.
+ *
+ * THE INVARIANT
+ *   A synthesized input event whose ack we await must reach the content
+ *   renderer -- and when it does not, we must stop waiting.
+ *
+ * Nothing else in juggler may call jugglerSendMouseEvent / sendWheelEvent or do
+ * browser-relative coordinate arithmetic; scripts/check-input-dispatch.py fails
+ * the build if it does. See docs/input-dispatch.md.
+ */
+
+const {setTimeout} = ChromeUtils.importESModule('resource://gre/modules/Timer.sys.mjs');
+
+/**
+ * How long to wait for a juggler-mouse-event-hit-renderer ack before giving up.
+ *
+ * Measured on v152.0.4-beta.30, headless Linux, over 1000+ dispatches:
+ *
+ *   content main thread        p50     p99     max
+ *   idle                       0ms     1ms     12ms
+ *   busy (8ms burned/event)    8ms     9ms     12ms
+ *   blocked (3s sync script)   0ms     1ms     2849ms
+ *
+ * Typical latency is three orders of magnitude below this. The deadline is not
+ * sized by the typical case though: the ack is delivered FROM the content main
+ * thread, so it inherits any block on it, and block length is page-controlled
+ * and unbounded. Pages that block for seconds are the normal case on the
+ * targets Camoufox exists to handle. Sizing this near the p99 would silently
+ * drop real input on merely-slow pages -- a correctness bug wearing the exact
+ * costume of the deadlock it replaces. Waiting too long costs a few seconds
+ * once and then recovers; waiting too little costs input loss that nobody can
+ * diagnose. So: well above the slowest legitimate ack, not near the typical one.
+ */
+export const kAckDeadlineMs = 5000;
+
+/** Delay between humanized trajectory points, preserving the original cadence. */
+export const kTrajectoryStepMs = 10;
+
+function warnUndelivered(eventType, x, y, box, deadlineMs) {
+  dump(
+    `[juggler] WARN ${eventType} at (${x}, ${y}) was not delivered to the ` +
+    `renderer after ${deadlineMs}ms; dropping it (browser rect ` +
+    `${box.width}x${box.height} at +${box.left}+${box.top})\n`
+  );
+}
+
+export class MouseDispatch {
+  /**
+   * @param {Window} win chrome window owning the browser element.
+   * @param {DOMRect} boundingBox the browser element's rect, already measured.
+   * @param {object} eventArgs button / clickCount / modifiers / buttons.
+   */
+  constructor(win, boundingBox, {button = 0, clickCount = 0, modifiers = 0, buttons = 0} = {}) {
+    this._win = win;
+    this._box = boundingBox;
+    this._args = {button, clickCount, modifiers, buttons};
+
+    // The first whole pixel inside the browser element on each axis.
+    //
+    // The element's origin is not pixel-aligned: the chrome above the content is
+    // a fractional number of CSS pixels tall, and how many depends on the spoofed
+    // OS (measured: windows 51.4, macos 53.1, linux 56.5). A relative coordinate
+    // of 0 therefore dispatches at absolute y == boundingBox.top exactly -- the
+    // content area's first, only partly covered row. The widget rounds that to a
+    // whole device row before hit-testing it, and wherever round(top) < top the
+    // rounded row still belongs to chrome, so the event fires as an exit event
+    // rather than eMouseMove and no ack is ever produced (#751, #752).
+    //
+    // Snapping onto ceil() keeps the point inside content pixel 0 while landing
+    // clear of the boundary. It is a sub-pixel shift and only ever affects the
+    // first row/column; boundingBox.left is normally a whole 0 and unaffected.
+    this._originX = Math.ceil(boundingBox.left);
+    this._originY = Math.ceil(boundingBox.top);
+
+    // The far edge has the same problem, and the bounds check below cannot see
+    // it either. The element's height is fractional too -- measured, it is
+    // consistently 0.5 CSS px less than the innerHeight the page reports, so
+    // the page's last row is only half covered. A point in it dispatches at an
+    // absolute coordinate that rounds onto the row *past* the content, and is
+    // dropped exactly like the top-edge case. Deterministic: with the box at
+    // 1920x977.5 +0+56.5, relative y == 977 (innerHeight - 1, well inside the
+    // viewport as far as the page is concerned) dispatches at 1033.5, rounds to
+    // 1034, and the content ends at 1034.
+    //
+    // So clamp to the last whole pixel fully inside the element as well. Found
+    // by tests/patches/mouse-boundary-sweep.py, not by a report -- it predates
+    // this module and deadlocks a stock build.
+    this._limitX = Math.ceil(boundingBox.left + boundingBox.width) - 1;
+    this._limitY = Math.ceil(boundingBox.top + boundingBox.height) - 1;
+  }
+
+  static forBrowser(win, linkedBrowser, eventArgs) {
+    return new MouseDispatch(win, linkedBrowser.getBoundingClientRect(), eventArgs);
+  }
+
+  get boundingBox() {
+    return this._box;
+  }
+
+  /**
+   * Is this relative point inside the content viewport at all?
+   *
+   * The far edges are exclusive: a point at exactly x == width or y == height
+   * lies on the opposite boundary row and fires as an exit event, so it must be
+   * treated as out-of-viewport rather than dispatched (#225). The near edges are
+   * inclusive -- 0 is a legitimate coordinate a caller may ask for, and the
+   * constructor's snap is what makes it safe to dispatch.
+   */
+  isInViewport(x, y) {
+    return x >= 0 && y >= 0 && x < this._box.width && y < this._box.height;
+  }
+
+  /** Relative point -> absolute, snapped clear of both of the element's edges. */
+  toAbsolute(x, y) {
+    return {
+      x: Math.min(Math.max(x + this._box.left, this._originX), this._limitX),
+      y: Math.min(Math.max(y + this._box.top, this._originY), this._limitY),
+    };
+  }
+
+  _sendAbsolute(eventType, absX, absY) {
+    return this._win.windowUtils.jugglerSendMouseEvent(
+      eventType,
+      absX,
+      absY,
+      this._args.button,
+      this._args.clickCount,
+      this._args.modifiers,
+      false /* aIgnoreRootScrollFrame */,
+      0.0 /* pressure */,
+      0 /* inputSource */,
+      true /* isDOMEventSynthesized */,
+      false /* isWidgetEventSynthesized */,
+      this._args.buttons,
+      this._win.windowUtils.DEFAULT_MOUSE_POINTER_ID /* pointerIdentifier */,
+      false /* disablePointerEvent */
+    );
+  }
+
+  /**
+   * Dispatch one event and wait for the renderer to ack it, under a deadline.
+   *
+   * Returns the ack event object, or null if none arrived in time -- in which
+   * case the event is dropped and a warning is logged. Never rejects and never
+   * waits forever: input dispatch is serialized on activateAndRun()'s
+   * process-global chain, so an unbounded wait here wedges every later input
+   * event in the process, in every tab, for the life of the browser.
+   */
+  async sendAcked(watcher, eventType, x, y, deadlineMs = kAckDeadlineMs) {
+    const {x: absX, y: absY} = this.toAbsolute(x, y);
+    // This dispatches to the renderer synchronously.
+    const jugglerEventId = this._sendAbsolute(eventType, absX, absY);
+    const ack = await watcher.ensureEventWithin(
+      eventType, deadlineMs, eventObject => eventObject.jugglerEventId === jugglerEventId);
+    if (!ack)
+      warnUndelivered(eventType, x, y, this._box, deadlineMs);
+    return ack;
+  }
+
+  /**
+   * Dispatch the intermediate points of a humanized trajectory.
+   *
+   * Points outside the viewport are skipped. Bounding each ack individually is
+   * not enough to bound the work: a curve is ~110 points dispatched inside a
+   * SINGLE activation-chain slot, so a curve riding a coordinate that cannot be
+   * delivered would spend 110 x the deadline there. Rather than a wall-clock
+   * budget -- which would false-fire on exactly the slow pages the deadline
+   * exists to tolerate -- the first undelivered point abandons the rest of the
+   * curve. Intermediate points are humanization garnish: if one did not reach
+   * the renderer the rest of that curve almost certainly will not either, and
+   * dropping them costs realism, not correctness. The caller still dispatches
+   * the real destination afterwards.
+   *
+   * @returns {boolean} true if the whole curve was delivered.
+   */
+  async sendTrajectoryAcked(watcher, eventType, points, stepDelayMs = kTrajectoryStepMs) {
+    for (const [x, y] of points) {
+      if (!this.isInViewport(x, y))
+        continue;
+      if (!await this.sendAcked(watcher, eventType, x, y))
+        return false;
+      await new Promise(resolve => setTimeout(resolve, stepDelayMs));
+    }
+    return true;
+  }
+
+  /**
+   * Park the cursor off web content so hover effects clear.
+   *
+   * Deliberately dispatched at the chrome window's own origin rather than a
+   * content coordinate, and deliberately unacked: it never enters the renderer,
+   * so there is no ack to wait for.
+   */
+  parkOffContent() {
+    this._sendAbsolute('mousemove', 0, 0);
+  }
+
+  /** Wheel events take the same conversion; they are not acked. */
+  sendWheel(x, y, {deltaX, deltaY, deltaZ, deltaMode, lineOrPageDeltaX, lineOrPageDeltaY}) {
+    const {x: absX, y: absY} = this.toAbsolute(x, y);
+    this._win.windowUtils.sendWheelEvent(
+      absX,
+      absY,
+      deltaX,
+      deltaY,
+      deltaZ,
+      deltaMode,
+      this._args.modifiers,
+      lineOrPageDeltaX,
+      lineOrPageDeltaY,
+      0 /* options */);
+  }
+}

--- a/additions/juggler/jar.mn
+++ b/additions/juggler/jar.mn
@@ -8,6 +8,7 @@ juggler.jar:
   content/components/Juggler.js (components/Juggler.js)
 
   content/Helper.js (Helper.js)
+  content/input/MouseDispatch.js (input/MouseDispatch.js)
   content/NetworkObserver.js (NetworkObserver.js)
   content/ChannelEventSink.sys.mjs (ChannelEventSink.sys.mjs)
   content/TargetRegistry.js (TargetRegistry.js)

--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -527,14 +527,37 @@ export class PageHandler {
         await helper.awaitTopic('apz-repaints-flushed');
 
       const watcher = new EventWatcher(this._pageEventSink, types, this._pendingEventWatchers);
+      // The browser element's origin is not pixel-aligned: the chrome above the
+      // content is a fractional number of CSS pixels tall, and how many depends
+      // on the spoofed OS (measured: windows 51.4, macos 53.1, linux 56.5). So a
+      // relative coordinate of 0 dispatches at absolute y == boundingBox.top
+      // exactly -- the content area's first, only partly covered row. The widget
+      // rounds that to a whole device row before hit-testing it, and wherever
+      // round(top) < top the rounded row still belongs to chrome: the event fires
+      // as an exit event rather than eMouseMove, no
+      // juggler-mouse-event-hit-renderer ack is produced, and because dispatch is
+      // serialized on activateAndRun()'s process-global chain (TargetRegistry.js)
+      // that one missing ack wedges every later input event in the process
+      // forever. windows and macos land on the wrong side of that rounding, so
+      // page.mouse.move(x, 0) deadlocks on them every time; linux never does.
+      // This is the near edge's version of the x==width / y==height deadlock the
+      // bounds checks below guard against, but it cannot be fixed the same way:
+      // unlike the far edges, 0 is a legitimate in-viewport coordinate a caller
+      // may ask for, and the out-of-viewport branch drops mousedown/mouseup
+      // silently -- which is what makes a click look like it simply did nothing.
+      // Snapping to the first whole pixel inside the element stays within content
+      // pixel 0 while landing clear of the boundary. boundingBox.left is normally
+      // a whole 0 and so needs no rounding, but the same snap covers it.
+      const originX = Math.ceil(boundingBox.left);
+      const originY = Math.ceil(boundingBox.top);
       // Dispatch a single synthesized mouse event to the renderer and return a
       // promise that resolves once the renderer acks it.
       const sendOne = (eventType, eventX, eventY) => {
         // This dispatches to the renderer synchronously.
         const jugglerEventId = win.windowUtils.jugglerSendMouseEvent(
           eventType,
-          eventX + boundingBox.left,
-          eventY + boundingBox.top,
+          Math.max(eventX + boundingBox.left, originX),
+          Math.max(eventY + boundingBox.top, originY),
           button,
           clickCount,
           modifiers,

--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -9,6 +9,7 @@ const {NetUtil} = ChromeUtils.importESModule('resource://gre/modules/NetUtil.sys
 const {NetworkObserver, PageNetwork} = ChromeUtils.importESModule('chrome://juggler/content/NetworkObserver.js');
 const {PageTarget} = ChromeUtils.importESModule('chrome://juggler/content/TargetRegistry.js');
 const {setTimeout} = ChromeUtils.importESModule('resource://gre/modules/Timer.sys.mjs');
+const {MouseDispatch} = ChromeUtils.importESModule('chrome://juggler/content/input/MouseDispatch.js');
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
@@ -517,88 +518,36 @@ export class PageHandler {
 
   async ['Page.dispatchMouseEvent']({type, x, y, button, clickCount, modifiers, buttons}) {
     const win = this._pageTarget._window;
+    const eventArgs = {button, clickCount, modifiers, buttons};
     const sendEvents = async (types) => {
       // 1. Scroll element to the desired location first; the coordinates are relative to the element.
       this._pageTarget._linkedBrowser.scrollRectIntoViewIfNeeded(x, y, 0, 0);
       // 2. Get element's bounding box in the browser after the scroll is completed.
-      const boundingBox = this._pageTarget._linkedBrowser.getBoundingClientRect();
+      //    MouseDispatch owns every conversion from these relative coordinates to
+      //    absolute ones, and every wait for a renderer ack.
+      const dispatch = MouseDispatch.forBrowser(win, this._pageTarget._linkedBrowser, eventArgs);
       // 3. Make sure compositor is flushed after scrolling.
       if (win.windowUtils.flushApzRepaints())
         await helper.awaitTopic('apz-repaints-flushed');
 
       const watcher = new EventWatcher(this._pageEventSink, types, this._pendingEventWatchers);
-      // The browser element's origin is not pixel-aligned: the chrome above the
-      // content is a fractional number of CSS pixels tall, and how many depends
-      // on the spoofed OS (measured: windows 51.4, macos 53.1, linux 56.5). So a
-      // relative coordinate of 0 dispatches at absolute y == boundingBox.top
-      // exactly -- the content area's first, only partly covered row. The widget
-      // rounds that to a whole device row before hit-testing it, and wherever
-      // round(top) < top the rounded row still belongs to chrome: the event fires
-      // as an exit event rather than eMouseMove, no
-      // juggler-mouse-event-hit-renderer ack is produced, and because dispatch is
-      // serialized on activateAndRun()'s process-global chain (TargetRegistry.js)
-      // that one missing ack wedges every later input event in the process
-      // forever. windows and macos land on the wrong side of that rounding, so
-      // page.mouse.move(x, 0) deadlocks on them every time; linux never does.
-      // This is the near edge's version of the x==width / y==height deadlock the
-      // bounds checks below guard against, but it cannot be fixed the same way:
-      // unlike the far edges, 0 is a legitimate in-viewport coordinate a caller
-      // may ask for, and the out-of-viewport branch drops mousedown/mouseup
-      // silently -- which is what makes a click look like it simply did nothing.
-      // Snapping to the first whole pixel inside the element stays within content
-      // pixel 0 while landing clear of the boundary. boundingBox.left is normally
-      // a whole 0 and so needs no rounding, but the same snap covers it.
-      const originX = Math.ceil(boundingBox.left);
-      const originY = Math.ceil(boundingBox.top);
-      // Dispatch a single synthesized mouse event to the renderer and return a
-      // promise that resolves once the renderer acks it.
-      const sendOne = (eventType, eventX, eventY) => {
-        // This dispatches to the renderer synchronously.
-        const jugglerEventId = win.windowUtils.jugglerSendMouseEvent(
-          eventType,
-          Math.max(eventX + boundingBox.left, originX),
-          Math.max(eventY + boundingBox.top, originY),
-          button,
-          clickCount,
-          modifiers,
-          false /* aIgnoreRootScrollFrame */,
-          0.0 /* pressure */,
-          0 /* inputSource */,
-          true /* isDOMEventSynthesized */,
-          false /* isWidgetEventSynthesized */,
-          buttons,
-          win.windowUtils.DEFAULT_MOUSE_POINTER_ID /* pointerIdentifier */,
-          false /* disablePointerEvent */
-        );
-        return watcher.ensureEvent(eventType, eventObject => eventObject.jugglerEventId === jugglerEventId);
-      };
-
       const promises = [];
-      for (const type of types) {
+      for (const eventType of types) {
         // Camoufox: when humanize is enabled, expand a direct mousemove into a
         // human-like trajectory of intermediate mousemoves generated in C++
         // (ChromeUtils.camouGetMouseTrajectory / MouseTrajectories.hpp).
-        if (type === 'mousemove' && ChromeUtils.camouGetBool('humanize', false)) {
+        if (eventType === 'mousemove' && ChromeUtils.camouGetBool('humanize', false)) {
           const trajectory = ChromeUtils.camouGetMouseTrajectory(this._lastTrackedPos.x, this._lastTrackedPos.y, x, y);
-          // Dispatch intermediate points sequentially with a short delay. The
-          // first/last pairs are skipped: the last pair is the exact
+          // The first and last pairs are skipped: the last pair is the exact
           // destination, which is dispatched explicitly below.
-          for (let i = 2; i < trajectory.length - 2; i += 2) {
-            const currentX = trajectory[i];
-            const currentY = trajectory[i + 1];
-            // Skip movement that is out of bounds. Must match the endpoint guard
-            // below (>=, not >): a point at exactly x==width or y==height fires as
-            // an exit event instead of eMouseMove, so the hit-renderer ack never
-            // arrives and every later input event hangs behind it forever.
-            if (currentX < 0 || currentY < 0 || currentX >= boundingBox.width || currentY >= boundingBox.height)
-              continue;
-            await sendOne('mousemove', currentX, currentY);
-            await new Promise(resolve => setTimeout(resolve, 10));
-          }
+          const points = [];
+          for (let i = 2; i < trajectory.length - 2; i += 2)
+            points.push([trajectory[i], trajectory[i + 1]]);
+          await dispatch.sendTrajectoryAcked(watcher, 'mousemove', points);
           // Always finish exactly on the requested destination.
-          promises.push(sendOne('mousemove', x, y));
+          promises.push(dispatch.sendAcked(watcher, 'mousemove', x, y));
         } else {
-          promises.push(sendOne(type, x, y));
+          promises.push(dispatch.sendAcked(watcher, eventType, x, y));
         }
       }
       await Promise.all(promises);
@@ -611,32 +560,15 @@ export class PageHandler {
     await this._pageTarget.activateAndRun(async () => {
       this._pageTarget.ensureContextMenuClosed();
       // If someone asks us to dispatch mouse event outside of viewport, then we normally would drop it.
-      const boundingBox = this._pageTarget._linkedBrowser.getBoundingClientRect();
-      // Treat exact-edge coordinates as out-of-viewport: a mousemove at x==width or y==height fires as an exit event instead of eMouseMove, so the hit-renderer signal never arrives and every later input event hangs behind it forever.
-      if (x < 0 || y < 0 || x >= boundingBox.width || y >= boundingBox.height) {
+      const dispatch = MouseDispatch.forBrowser(win, this._pageTarget._linkedBrowser, eventArgs);
+      if (!dispatch.isInViewport(x, y)) {
         if (type !== 'mousemove')
           return;
 
         // A special hack: if someone tries to do `mousemove` outside of
         // viewport coordinates, then move the mouse off from the Web Content.
         // This way we can eliminate all the hover effects.
-        // NOTE: since this won't go inside the renderer, there's no need to wait for ACK.
-        win.windowUtils.jugglerSendMouseEvent(
-          'mousemove',
-          0 /* x */,
-          0 /* y */,
-          button,
-          clickCount,
-          modifiers,
-          false /* aIgnoreRootScrollFrame */,
-          0.0 /* pressure */,
-          0 /* inputSource */,
-          true /* isDOMEventSynthesized */,
-          false /* isWidgetEventSynthesized */,
-          buttons,
-          win.windowUtils.DEFAULT_MOUSE_POINTER_ID /* pointerIdentifier */,
-          false /* disablePointerEvent */
-        );
+        dispatch.parkOffContent();
         return;
       }
 
@@ -723,24 +655,22 @@ export class PageHandler {
       // 1. Scroll element to the desired location first; the coordinates are relative to the element.
       this._pageTarget._linkedBrowser.scrollRectIntoViewIfNeeded(x, y, 0, 0);
       // 2. Get element's bounding box in the browser after the scroll is completed.
-      const boundingBox = this._pageTarget._linkedBrowser.getBoundingClientRect();
-
       const win = this._pageTarget._window;
+      const dispatch = MouseDispatch.forBrowser(win, this._pageTarget._linkedBrowser, {modifiers});
       // 3. Make sure compositor is flushed after scrolling.
       if (win.windowUtils.flushApzRepaints())
         await helper.awaitTopic('apz-repaints-flushed');
 
-      win.windowUtils.sendWheelEvent(
-        x + boundingBox.left,
-        y + boundingBox.top,
+      // Same conversion as a mouse event: a wheel at relative y == 0 would
+      // otherwise land on the chrome/content boundary and scroll the tab strip.
+      dispatch.sendWheel(x, y, {
         deltaX,
         deltaY,
         deltaZ,
         deltaMode,
-        modifiers,
         lineOrPageDeltaX,
         lineOrPageDeltaY,
-        0 /* options */);
+      });
     }, { muteNotificationsPopup: true });
   }
 

--- a/docs/input-dispatch.md
+++ b/docs/input-dispatch.md
@@ -1,0 +1,73 @@
+# Synthesized input dispatch
+
+Every synthesized mouse and wheel event in the parent process goes through
+`additions/juggler/input/MouseDispatch.js`. `scripts/check-input-dispatch.py`
+fails the build if anything else dispatches input or does browser-relative
+coordinate arithmetic, and it runs on every pull request.
+
+## The invariant
+
+> A synthesized input event whose ack we await must reach the content
+> renderer — and when it does not, we must stop waiting.
+
+## Why it is worth a module and a lint
+
+Four deadlocks shipped between 2026-04 and 2026-09, all the same failure:
+
+| Date | Commit | Trigger |
+|---|---|---|
+| 2026-06-04 | `9270618` | `x == width` / `y == height` — the far edges |
+| 2026-07-18 | `541ffca` | trajectory points, which bypassed the endpoint's guard (#225, #677) |
+| 2026-07-24 | `16e5a13` | a zero-displacement move |
+| 2026-09-03 | `014cc65` | `y == 0` — the near edge (#751, #752) |
+
+Each was fixed by adding one more coordinate guard at one more call site. That
+does not converge, for two reasons.
+
+**The trigger set is not enumerable.** Whether relative `y == 0` reaches the
+renderer is decided by `Math.round(boundingBox.top) < boundingBox.top` — a
+rounding accident in the fractional height of browser chrome, which varies with
+the *spoofed OS*: windows `51.4` → `51` deadlocks, macos `53.1` → `53`
+deadlocks, linux `56.5` → `57` is fine. No review catches that, and no
+hand-written list of coordinates contains it.
+
+**Every miss costs the whole process.** `activateAndRun()`
+(`TargetRegistry.js`) serializes input on a promise chain shared by every tab in
+the process. It swallows errors to keep the chain running, but it cannot swallow
+a callback that never returns. One unbounded `await` for an ack that will never
+arrive wedges every later input event, in every tab, permanently — at 0% CPU,
+with nothing in flight and no diagnostic.
+
+`#677` is why review is not enough: restoring the humanize trajectory meant
+writing a bounds check, and the one written was a copy of the pre-`#225` form,
+reintroducing a fixed deadlock one day before it was re-fixed.
+
+## How it is enforced
+
+**One chokepoint.** `MouseDispatch` owns the relative→absolute conversion (with
+the boundary snap), the in-viewport predicate, and the ack wait. Callers pass
+relative coordinates and never see a bounding box.
+
+**Bounded waits.** `sendAcked()` waits at most `kAckDeadlineMs` (5s) and then
+drops the event with a warning naming the type, coordinate and browser rect. The
+deadline is sized above the slowest *legitimate* ack, not near the typical one:
+acks are p99 1ms on an idle page, but they are delivered from the content main
+thread and inherit any block on it — a 3s synchronous script delayed one by
+2849ms. `sendTrajectoryAcked()` abandons the rest of a curve after the first
+undelivered point, so ~110 bounded waits cannot add up to an unbounded slot.
+`activateAndRun()` carries a 30s backstop for the other unbounded waits
+reachable from the same slot (`apz-repaints-flushed`, `TabSwitchDone`, the drag
+path's waits), none of which has failed yet.
+
+**The static check.** `scripts/check-input-dispatch.py`, wired into
+`.github/workflows/lint.yml`. Two exemptions, both content-process:
+`PageAgent.js` (drag events, already content-relative, no ack) and
+`FrameTree.js` (the ack *producer*).
+
+**Boundary coverage.** `tests/patches/mouse-boundary-sweep.py` sweeps the whole
+viewport ring across every spoofed OS with humanize on and off, asserting each
+point is acked *and observed by the page*. Hand-picked coordinate lists are what
+let each of the four bugs through: `humanize-edge-deadlock.py` probed only the
+far edges, and `humanize-mouse-trajectory.py` pins `os="linux"` — the one
+fingerprint immune to `#751`. `tests/patches/input-ack-backstop.py` covers the
+bounded wait itself.

--- a/scripts/check-input-dispatch.py
+++ b/scripts/check-input-dispatch.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Enforce that synthesized input is dispatched from exactly one place.
+
+WHY THIS EXISTS
+Between 2026-04 and 2026-09, four deadlocks shipped from the same invariant
+being broken in four different ways -- exact-edge coordinates (#225), humanized
+trajectory points that bypassed the endpoint's guard (#677), a zero-displacement
+move, and the top-edge row (#751, #752). Each was fixed by adding one more
+coordinate guard at one more call site.
+
+The invariant:
+
+    A synthesized input event whose ack we await must reach the content
+    renderer -- and when it does not, we must stop waiting.
+
+It is unenforceable by review, because a violation looks like ordinary
+arithmetic and costs the entire browser process. #677 is the proof: restoring
+the humanize trajectory meant writing a bounds check, and the check that got
+written was a copy of the pre-#225 form -- reintroducing a fixed deadlock one
+day before it was re-fixed. Nobody caught it in review; a grep would have.
+
+So: one module owns the conversion, the bounds predicate and the ack wait, and
+this check fails the build if anything else takes that job on. It needs no
+browser build and runs in seconds, so it can gate every pull request.
+
+    python3 scripts/check-input-dispatch.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCAN_ROOT = ROOT / "additions" / "juggler"
+CHOKEPOINT = "additions/juggler/input/MouseDispatch.js"
+DOC = "docs/input-dispatch.md"
+
+# The two exemptions are both the CONTENT process -- the other end of the wire,
+# where the chokepoint's job does not exist:
+#
+#   PageAgent  dispatches drag events with coordinates that are already
+#              content-relative. No browser-element offset, no ack awaited.
+#   FrameTree  is the ack PRODUCER: it observes the
+#              juggler-mouse-event-hit-renderer notification and emits the
+#              InputEvent carrying jugglerEventId. It waits for nothing.
+#
+# Both are narrow and deliberate. Anything in the parent process is covered.
+CONTENT_DRAG = "additions/juggler/content/PageAgent.js"
+CONTENT_ACK_SOURCE = "additions/juggler/content/FrameTree.js"
+
+# (regex, what the code is doing, files exempt in addition to the chokepoint)
+RULES = [
+    (r"\bjugglerSendMouseEvent\s*\(", "dispatches a synthesized mouse event", {CONTENT_DRAG}),
+    (r"\bsendWheelEvent\s*\(", "dispatches a synthesized wheel event", set()),
+    (r"\bjugglerEventId\b", "waits for a renderer ack", {CONTENT_ACK_SOURCE}),
+    (r"\bboundingBox\s*\.\s*(?:left|top)\b", "does browser-relative coordinate arithmetic", set()),
+]
+
+REMEDY = (
+    f"Route it through MouseDispatch ({CHOKEPOINT}): sendAcked() to dispatch and\n"
+    f"    wait under a deadline, isInViewport() for the bounds predicate,\n"
+    f"    toAbsolute() for the conversion. See {DOC}."
+)
+
+
+def main() -> int:
+    if not (ROOT / CHOKEPOINT).is_file():
+        print(f"FAIL: the chokepoint {CHOKEPOINT} is missing.")
+        print("      If it moved, update CHOKEPOINT in this script and in " + DOC + ".")
+        return 1
+
+    compiled = [(re.compile(p), what, exempt) for p, what, exempt in RULES]
+    violations = []
+
+    for path in sorted(SCAN_ROOT.rglob("*.js")):
+        rel = path.relative_to(ROOT).as_posix()
+        if rel == CHOKEPOINT or path.name.endswith(".bak"):
+            continue
+        for lineno, line in enumerate(path.read_text(errors="replace").splitlines(), 1):
+            if line.lstrip().startswith(("//", "*", "/*")):
+                continue
+            for pattern, what, exempt in compiled:
+                if rel in exempt:
+                    continue
+                if pattern.search(line):
+                    violations.append((rel, lineno, what, line.strip()))
+
+    if not violations:
+        scanned = sum(1 for _ in SCAN_ROOT.rglob("*.js"))
+        print(f"input-dispatch: ok -- {scanned} files scanned, all synthesized input "
+              f"goes through {CHOKEPOINT}")
+        return 0
+
+    print("input-dispatch: FAILED\n")
+    for rel, lineno, what, line in violations:
+        print(f"  {rel}:{lineno} {what} outside the chokepoint")
+        print(f"    {line}")
+    print(f"\n    {REMEDY}")
+    print(f"\n{len(violations)} violation(s).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/patches/input-ack-backstop.py
+++ b/tests/patches/input-ack-backstop.py
@@ -1,0 +1,130 @@
+"""
+Verify the renderer-ack wait is bounded (daijro/camoufox#751, #752).
+
+This guards the backstop itself -- the one mechanism that makes an undelivered
+input event survivable rather than fatal.
+
+Camoufox dispatches synthesized mouse events inside `activateAndRun()`
+(additions/juggler/TargetRegistry.js), which serializes every dispatch on a
+*process-global* promise chain. Each dispatch awaits a hit-renderer ack. Before
+the backstop that wait was unbounded, so an ack that never arrived did not lose
+one event -- it wedged every later input event in the process, in every tab,
+permanently, at 0% CPU with no diagnostic. All four shipped deadlocks were that
+failure with four different triggers; see docs/input-dispatch.md.
+
+`MouseDispatch.sendAcked()` now waits at most `kAckDeadlineMs`, then drops the
+event with a warning and lets the chain advance.
+
+HOW THIS TEST WORKS
+The ack is delivered from the content main thread, so blocking that thread
+delays it by exactly the block duration -- a legitimate mechanism for producing
+a late ack, with no test-only hook in production code. The page is made to block
+for well over the deadline; a bounded wait returns in about the deadline, an
+unbounded one waits for the whole block.
+
+The gap is what makes the assertion meaningful: with a ~5s deadline and a 40s
+block, "returned in under 20s" cannot be satisfied by an unbounded wait, and
+does not depend on the exact deadline value.
+
+Dropping that event is the correct, chosen behaviour: warn and continue. The
+test therefore asserts recovery, not delivery -- the move may legitimately be
+lost, but the browser must still be usable afterwards.
+
+Run against a specific build:
+    CAMOUFOX_EXECUTABLE_PATH=/path/to/camoufox-bin python3 tests/patches/input-ack-backstop.py
+
+What PASS means:
+    * a dispatch whose ack is late by far more than the deadline returns in
+      roughly the deadline, not in the block duration;
+    * once the block clears, input still works -- the chain advanced rather
+      than being abandoned mid-slot.
+
+Before the backstop the first move waits out the entire block.
+"""
+
+import asyncio
+import os
+import sys
+import time
+
+from camoufox.async_api import AsyncCamoufox
+
+# Far longer than kAckDeadlineMs (5s), so the two outcomes cannot be confused.
+BLOCK_MS = 40000
+# Generous over the deadline, far under the block.
+BOUNDED_S = 20
+RECOVERY_TIMEOUT_S = 30
+
+EXECUTABLE_PATH = os.environ.get("CAMOUFOX_EXECUTABLE_PATH")
+
+
+def _launch_kwargs():
+    kwargs = dict(headless=True, os="windows", humanize=False)
+    if EXECUTABLE_PATH:
+        kwargs["executable_path"] = EXECUTABLE_PATH
+    return kwargs
+
+
+async def main() -> int:
+    print("\n=== bounded renderer-ack wait ===")
+    async with AsyncCamoufox(**_launch_kwargs()) as browser:
+        page = await browser.new_page()
+        await page.set_content('<body style="margin:0;height:1200px"></body>')
+        await page.evaluate(
+            "window.__moves=0;addEventListener('mousemove',()=>window.__moves++)")
+        await asyncio.wait_for(page.mouse.move(300, 300), timeout=RECOVERY_TIMEOUT_S)
+
+        # Block the content main thread. Deliberately not awaited: the block has
+        # to still be running when the move below is dispatched.
+        blocker = asyncio.ensure_future(page.evaluate(
+            f"(()=>{{const end=Date.now()+{BLOCK_MS};while(Date.now()<end);}})()"))
+        await asyncio.sleep(0.25)
+
+        print(f"  content main thread blocked for {BLOCK_MS}ms; dispatching a move",
+              flush=True)
+        t0 = time.time()
+        try:
+            await asyncio.wait_for(page.mouse.move(500, 400), timeout=BOUNDED_S)
+        except asyncio.TimeoutError:
+            print(f"  FAIL: still waiting after {BOUNDED_S}s")
+            print(
+                "\n  The ack wait is unbounded. An event that never reaches the\n"
+                "  renderer will wedge the process-global activation chain forever.\n"
+                "  Fix: bound it in MouseDispatch.sendAcked() via\n"
+                "  EventWatcher.ensureEventWithin(). See docs/input-dispatch.md.\n")
+            blocker.cancel()
+            return 1
+        waited = time.time() - t0
+        print(f"  returned after {waited:.1f}s (block runs for {BLOCK_MS / 1000:.0f}s)",
+              flush=True)
+
+        # Let the block finish, then prove the chain advanced rather than died.
+        try:
+            await asyncio.wait_for(blocker, timeout=BLOCK_MS / 1000 + 15)
+        except asyncio.TimeoutError:
+            print("  FAIL: the blocking script never finished")
+            return 1
+        except Exception:
+            pass  # a lost evaluate is fine; the chain is what matters
+
+        before = await asyncio.wait_for(
+            page.evaluate("window.__moves"), timeout=RECOVERY_TIMEOUT_S)
+        try:
+            await asyncio.wait_for(page.mouse.move(700, 500), timeout=RECOVERY_TIMEOUT_S)
+            await asyncio.wait_for(page.mouse.click(650, 450), timeout=RECOVERY_TIMEOUT_S)
+            after = await asyncio.wait_for(
+                page.evaluate("window.__moves"), timeout=RECOVERY_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            print("  FAIL: input dead after the late ack -- the chain is poisoned")
+            return 1
+        if after <= before:
+            print("  FAIL: the browser accepted moves but the page saw none")
+            return 1
+
+        print(f"  input still live afterwards ({after - before} mousemove seen)")
+        print("\n  PASS: the ack wait is bounded and the chain recovers\n")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/patches/mouse-boundary-sweep.py
+++ b/tests/patches/mouse-boundary-sweep.py
@@ -1,0 +1,135 @@
+"""
+Sweep the viewport boundary for coordinates that never reach the renderer.
+
+This replaces hand-picked edge targets, which are what let four deadlocks
+through. Each of the earlier tests probed the coordinates that had just been
+found broken, so the next variant was always outside the list:
+
+    humanize-edge-deadlock.py   probes the right and bottom edges only, so the
+                                near edge (#751) passed it cleanly
+    humanize-mouse-trajectory.py  pins os="linux", the one spoofed OS whose
+                                chrome offset is immune to #751
+
+The failure they all share: a synthesized event that hit-tests outside the
+content widget fires as an exit event rather than eMouseMove, no
+juggler-mouse-event-hit-renderer ack is produced, and -- because dispatch is
+serialized on activateAndRun()'s process-global chain -- that one missing ack
+wedges every later input event in the process. See docs/input-dispatch.md.
+
+Rather than guess which coordinates do that, sweep the ring:
+
+    x in {0, 1, w/2, w-2, w-1}  x  y in {0, 1, h/2, h-2, h-1}
+
+across every spoofed OS (the chrome offset that decides #751 is a function of
+it: windows 51.4, macos 53.1, linux 56.5) and with humanize both off and on.
+
+Each point must be *delivered*, not merely survived: the page has to observe a
+mousemove. A point that is dropped without hanging is still a bug -- it is the
+"click did nothing" half of #752 -- and asserting only "did not time out" would
+miss it.
+
+This test depends on the ack backstop (MouseDispatch kAckDeadlineMs) to run at
+all. Without it the first undelivered coordinate wedges the browser and the
+sweep dies there, reporting one point instead of the whole failing set.
+
+Run against a specific build:
+    CAMOUFOX_EXECUTABLE_PATH=/path/to/camoufox-bin python3 tests/patches/mouse-boundary-sweep.py
+
+What PASS means: every ring coordinate, on every spoofed OS, humanized and not,
+was acked and seen by the page; and input is still live at the end of each run.
+"""
+
+import asyncio
+import os
+import sys
+
+from camoufox.async_api import AsyncCamoufox
+
+SPOOFED_OSES = ["windows", "macos", "linux"]
+# Well inside the viewport, so every dispatched point is a real displacement.
+INTERIOR = (0.34, 0.34)
+# Per-point ceiling. Comfortably above the 5s ack deadline, so a dropped point
+# shows up as "not delivered" with a fast return rather than as a timeout here.
+POINT_TIMEOUT_S = 25
+
+EXECUTABLE_PATH = os.environ.get("CAMOUFOX_EXECUTABLE_PATH")
+
+RECORDER = "window.__moves=0;addEventListener('mousemove',()=>window.__moves++)"
+
+
+def _launch_kwargs(humanize, spoofed_os):
+    kwargs = dict(headless=True, os=spoofed_os, humanize=humanize)
+    if EXECUTABLE_PATH:
+        kwargs["executable_path"] = EXECUTABLE_PATH
+    return kwargs
+
+
+def _ring(w, h):
+    xs = [0, 1, w // 2, w - 2, w - 1]
+    ys = [0, 1, h // 2, h - 2, h - 1]
+    return [(x, y) for y in ys for x in xs]
+
+
+async def _sweep(spoofed_os, humanize) -> list:
+    """Returns the coordinates that did not reach the renderer."""
+    undelivered = []
+    async with AsyncCamoufox(**_launch_kwargs(humanize, spoofed_os)) as browser:
+        page = await browser.new_page()
+        await page.set_content('<body style="margin:0;height:1600px"></body>')
+        await page.evaluate(RECORDER)
+        vp = await page.evaluate("({w:innerWidth,h:innerHeight})")
+        w, h = vp["w"], vp["h"]
+        home = (int(w * INTERIOR[0]), int(h * INTERIOR[1]))
+        points = _ring(w, h)
+        print(f"  [{spoofed_os}, humanize={humanize}] {w}x{h}: "
+              f"{len(points)} ring points", flush=True)
+
+        for x, y in points:
+            await asyncio.wait_for(page.mouse.move(*home), timeout=POINT_TIMEOUT_S)
+            before = await page.evaluate("window.__moves")
+            try:
+                await asyncio.wait_for(page.mouse.move(x, y), timeout=POINT_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                undelivered.append(((x, y), "hung -- the ack backstop did not fire"))
+                # The chain is wedged; nothing after this can run.
+                return undelivered
+            after = await asyncio.wait_for(
+                page.evaluate("window.__moves"), timeout=POINT_TIMEOUT_S)
+            if after == before:
+                undelivered.append(((x, y), "dispatched, but the page saw no mousemove"))
+
+        # Prove the chain is not poisoned rather than trusting the absence of a
+        # timeout above.
+        try:
+            await asyncio.wait_for(page.mouse.move(*home), timeout=POINT_TIMEOUT_S)
+            await asyncio.wait_for(page.mouse.click(*home), timeout=POINT_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            undelivered.append((home, "input dead after the sweep"))
+    return undelivered
+
+
+async def main() -> int:
+    print("\n=== viewport boundary sweep ===")
+    failures = []
+    for spoofed_os in SPOOFED_OSES:
+        for humanize in (False, True):
+            bad = await _sweep(spoofed_os, humanize)
+            for point, why in bad:
+                failures.append((spoofed_os, humanize, point, why))
+                print(f"    FAIL {point}  {why}", flush=True)
+            if not bad:
+                print("    ok", flush=True)
+
+    if failures:
+        print(f"\n  {len(failures)} coordinate(s) did not reach the renderer.\n"
+              "  Every one of these wedges the process-global activation chain on a\n"
+              "  build without the ack backstop. Fix the conversion in\n"
+              "  additions/juggler/input/MouseDispatch.js -- see docs/input-dispatch.md.\n")
+        return 1
+
+    print("\n  PASS: every ring coordinate acked and observed, on every spoofed OS\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/patches/near-edge-mouse-deadlock.py
+++ b/tests/patches/near-edge-mouse-deadlock.py
@@ -21,9 +21,8 @@ the coordinate to a whole device row before hit-testing it. When
 an exit event rather than eMouseMove, no ack is produced, and the chain wedges.
 
 That makes it a deterministic property of the chrome height, which Camoufox
-varies with the spoofed OS. Measured on this build (`window.mozInnerScreenY`
-reports the rounded content origin, so it shows which side of the boundary the
-rounding lands on):
+varies with the spoofed OS. Measured on this build by logging `boundingBox` at
+the dispatch site, and pairing each offset with the outcome of a single move:
 
     os          boundingBox.top   rounds to   page.mouse.move(31, 0)
     windows     51.4              51  (above) hangs, 5/5
@@ -93,9 +92,6 @@ TIMEOUT_S = 20
 EXECUTABLE_PATH = os.environ.get("CAMOUFOX_EXECUTABLE_PATH")
 
 RECORDER = "window.__moves=0;addEventListener('mousemove',()=>window.__moves++)"
-# mozInnerScreenY - screenY is the chrome height as the widget rounds it, which
-# is the number that decides whether row 0 hit-tests into content or chrome.
-CHROME_OFFSET = "window.mozInnerScreenY - window.screenY"
 
 
 def _launch_kwargs(humanize, spoofed_os):
@@ -123,8 +119,6 @@ async def _direct_moves() -> bool:
             page = await browser.new_page()
             await page.set_content('<body style="margin:0;height:1200px"></body>')
             await page.evaluate(RECORDER)
-            offset = await page.evaluate(CHROME_OFFSET)
-            print(f"  [{spoofed_os}] content starts at screen row {offset}")
             # Start from an interior point so the move under test is a real
             # displacement, not a no-op skipped before dispatch.
             await asyncio.wait_for(page.mouse.move(*INTERIOR), timeout=TIMEOUT_S)

--- a/tests/patches/near-edge-mouse-deadlock.py
+++ b/tests/patches/near-edge-mouse-deadlock.py
@@ -1,0 +1,233 @@
+"""
+Verify a mouse event on the viewport's top edge does not deadlock (daijro/camoufox#751, #752).
+
+Camoufox dispatches synthesized mouse events inside `activateAndRun()`
+(additions/juggler/TargetRegistry.js), which serializes every dispatch on a
+*process-global* promise chain. Each dispatch awaits a `hit-renderer` ack from
+the content process. If an ack never arrives, the callback never returns, the
+global chain never advances, and every later input event in the process hangs
+behind it forever. Two triggers were already fixed and are guarded by
+humanize-edge-deadlock.py (the far edges, x==width / y==height, #225) and
+noop-mousemove-deadlock.py (a zero-displacement move). This is the third: the
+*near* edge, y==0.
+
+MECHANISM
+`sendOne()` in PageHandler.js dispatches at `eventY + boundingBox.top`, so a
+relative y of 0 dispatches at absolute y == `boundingBox.top` exactly -- the
+first row of the content area. That row is only partly covered whenever the
+chrome above it is a fractional number of CSS pixels tall, and the widget rounds
+the coordinate to a whole device row before hit-testing it. When
+`round(top) < top` the rounded row still belongs to chrome, the event fires as
+an exit event rather than eMouseMove, no ack is produced, and the chain wedges.
+
+That makes it a deterministic property of the chrome height, which Camoufox
+varies with the spoofed OS. Measured on this build (`window.mozInnerScreenY`
+reports the rounded content origin, so it shows which side of the boundary the
+rounding lands on):
+
+    os          boundingBox.top   rounds to   page.mouse.move(31, 0)
+    windows     51.4              51  (above) hangs, 5/5
+    macos       53.1              53  (above) hangs, 5/5
+    linux       56.5              57  (below) completes, 8/8
+
+So the default randomized fingerprint reaches it on most launches, and a run
+that spoofs Linux never does -- which is why this went unnoticed while the
+far-edge guards were in place. Relative x == 0 is unaffected for the same
+reason: `boundingBox.left` is a whole 0, so it needs no rounding.
+
+WHY NOT WIDEN THE BOUNDS CHECK
+The far edges were fixed by treating them as out-of-viewport. 0 cannot be: it is
+a legitimate in-viewport coordinate a caller may ask for, and the out-of-viewport
+branch silently drops mousedown/mouseup, so widening the check would turn the
+hang into a click that reports success and fires nothing (#752). The fix snaps
+the dispatched coordinate to the first whole pixel inside the browser element,
+which stays within content pixel 0 while landing clear of the boundary.
+
+COVERAGE
+Both dispatch paths reach the same conversion, so both are covered:
+  * direct dispatch -- `page.mouse.move(x, 0)`, humanize off, and the humanized
+    move's explicit endpoint. Deterministic on an affected chrome offset.
+  * humanized trajectory -- how it is actually hit in the field. Every
+    PageHandler starts at `_lastTrackedPos = {x: 0, y: 0}` (PageHandler.js:86),
+    so a session's FIRST humanized move always departs from the top-left corner,
+    and with the +/-80px knot boundary from MouseTrajectories.hpp the curve rides
+    the y==0 row. On a stock build a first humanized click hung on 5 of 20 cold
+    pages; all five had dispatched a point at y==0 and the 15 that completed had
+    dispatched none. Sampled here rather than asserted deterministically, since
+    whether the curve touches the row is random.
+
+Run against a specific build:
+    CAMOUFOX_EXECUTABLE_PATH=/path/to/camoufox-bin python3 tests/patches/near-edge-mouse-deadlock.py
+
+What PASS means:
+    * a move onto the top edge completes on every spoofed OS, and the page
+      actually observes it -- an event swallowed by chrome leaves no mousemove;
+    * the browser still responds to input afterwards, proving the global chain
+      is not poisoned;
+    * a session's first humanized click completes on repeated cold pages.
+
+Before the fix the first direct move times out; after it, every move completes.
+"""
+
+import asyncio
+import os
+import sys
+
+from camoufox.async_api import AsyncCamoufox
+
+# The chrome height, and so whether the top row rounds into chrome, depends on
+# the spoofed OS. Cover all three rather than assuming which one this host's
+# chrome puts on the wrong side of the boundary.
+SPOOFED_OSES = ["windows", "macos", "linux"]
+# Relative y == 0 is the deadlock coordinate. x is varied only to show it is the
+# whole row that is poisoned, not one particular pixel.
+TOP_EDGE_TARGETS = [(31, 0), (0, 0), (500, 0)]
+# Fresh pages for the humanized half: each resets _lastTrackedPos to (0, 0), so
+# each is an independent chance for the first trajectory to ride the top edge.
+COLD_PAGES = 4
+# Close enough to the top that a trajectory from (0, 0) sweeps the y==0 row.
+HUMANIZED_TARGET = (660, 186)
+INTERIOR = (250, 250)
+TIMEOUT_S = 20
+
+EXECUTABLE_PATH = os.environ.get("CAMOUFOX_EXECUTABLE_PATH")
+
+RECORDER = "window.__moves=0;addEventListener('mousemove',()=>window.__moves++)"
+# mozInnerScreenY - screenY is the chrome height as the widget rounds it, which
+# is the number that decides whether row 0 hit-tests into content or chrome.
+CHROME_OFFSET = "window.mozInnerScreenY - window.screenY"
+
+
+def _launch_kwargs(humanize, spoofed_os):
+    kwargs = dict(headless=True, os=spoofed_os, humanize=humanize)
+    if EXECUTABLE_PATH:
+        kwargs["executable_path"] = EXECUTABLE_PATH
+    return kwargs
+
+
+def _deadlock_report(what):
+    print(
+        f"\n  DEADLOCK: {what} produced no hit-renderer ack. The global activation\n"
+        "  chain is now wedged -- all further input hangs.\n"
+        "  Fix: snap the dispatched coordinate to the first whole pixel inside the\n"
+        "  browser element in PageHandler.js sendOne(), so a relative 0 does not\n"
+        "  land on the fractional chrome/content boundary.\n"
+    )
+
+
+async def _direct_moves() -> bool:
+    """A plain move onto the top edge must complete and be seen by the page."""
+    print("\n=== direct moves onto the top edge (humanize off) ===")
+    for spoofed_os in SPOOFED_OSES:
+        async with AsyncCamoufox(**_launch_kwargs(False, spoofed_os)) as browser:
+            page = await browser.new_page()
+            await page.set_content('<body style="margin:0;height:1200px"></body>')
+            await page.evaluate(RECORDER)
+            offset = await page.evaluate(CHROME_OFFSET)
+            print(f"  [{spoofed_os}] content starts at screen row {offset}")
+            # Start from an interior point so the move under test is a real
+            # displacement, not a no-op skipped before dispatch.
+            await asyncio.wait_for(page.mouse.move(*INTERIOR), timeout=TIMEOUT_S)
+
+            for x, y in TOP_EDGE_TARGETS:
+                label = f"  [{spoofed_os}] move -> ({x}, {y})"
+                before = await page.evaluate("window.__moves")
+                try:
+                    await asyncio.wait_for(page.mouse.move(x, y), timeout=TIMEOUT_S)
+                except asyncio.TimeoutError:
+                    print(f"{label}  FAIL: no ack after {TIMEOUT_S}s")
+                    _deadlock_report(f"a mousemove at ({x}, {y})")
+                    return False
+                after = await asyncio.wait_for(
+                    page.evaluate("window.__moves"), timeout=TIMEOUT_S
+                )
+                if after == before:
+                    print(f"{label}  FAIL: dispatched but the page saw no mousemove")
+                    print(
+                        "\n  The event was delivered outside the content area. It did not\n"
+                        "  hang this time, but it never reached the renderer either.\n"
+                    )
+                    return False
+                print(f"{label}  ok")
+                await asyncio.wait_for(page.mouse.move(*INTERIOR), timeout=TIMEOUT_S)
+
+            # The chain survived: prove input still works rather than trusting the
+            # absence of a timeout above.
+            try:
+                await asyncio.wait_for(page.mouse.move(400, 300), timeout=TIMEOUT_S)
+                live = await asyncio.wait_for(
+                    page.evaluate("window.__moves"), timeout=TIMEOUT_S
+                )
+            except asyncio.TimeoutError:
+                print(f"  [{spoofed_os}] FAIL: unresponsive after the edge moves")
+                return False
+            if not live:
+                print(f"  [{spoofed_os}] FAIL: no mousemove observed at all")
+                return False
+    return True
+
+
+async def _humanized() -> bool:
+    """The humanize path reaches the same conversion, by endpoint and by curve."""
+    print("\n=== humanized moves (humanize on) ===")
+    for spoofed_os in SPOOFED_OSES:
+        async with AsyncCamoufox(**_launch_kwargs(True, spoofed_os)) as browser:
+            # A humanized move whose destination IS the top edge: the trajectory's
+            # explicit endpoint dispatch is unconditional, so this is the
+            # deterministic half.
+            page = await browser.new_page()
+            await page.set_content('<body style="margin:0;height:1200px"></body>')
+            await page.evaluate(RECORDER)
+            await asyncio.wait_for(page.mouse.move(*INTERIOR), timeout=TIMEOUT_S)
+            label = f"  [{spoofed_os}] humanized move -> (500, 0)"
+            try:
+                await asyncio.wait_for(page.mouse.move(500, 0), timeout=TIMEOUT_S)
+            except asyncio.TimeoutError:
+                print(f"{label}  FAIL: no ack after {TIMEOUT_S}s")
+                _deadlock_report("a humanized move ending at y==0")
+                return False
+            print(f"{label}  ok")
+            await page.close()
+
+            # Cold pages: the trajectory departs (0, 0) and may ride the y==0 row.
+            for i in range(1, COLD_PAGES + 1):
+                label = f"  [{spoofed_os}] cold page {i}/{COLD_PAGES}: click -> {HUMANIZED_TARGET}"
+                page = await browser.new_page()
+                await page.set_content(
+                    '<button id="b" style="position:absolute;left:600px;top:160px;'
+                    'width:120px;height:52px">go</button>'
+                )
+                await page.evaluate(
+                    "window.__clicked=false;document.getElementById('b')"
+                    ".addEventListener('click',()=>window.__clicked=true)"
+                )
+                try:
+                    # click() moves first, so this is the session's first
+                    # trajectory -- generated from the initial (0, 0).
+                    await asyncio.wait_for(page.click("#b"), timeout=TIMEOUT_S)
+                    clicked = await asyncio.wait_for(
+                        page.evaluate("window.__clicked"), timeout=TIMEOUT_S
+                    )
+                except asyncio.TimeoutError:
+                    print(f"{label}  FAIL: no ack after {TIMEOUT_S}s")
+                    _deadlock_report("a humanized trajectory point at y==0")
+                    return False
+                if not clicked:
+                    print(f"{label}  FAIL: click completed but the target never fired")
+                    return False
+                print(f"{label}  ok")
+                await page.close()
+    return True
+
+
+async def main() -> int:
+    if not await _direct_moves():
+        return 1
+    if not await _humanized():
+        return 1
+    print("\n  PASS: top-edge moves completed and were seen; input still live\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Related Issue

Closes #752
Closes #751

## Description

`Mouse.move()` / `click()` at certain viewport coordinates permanently wedges **all** input dispatch in the browser process — every tab, no error, no CPU use, no diagnostic. This is the fifth report of the same family (#225 and its relatives were the earlier ones), so this PR fixes the instance *and* removes the class.

### The bug

`sendOne` dispatched at `eventY + boundingBox.top`. A relative `y == 0` lands at exactly `boundingBox.top`, which is the content area's first half-covered device row. The widget rounds to a whole row, and wherever `Math.round(top) < top` that row still belongs to chrome — so the event hit-tests outside the content widget and fires as an *exit* event instead of `eMouseMove`. No `juggler-mouse-event-hit-renderer` ack is produced.

`EventWatcher.ensureEvent()` then waits **forever**, holding `globalTabAndWindowActivationChain` — a module-global promise that serializes every input dispatch in the process. One bad coordinate deadlocks the whole browser.

It is deterministic per spoofed OS, because the chrome height differs:

| spoofed OS | `boundingBox.top` | rounds to | result |
|---|---|---|---|
| windows | 51.4 | 51 | hangs |
| macos | 53.1 | 53 | hangs |
| linux | 56.5 | 57 | fine |

That per-OS split is why this kept getting reported and kept looking unreproducible — `humanize-mouse-trajectory.py` happened to pin `os="linux"`, the one immune fingerprint. `x == 0` was never affected because `boundingBox.left` is a whole `0`.

### The fix — three layers

Guarding each call site is what we've done four times already, and it keeps breaking because the guard has to be remembered at every new dispatch site. Instead:

**1. One chokepoint.** New `additions/juggler/input/MouseDispatch.js` owns relative→absolute conversion, the bounds predicate, and the ack wait. Absolute coordinates are clamped into the last whole device pixel inside the element on all four sides. `PageHandler.js` **loses 92 lines and gains 22** — its three ad-hoc bounds checks and every raw dispatch call are gone, so the vendored file's diff against upstream juggler gets *smaller*. Wheel events now go through the same conversion, so a wheel at `y == 0` no longer scrolls the tab strip.

**2. Bounded waits.** `EventWatcher.ensureEventWithin()` replaces the unbounded wait: 5s, then drop the event and log type/coordinate/rect. A trajectory abandons its remaining points after the first undelivered one. `activateAndRun()` gets a 30s backstop so the chain can never be held forever by anything, acks included.

The 5s figure is measured, not guessed — over 1000+ dispatches the ack is p50 0ms / p99 1ms / max 12ms idle, but **max 2849ms behind a 3s synchronous script**, because the ack is delivered from the content main thread and inherits any block on it. A 1s deadline would silently drop legitimate input on slow pages. A wall-clock budget across a whole trajectory was rejected for the same reason: it would false-fire on exactly the slow pages the deadline exists to tolerate.

**3. Enforcement.** `scripts/check-input-dispatch.py` fails if `jugglerSendMouseEvent`, `sendWheelEvent`, `jugglerEventId` or `boundingBox.left/top` appear anywhere outside the chokepoint, wired into a new `.github/workflows/lint.yml`. Two documented content-process exemptions: `PageAgent.js` (drag, already content-relative) and `FrameTree.js` (the ack *producer*, which the lint itself flagged). `docs/input-dispatch.md` states the invariant: *a synthesized input event whose ack we await must reach the content renderer — and when it does not, we must stop waiting.*

Note `build.yml` only runs on tags, so nothing was checking PRs before this.

### A fifth instance, found by the new sweep

On its first run, on a build that already had the near-edge fix, `mouse-boundary-sweep.py` found another one. `boundingBox.height` is consistently **0.5 CSS px less** than the `innerHeight` the page reports, so the page's last row is half-covered. With the box at `1920x977.5 +0+56.5`, relative `y == 977` — `innerHeight - 1`, well inside the viewport as far as the page is concerned, and somewhere Playwright will happily click — dispatches at 1033.5, rounds to 1034, and the content ends at 1034. Deterministic 4/4, pre-existing, and it deadlocks a stock build. Fixed by the same symmetric clamp.

It's the first one in this family found before a user hit it. The ack backstop is what makes the sweep possible at all: on stock, the first bad coordinate kills the run.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

All results below are from a **cold build** — `rm -rf` of the source dir, re-extract, patches re-applied, `mach build` + `mach package` — not an incremental tree.

**`tests/patches/` — 14/14 pass, zero non-zero exits.** Three are new:

- `near-edge-mouse-deadlock.py` — `{windows, macos, linux}` × `{(31,0), (0,0), (500,0)}`, plus a humanized endpoint and cold-page first-click runs. Fails on stock at the first move.
- `mouse-boundary-sweep.py` — `{0, 1, w//2, w-2, w-1} × {0, 1, h//2, h-2, h-1}` across 3 spoofed OSes × humanize on/off (150 coordinates, 6 scenarios), asserting each point is both acked and observed by the page.
- `input-ack-backstop.py` — blocks the content main thread for 40s and asserts the move returns bounded. **Measured 5.0s.** It uses a genuine late ack rather than a test-only hook in shipped code.

To reproduce (three prerequisites that are easy to miss — `tests/patches/` is *not* run by `make tests`, which is `pytest async/` only):

```bash
make stage-fonts
# needs a venv with the camoufox package; tests/setup-venv.sh does not build one.
# build-tester/.venv works:
CAMOUFOX_EXECUTABLE_PATH=<path>/dist/bin/camoufox-bin \
  build-tester/.venv/bin/python tests/patches/mouse-boundary-sweep.py
```

**`async/` (the `make tests` suite) — 14 failures, all pre-existing.** Verified by A/B rather than assumed: swapping the juggler files to `upstream/main`'s on the same binary — which is the entirety of this change, since it's JS only — fails 13 of the same 14. Nothing passes on stock and fails with this branch. The one delta goes the other way (`test_page_clock.py::TestWhileRunning::test_should_pause` fails on stock, passes here — a timing test, so likely flake rather than a fix). Seven of the fourteen are `test_headful.py` under the runner's default `--headless`.

**Packaging.** `jar.mn` adds the first *new file* juggler has gained, so it was verified end-to-end rather than by inspection: `chrome/juggler/content/input/MouseDispatch.js` (10052 bytes) is present in the packaged `omni.ja`. `package-manifest.in:207` packages juggler as a tree, not a file list, so no manifest change is needed.

**Lint.** `input-dispatch: ok -- 16 files scanned`. Verified in both directions — passes clean, and fails when a dispatch site is injected.

**Not covered:** the 30s `activateAndRun` backstop has no automated test. Exercising it needs a stall that isn't an ack, which would mean a hook in shipped code; it rests on prototype measurement only.

## Fingerprint Report

Service tester is marked out of service in the template, so build tester only. Certificate text rather than a screenshot:

<details>
<summary>Fingerprint report — build-tester, Grade A, 962/962</summary>

```
╔════════════════════════════════════════════════════════════╗
║          CAMOUFOX BUILD VERIFICATION CERTIFICATE           ║
╠════════════════════════════════════════════════════════════╣
║  Grade: A     Score: 962/962     Profiles: 8               ║
║  Issued: 2026-09-04T18:23:36.074883Z                       ║
║  Status: ALL PASS                                          ║
╠════════════════════════════════════════════════════════════╣
║  SECTION RESULTS                                           ║
║  Automation Detection ..................... 32/32  [PASS]  ║
║  JS Engine ................................ 40/40  [PASS]  ║
║  Lie Detection .......................... 104/104  [PASS]  ║
║  Firefox APIs ............................. 88/88  [PASS]  ║
║  Cross-Signal ............................. 16/16  [PASS]  ║
║  CSS Fingerprint .......................... 64/64  [PASS]  ║
║  Math Engine .............................. 24/24  [PASS]  ║
║  Permissions .............................. 16/16  [PASS]  ║
║  Speech Voices ............................ 16/16  [PASS]  ║
║  Performance .............................. 16/16  [PASS]  ║
║  Intl Consistency ......................... 24/24  [PASS]  ║
║  Emoji ...................................... 8/8  [PASS]  ║
║  Canvas Noise ............................... 8/8  [PASS]  ║
║  WebGL Render ............................... 8/8  [PASS]  ║
║  Font Platform ............................ 16/16  [PASS]  ║
║  Audio Integrity .......................... 32/32  [PASS]  ║
║  Iframe Testing ........................... 24/24  [PASS]  ║
║  Headless Detection ....................... 80/80  [PASS]  ║
║  Trash Detection .......................... 40/40  [PASS]  ║
║  Font Environment ......................... 20/20  [PASS]  ║
║  Workers .................................. 64/64  [PASS]  ║
║  WebRTC ..................................... 8/8  [PASS]  ║
║  Stability .................................. 8/8  [PASS]  ║
║  Mac Uniqueness ............................. 4/4  [PASS]  ║
║  Linux Uniqueness ......................... 3/4  [1 FAIL]  ║
╠════════════════════════════════════════════════════════════╣
║  CROSS-PROFILE UNIQUENESS                                  ║
║  macOS  Audio:3/3  Canvas:3/3  TZ:3/3  Screen:3/3          ║
║  Linux  Audio:3/3  Canvas:2/3  TZ:3/3  Screen:3/3          ║
╠════════════════════════════════════════════════════════════╣
║  ID:   6bb02b09-2dec-4f17-96d2-c930732958a2                ║
╚════════════════════════════════════════════════════════════╝
```

</details>

The `Linux Uniqueness 3/4` row is worth a look but is **not** from this PR — cross-profile uniqueness isn't part of the 962 score, and across three runs the collision moves between signals and platforms (run 1: macOS Canvas + Linux Screen; run 2: clean; run 3: Linux Canvas). Two of three runs hit a *canvas* collision, though, which looks like a real pre-existing weakness in per-profile canvas seeding. Happy to open a separate issue.

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass~~ — marked out of service in the template
- [x] Build test passes — Grade A, 962/962, certificate above (text rather than screenshot)

## Two things noticed in passing, not fixed here

1. **`make build` on Linux silently cross-compiles for macOS.** `scripts/patch.py:239` defaults to `macos, arm64` when `BUILD_TARGET` is unset, so a bare `make build` on a Linux host produces `obj-aarch64-apple-darwin` and **exits 0** while `xcrun` and `rust-objcopy` fail in warnings. It looks like a successful build until you notice the obj directory name. Defaulting to the host triple, or refusing to guess, would save someone an hour.
2. **`tests/patches/` has no runner.** It isn't part of `make tests`, the files are hyphenated so pytest won't collect them, and they need both `make stage-fonts` and a venv containing the `camoufox` package that `tests/setup-venv.sh` doesn't create. Wiring it into a make target would make it much harder to skip.

## Open design questions

- Should an undelivered event surface to the Playwright client rather than only the browser log? With warn-and-continue, a user not running `DEBUG=pw:browser` sees a click that silently does nothing — which is exactly what #752 looked like.
- Should `globalTabAndWindowActivationChain` be scoped per window instead of per process? Process-global is why one bad coordinate in one tab freezes every tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQgHHGRXNp29jr4xQjK7iv
