### PR TITLE
fix(stealth): apply the per-context font list in the default context (#757)

### DIFF
--- a/patches/font-list-spoofing.patch
+++ b/patches/font-list-spoofing.patch
@@ -235,17 +235,35 @@ index xxxxxxxxxx..yyyyyyyyyy 100644
  #include "mozilla/gfx/2D.h"
  #include "mozilla/ipc/FileDescriptorUtils.h"
  #include "mozilla/TextUtils.h"
-@@ -1632,6 +1633,16 @@
+@@ -1632,6 +1633,34 @@
    nsAutoCString key;
    GenerateFontListKey(aFamily, key);
 
-+  // Per-context font list filtering
-+  {
++  // Per-context font list filtering.
++  //
++  // Guarded on HasFontList() alone. userContextId 0 is juggler's default
++  // browser context -- "Default context has userContextId === 0"
++  // (TargetRegistry.js) -- which is the context Playwright's
++  // launch_persistent_context() runs in, so a `ctx != 0` guard meant
++  // setFontList() stored a list there and nothing ever read it. Measured on
++  // 152.0.4-beta.30 with a macOS mask and no global "fonts" allowlist: a
++  // persistent context resolved all 14 probed Windows-only families, the
++  // same as an unmasked baseline, while navigator.platform read MacIntel.
++  // A non-default context resolved 4. HasFontList() is the correct test on
++  // its own: false until setFontList() has run for that context.
++  //
++  // Chrome documents are exempt for the reason font-hijacker.patch gives: the
++  // parent process paints the browser UI from this same list, and filtering it
++  // leaves the Windows titlebar drawing tofu instead of its Segoe Fluent Icons
++  // glyphs (#695). `ctx != 0` masked that before -- chrome resolves fonts with
++  // the thread-local still at 0 -- so the exemption has to be explicit now. A
++  // null provider is an internal lookup with no document behind it, which
++  // upstream likewise treats as privileged.
++  if (aFontVisibilityProvider && !aFontVisibilityProvider->IsChrome()) {
 +    uint32_t ctx = mozilla::dom::FontListManager::GetCurrentContext();
-+    if (ctx != 0 && mozilla::dom::FontListManager::HasFontList(ctx)) {
-+      if (!mozilla::dom::FontListManager::IsFontAllowed(ctx, key)) {
-+        return false;
-+      }
++    if (mozilla::dom::FontListManager::HasFontList(ctx) &&
++        !mozilla::dom::FontListManager::IsFontAllowed(ctx, key)) {
++      return false;
 +    }
 +  }
 +

--- a/pythonlib/tests/test_percontext_default_context.py
+++ b/pythonlib/tests/test_percontext_default_context.py
@@ -1,0 +1,107 @@
+"""Guard: the per-context font list must apply in the default browser context.
+
+Regression guard for the font-list gap. `window.setFontList()` stored the spoofed
+list, but the filter in gfxPlatformFontList::FindAndAddFamiliesLocked was gated on
+
+    if (ctx != 0 && FontListManager::HasFontList(ctx)) { ... }
+
+and juggler's default browser context IS userContextId 0 --
+additions/juggler/TargetRegistry.js:
+
+    // Default context has userContextId === 0, but we pass undefined to many APIs
+    this.userContextId = 0;
+
+That is the context Playwright's launch_persistent_context() runs in, so
+setFontList() stored a list there, deleted itself from window, reported nothing,
+and nothing ever read it. Measured on 152.0.4-beta.30, macOS mask, no global
+CAMOU_CONFIG["fonts"] allowlist: a persistent context resolved all 14 probed
+Windows-only families -- identical to an unmasked baseline -- while
+navigator.platform read MacIntel. A non-default context resolved 4.
+
+Playwright's browser.new_page() is not affected: it creates its own context, so
+it never lands in id 0. build-tester never caught it either, because
+scripts/runner.py builds every profile with browser.new_context() (lines 109,
+339), which allocates a non-zero id.
+
+HasFontList() is the correct guard on its own -- false until setFontList() has run
+for that context, so id 0 behaves as before when nothing set a list.
+
+Note this is the *lookup* side. A `userContextId != 0` test on the *setter* side is
+a different, legitimate pattern: SetAudioFingerprintSeed, SetScreenDimensions,
+SetTimezone and SetWebGLVendor all mirror their write into context 0 as a fallback
+for workers whose context id differs from the parent page. Those are writes to an
+extra context, not a refusal to read one, and this test does not touch them.
+
+Second assertion: the filter must keep chrome documents out. `ctx != 0` was also,
+accidentally, the only thing doing that -- a chrome document resolves fonts with the
+thread-local still at 0 -- so removing it makes the exemption load-bearing. Without
+it this is daijro/camoufox#695 again: the Windows titlebar draws tofu instead of its
+Segoe Fluent Icons glyphs.
+
+Run with:
+    cd pythonlib && python -m pytest tests/test_percontext_default_context.py -v
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+PATCH = REPO / "patches" / "font-list-spoofing.patch"
+TARGET = "gfx/thebes/gfxPlatformFontList.cpp"
+
+# `ctx != 0`, `userContextId != 0`, `0 != ctx`, ... on a context identifier.
+CONTEXT_VAR = r"(?:a?[Uu]ser[Cc]ontext[Ii]d|ctx|contextId)"
+NONZERO_GUARD = re.compile(
+    r"(?:%s\s*!=\s*0)|(?:0\s*!=\s*%s)" % (CONTEXT_VAR, CONTEXT_VAR)
+)
+
+
+def _added_lines_for(patch: Path, target: str, code_only: bool = False) -> list:
+    """Lines the patch adds to `target`, as (line number in patch, text).
+
+    With code_only, `//` comment lines are dropped -- the comment above the fix
+    quotes the `ctx != 0` guard it removed, and that quote is not the guard.
+    """
+    added, in_target = [], False
+    for n, line in enumerate(patch.read_text(errors="ignore").splitlines(), 1):
+        if line.startswith("diff --git "):
+            in_target = line.endswith(target)
+            continue
+        if in_target and line.startswith("+") and not line.startswith("+++"):
+            text = line[1:]
+            if code_only and text.lstrip().startswith("//"):
+                continue
+            added.append((n, text))
+    return added
+
+
+def test_font_list_filter_applies_to_the_default_context():
+    added = _added_lines_for(PATCH, TARGET, code_only=True)
+    assert added, f"{PATCH.name} no longer patches {TARGET}"
+
+    offenders = [
+        f"{PATCH.name}:{n}: {text.strip()}"
+        for n, text in added
+        if NONZERO_GUARD.search(text)
+    ]
+    assert not offenders, (
+        "the per-context font list lookup is gated on the context id being "
+        "non-zero, which skips the default browser context -- juggler's "
+        "userContextId 0, where browser.new_page() lands:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_font_list_filter_exempts_chrome_documents():
+    added = "\n".join(text for _, text in _added_lines_for(PATCH, TARGET))
+
+    assert "FontListManager::HasFontList" in added, (
+        f"the font list filter is no longer in {TARGET}; this guard needs "
+        "updating to point at wherever it moved"
+    )
+    assert "IsChrome()" in added, (
+        "the per-context font filter has no chrome exemption. The browser UI is "
+        "painted from this same font list, so filtering it leaves the Windows "
+        "titlebar drawing tofu instead of its Segoe Fluent Icons glyphs "
+        "(daijro/camoufox#695)."
+    )


### PR DESCRIPTION
## Related Issue

Closes #757

## Description

`window.setFontList()` stored the spoofed font list but nothing read it back for
`userContextId` 0. The filter in `gfxPlatformFontList::FindAndAddFamiliesLocked` was
gated on `ctx != 0`, and 0 is juggler's default browser context
(`TargetRegistry.js`: `// Default context has userContextId === 0`) — the context
`launch_persistent_context()` runs in. The setter stored the list, deleted itself from
`window`, returned normally, and the mask never applied.

`HasFontList(ctx)` on the same line was always the correct guard: false until
`setFontList()` has run for that context, so id 0 behaves exactly as before when
nothing set a list.

Removing the guard alone would have reintroduced #695. A chrome document resolves
fonts with the thread-local still at 0, so `ctx != 0` was also the only thing keeping
the browser UI out of the mask — once a page in the default context set a list, chrome
lookups would be filtered and the Windows titlebar would draw tofu instead of its Segoe
Fluent Icons glyphs. The chrome exemption is now explicit, using the same
`aFontVisibilityProvider && !IsChrome()` test `font-hijacker.patch` uses for the global
mask.

One hunk in one patch file, plus a test. No API or config surface changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

### Browser

152.0.4-beta.30, Windows 11 host, raw binary, no `CAMOU_CONFIG`, fingerprint from
`generate_context_fingerprint(os="macos")` applied with `add_init_script`. Probe is 14
Windows-only families measured with `measureText()`. Script is in #757.

Before:

| launch | `navigator.platform` | families resolved |
| --- | --- | --- |
| no init script (baseline) | `Win32` | 14 |
| `browser.new_context()` | `MacIntel` | 3 |
| `launch_persistent_context()` | `MacIntel` | **14** |

`navigator.platform` is spoofed in both masked rows, so the init script ran and only
the font list was ignored.

### Static regression test

`pythonlib/tests/test_percontext_default_context.py`, in the style of
`test_config_schema.py` — two assertions over `patches/font-list-spoofing.patch`: that
the lookup does not gate on a non-zero context id, and that the filter exempts chrome
documents. No build or browser needed.

```
against pristine main:   2 failed
with this patch:         2 passed
rest of the suite:       206 passed, 5 skipped
```

The setter-side `userContextId != 0` in `SetAudioFingerprintSeed`,
`SetScreenDimensions`, `SetTimezone` and `SetWebGLVendor` is deliberately not covered
by the guard — those mirror a write into context 0 as a fallback for workers whose
context id differs from the parent page, which is a write to an extra context rather
than a refusal to read one.

### Not yet run

I do not have a Linux build host, so the browser-level "after" numbers and the
build-tester score are not filled in. Opening as a draft for that reason. If someone
with a build can run the script from #757 against a patched binary, the persistent row
should drop from 14 to 3, and the chrome UI should keep its real fonts with a font list
set on the default context.

### Coverage gap this exposes

`build-tester/scripts/runner.py` builds every per-context profile with
`browser.new_context()` (lines 109, 339), which always allocates a non-zero
`userContextId`, so the guard was always satisfied under test. A profile that goes
through `launch_persistent_context()` would have caught it; happy to add one here if
you would rather it land together.

## Fingerprint Report

<details>
<summary>Fingerprint report</summary>

Not run — no Linux build host. See "Not yet run" above.

</details>

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [ ] ~~Service tests pass~~ temporarily out of service
- [ ] Build test passes — needs a build host; draft until then
