### PR TITLE
Filter unsupported WebGL fingerprint presets

### DIFF
--- a/pythonlib/camoufox/fingerprints.py
+++ b/pythonlib/camoufox/fingerprints.py
@@ -14,6 +14,7 @@ from browserforge.fingerprints import (
 
 from camoufox.pkgman import load_yaml
 from camoufox.webgl import sample_webgl
+from camoufox.webgl.sample import get_possible_pairs
 
 # Load the browserforge.yaml file
 BROWSERFORGE_DATA = load_yaml('browserforge.yml')
@@ -26,6 +27,7 @@ PRESETS_V150_FILE = Path(__file__).parent / 'fingerprint-presets-v150.json'
 # Firefox major version at which the v150 preset bundle becomes preferred.
 PRESETS_V150_MIN_FF = 149
 _PRESETS_CACHE: Dict[Path, Dict] = {}
+_SUPPORTED_WEBGL_PAIRS: Optional[Dict[str, FrozenSet[Tuple[str, str]]]] = None
 
 # CreepJS OS marker fonts used for OS detection
 _MACOS_MARKER_FONTS = [
@@ -727,10 +729,26 @@ def get_random_preset(
     else:
         os_keys = all_os_keys
 
-    # Collect all matching presets
+    global _SUPPORTED_WEBGL_PAIRS
+    if _SUPPORTED_WEBGL_PAIRS is None:
+        _SUPPORTED_WEBGL_PAIRS = {
+            target_os: frozenset(pairs)
+            for target_os, pairs in get_possible_pairs().items()
+        }
+
+    # Collect presets whose WebGL data can be resolved for the target OS.
+    # Some bundled presets contain pairs absent from webgl_data.db; selecting
+    # one would otherwise make launch_options() fail nondeterministically.
     candidates: List[Dict] = []
     for key in os_keys:
-        candidates.extend(presets.get('presets', {}).get(key, []))
+        target_os = {'windows': 'win', 'macos': 'mac', 'linux': 'lin'}.get(key, key)
+        supported_pairs = _SUPPORTED_WEBGL_PAIRS.get(target_os, frozenset())
+        for preset in presets.get('presets', {}).get(key, []):
+            webgl = preset.get('webgl', {})
+            vendor = webgl.get('unmaskedVendor')
+            renderer = webgl.get('unmaskedRenderer')
+            if not vendor or not renderer or (vendor, renderer) in supported_pairs:
+                candidates.append(preset)
 
     if not candidates:
         return None

--- a/pythonlib/tests/test_webgl_screen_consistency.py
+++ b/pythonlib/tests/test_webgl_screen_consistency.py
@@ -321,3 +321,38 @@ def test_preset_screens_are_never_lifted():
             preset["screen"]["width"],
             preset["screen"]["height"],
         )
+
+
+@pytest.mark.parametrize("ff_version", ["148", "152"])
+@pytest.mark.parametrize(
+    "target_os,webgl_os",
+    [("windows", "win"), ("macos", "mac"), ("linux", "lin")],
+)
+def test_random_preset_pool_only_contains_supported_webgl_pairs(
+    monkeypatch, ff_version, target_os, webgl_os
+):
+    """Every preset eligible for random selection must survive launch_options.
+
+    The bundled preset files contain vendor/renderer pairs absent from
+    webgl_data.db. Selection therefore failed only when random.choice happened
+    to pick one of those entries, making browser startup intermittently crash.
+    """
+    from camoufox.fingerprints import get_random_preset
+    from camoufox.webgl import sample_webgl
+
+    candidates = []
+
+    def capture(pool):
+        candidates.extend(pool)
+        return pool[0]
+
+    monkeypatch.setattr(fingerprints, "choice", capture)
+    get_random_preset(os=target_os, ff_version=ff_version)
+
+    assert candidates
+    for preset in candidates:
+        webgl = preset.get("webgl", {})
+        vendor = webgl.get("unmaskedVendor")
+        renderer = webgl.get("unmaskedRenderer")
+        if vendor and renderer:
+            sample_webgl(webgl_os, vendor, renderer)


### PR DESCRIPTION
## Related Issue

Closes #766

## Description

Filters bundled real-device presets against the vendor/renderer pairs supported by `webgl_data.db` for the target OS before random selection.

Some bundled presets cannot be resolved by `sample_webgl()`. Because `fingerprint_preset=True` chooses randomly, browser startup worked until it selected one of those entries and then failed with `ValueError: No WebGL data found...`.

The supported-pair lookup is cached, valid presets remain unchanged, and presets without explicit WebGL values remain eligible for the existing random WebGL fallback. If an OS has no supported presets, the existing `None` return continues to select the synthetic fingerprint path.

The regression test audits both bundled preset files across Windows, macOS, and Linux. Every preset offered to `random.choice` must be accepted by `sample_webgl()` for its target OS.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

```text
python -m pytest pythonlib/tests/test_webgl_screen_consistency.py -q
46 passed

python -m pytest pythonlib/tests -q
211 passed, 4 skipped
```

The deterministic reproduction from #766 fails before this patch and the affected preset is excluded from the random candidate pool after it.

## Fingerprint Report

Not applicable: this changes only which bundled presets are eligible for random selection. It does not modify any valid preset, generated fingerprint value, browser patch, or Firefox binary behavior. The service tester is currently marked out of service in the repository template; the full Python suite passes.

## Checklist

- [x] I have linked a related issue above
- [x] My changes are focused on a single logical change
- [x] I have added testing instructions which include the desired result
- [x] ~~Service tests pass (for python library changes)~~ temporarily out of service
- [x] Build test is not applicable (no browser patch changes)
